### PR TITLE
Add Claude provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ tool prompt aligned with the tools that the agent can actually call.
 
 - **Provider-driven tool surface** — tools are injected based on what the active
   provider actually supports, not a fixed list
-- **Five providers**: Codex, Exa, Gemini, Parallel, Valyu — each with its own
-  SDK, strengths, and capability set
+- **Six providers**: Claude, Codex, Exa, Gemini, Parallel, Valyu — each with
+  its own SDK, strengths, and capability set
 - **One config command** (`/web-providers`) with a TUI that adapts to the
   selected provider
 - **Transparent fallback** — search falls back to Codex when no provider is
@@ -57,8 +57,9 @@ This command edits a single global config file:
 
 The flow is provider-first: pick the active provider, then configure only that
 provider's tool toggles and settings. Each provider view surfaces the knobs that
-actually apply—Codex shows reasoning-effort and web-search-mode toggles; Exa
-shows search type and text-content flags; and so on.
+actually apply—Claude shows model/effort/turns settings; Codex shows
+reasoning-effort and web-search-mode toggles; Exa shows search type and
+text-content flags; and so on.
 
 ## 🔧 Tools
 
@@ -70,11 +71,11 @@ corresponding tool is never exposed to the agent.
 
 Search the web and return titles, URLs, and snippets.
 
-| Parameter    | Type    | Default  | Description                                                         |
-| ------------ | ------- | -------- | ------------------------------------------------------------------- |
-| `query`      | string  | required | What to search for                                                  |
-| `maxResults` | integer | `5`      | Result count, clamped to `1–20`                                     |
-| `provider`   | string  | auto     | Optional override: `codex`, `exa`, `gemini`, `parallel`, or `valyu` |
+| Parameter    | Type    | Default  | Description                                                                   |
+| ------------ | ------- | -------- | ----------------------------------------------------------------------------- |
+| `query`      | string  | required | What to search for                                                            |
+| `maxResults` | integer | `5`      | Result count, clamped to `1–20`                                               |
+| `provider`   | string  | auto     | Optional override: `claude`, `codex`, `exa`, `gemini`, `parallel`, or `valyu` |
 
 ### `web_contents`
 
@@ -111,13 +112,21 @@ Run a longer-form research task.
 Every provider is a thin adapter around an official SDK. The table below
 summarises which capabilities each provider exposes:
 
-| Provider     | search | contents | answer | research | Auth                 |
-| ------------ | :----: | :------: | :----: | :------: | -------------------- |
-| **Codex**    |   ✓    |          |        |          | Local Codex CLI auth |
-| **Exa**      |   ✓    |    ✓     |   ✓    |    ✓     | `EXA_API_KEY`        |
-| **Gemini**   |   ✓    |          |   ✓    |    ✓     | `GOOGLE_API_KEY`     |
-| **Parallel** |   ✓    |    ✓     |        |          | `PARALLEL_API_KEY`   |
-| **Valyu**    |   ✓    |    ✓     |   ✓    |    ✓     | `VALYU_API_KEY`      |
+| Provider     | search | contents | answer | research | Auth                   |
+| ------------ | :----: | :------: | :----: | :------: | ---------------------- |
+| **Claude**   |   ✓    |          |   ✓    |          | Local Claude Code auth |
+| **Codex**    |   ✓    |          |        |          | Local Codex CLI auth   |
+| **Exa**      |   ✓    |    ✓     |   ✓    |    ✓     | `EXA_API_KEY`          |
+| **Gemini**   |   ✓    |          |   ✓    |    ✓     | `GOOGLE_API_KEY`       |
+| **Parallel** |   ✓    |    ✓     |        |          | `PARALLEL_API_KEY`     |
+| **Valyu**    |   ✓    |    ✓     |   ✓    |    ✓     | `VALYU_API_KEY`        |
+
+### Claude
+
+- SDK: `@anthropic-ai/claude-agent-sdk`
+- Uses Claude Code's built-in `WebSearch` and `WebFetch` tools behind a
+  structured JSON adapter
+- Great for search plus grounded answers if you already use Claude Code locally
 
 ### Codex
 
@@ -174,6 +183,13 @@ Example:
 {
   "version": 1,
   "providers": {
+    "claude": {
+      "enabled": false,
+      "tools": {
+        "search": true,
+        "answer": true
+      }
+    },
     "codex": {
       "enabled": true,
       "tools": {

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ tool prompt aligned with the tools that the agent can actually call.
   its own SDK, strengths, and capability set
 - **One config command** (`/web-providers`) with a TUI that adapts to the
   selected provider
-- **Transparent fallback** — search falls back to Codex when no provider is
-  explicitly enabled and the local Codex CLI is installed and authenticated
+- **Transparent fallback** — search falls back to Codex first, then Claude,
+  when no provider is explicitly enabled and the local CLI is installed and
+  authenticated
 - **Per-provider tool toggles** — disable individual capabilities you don't need
   without switching providers
 - **Truncated output with temp-file spillover** for large results
@@ -166,8 +167,8 @@ summarises which capabilities each provider exposes:
 - Managed tools are registered from available provider capabilities, but the
   active tool set can still be narrower if you removed a tool from the session
 - If no provider is explicitly enabled for search, the extension falls back to
-  Codex only when the local Codex CLI is installed and authenticated, unless
-  Codex was explicitly configured as disabled
+  Codex first and then Claude when the local CLI is installed and authenticated,
+  unless either provider was explicitly configured as disabled
 - Tools stay inactive when no provider is available for their capability, so
   they are not injected into the LLM prompt
 - Before each agent run, the extension removes newly unavailable managed tools

--- a/README.md
+++ b/README.md
@@ -32,9 +32,8 @@ tool prompt aligned with the tools that the agent can actually call.
   its own SDK, strengths, and capability set
 - **One config command** (`/web-providers`) with a TUI that adapts to the
   selected provider
-- **Transparent fallback** — search falls back to Codex first, then Claude,
-  when no provider is explicitly enabled and the local CLI is installed and
-  authenticated
+- **Transparent fallback** — search falls back to Codex when no provider is
+  explicitly enabled and the local CLI is installed and authenticated
 - **Per-provider tool toggles** — disable individual capabilities you don't need
   without switching providers
 - **Truncated output with temp-file spillover** for large results
@@ -167,8 +166,8 @@ summarises which capabilities each provider exposes:
 - Managed tools are registered from available provider capabilities, but the
   active tool set can still be narrower if you removed a tool from the session
 - If no provider is explicitly enabled for search, the extension falls back to
-  Codex first and then Claude when the local CLI is installed and authenticated,
-  unless either provider was explicitly configured as disabled
+  Codex when the local CLI is installed and authenticated, unless Codex was
+  explicitly configured as disabled
 - Tools stay inactive when no provider is available for their capability, so
   they are not injected into the LLM prompt
 - Before each agent run, the extension removes newly unavailable managed tools

--- a/changelog/unreleased/claude-provider-for-web-search-and-answers.md
+++ b/changelog/unreleased/claude-provider-for-web-search-and-answers.md
@@ -1,0 +1,10 @@
+---
+title: Claude provider for web search and answers
+type: feature
+authors:
+  - mavam
+  - codex
+created: 2026-03-09T19:55:02.003606Z
+---
+
+`pi-web-providers` now supports Claude as a provider for `web_search` and `web_answer` when Claude Code is installed and authenticated locally. This lets you route grounded web lookups through Claude Code's built-in `WebSearch` and `WebFetch` tools and configure Claude-specific defaults such as the model, effort level, maximum turns, and executable path from `/web-providers`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.2.71",
         "@google/genai": "^1.44.0",
         "@openai/codex-sdk": "^0.111.0",
         "exa-js": "^2.7.0",
         "parallel-web": "^0.3.1",
-        "valyu-js": "^2.5.9"
+        "valyu-js": "^2.5.9",
+        "zod": "^4.1.11"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.6",
@@ -27,6 +29,29 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.2.71",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.71.tgz",
+      "integrity": "sha512-pIsQJnM7Y+cJHL7aFY6SCCW3FIni218gVEpPqG8XGowfYxboFNBbNssWiUNRwthT8bp9jypcX7q5kx0Xsw14xg==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "^0.34.2",
+        "@img/sharp-darwin-x64": "^0.34.2",
+        "@img/sharp-linux-arm": "^0.34.2",
+        "@img/sharp-linux-arm64": "^0.34.2",
+        "@img/sharp-linux-x64": "^0.34.2",
+        "@img/sharp-linuxmusl-arm64": "^0.34.2",
+        "@img/sharp-linuxmusl-x64": "^0.34.2",
+        "@img/sharp-win32-arm64": "^0.34.2",
+        "@img/sharp-win32-x64": "^0.34.2"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -1430,6 +1455,310 @@
         "@modelcontextprotocol/sdk": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -4001,6 +4330,15 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/exa-js/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/expect-type": {
@@ -6708,9 +7046,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-web-providers",
   "version": "0.1.0",
-  "description": "Configurable web access extension for pi that routes search, contents, answers, and research across Codex, Exa, Gemini, Parallel, and Valyu providers.",
+  "description": "Configurable web access extension for pi that routes search, contents, answers, and research across Claude, Codex, Exa, Gemini, Parallel, and Valyu providers.",
   "type": "module",
   "files": [
     "dist",
@@ -13,6 +13,7 @@
     "pi-extension",
     "coding-agent",
     "web-search",
+    "claude",
     "codex",
     "exa",
     "gemini",
@@ -37,7 +38,7 @@
     ]
   },
   "scripts": {
-    "build": "rm -rf dist && esbuild src/index.ts --bundle --format=esm --platform=node --outfile=dist/index.js --external:@mariozechner/pi-coding-agent --external:@mariozechner/pi-ai --external:@mariozechner/pi-tui --external:@sinclair/typebox --external:@google/genai --external:@openai/codex-sdk --external:exa-js --external:parallel-web --external:valyu-js",
+    "build": "rm -rf dist && esbuild src/index.ts --bundle --format=esm --platform=node --outfile=dist/index.js --external:@mariozechner/pi-coding-agent --external:@mariozechner/pi-ai --external:@mariozechner/pi-tui --external:@sinclair/typebox --external:@anthropic-ai/claude-agent-sdk --external:@google/genai --external:@openai/codex-sdk --external:exa-js --external:parallel-web --external:valyu-js",
     "prepare": "npm run build",
     "prepack": "npm run build",
     "check": "tsc --noEmit",
@@ -47,11 +48,13 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.71",
     "@google/genai": "^1.44.0",
     "@openai/codex-sdk": "^0.111.0",
     "exa-js": "^2.7.0",
     "parallel-web": "^0.3.1",
-    "valyu-js": "^2.5.9"
+    "valyu-js": "^2.5.9",
+    "zod": "^4.1.11"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.6",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,8 +1,14 @@
-import { getAgentDir } from "@mariozechner/pi-coding-agent";
 import { execSync } from "node:child_process";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import {
+  PROVIDER_TOOLS,
+  type ProviderToolId,
+  supportsProviderTool,
+} from "./provider-tools.js";
 import type {
+  ClaudeProviderConfig,
   CodexProviderConfig,
   ExaProviderConfig,
   GeminiProviderConfig,
@@ -12,11 +18,6 @@ import type {
   ValyuProviderConfig,
   WebProvidersConfig,
 } from "./types.js";
-import {
-  type ProviderToolId,
-  PROVIDER_TOOLS,
-  supportsProviderTool,
-} from "./provider-tools.js";
 
 const LEGACY_TOOL_ALIASES: Partial<
   Record<ProviderId, Partial<Record<string, ProviderToolId | null>>>
@@ -44,6 +45,13 @@ export function createDefaultConfig(): WebProvidersConfig {
   return {
     version: VERSION,
     providers: {
+      claude: {
+        enabled: false,
+        tools: {
+          search: true,
+          answer: true,
+        },
+      },
       codex: {
         enabled: true,
         tools: {
@@ -166,6 +174,7 @@ export function parseProviderConfig(
   text: string,
   source = CONFIG_FILE_NAME,
 ):
+  | ClaudeProviderConfig
   | CodexProviderConfig
   | ExaProviderConfig
   | GeminiProviderConfig
@@ -279,6 +288,12 @@ function normalizeConfig(raw: unknown, source: string): WebProvidersConfig {
     }
 
     config.providers = {};
+    if (raw.providers.claude !== undefined) {
+      config.providers.claude = normalizeClaudeProvider(
+        raw.providers.claude,
+        source,
+      );
+    }
     if (raw.providers.codex !== undefined) {
       config.providers.codex = normalizeCodexProvider(
         raw.providers.codex,
@@ -309,6 +324,7 @@ function normalizeConfig(raw: unknown, source: string): WebProvidersConfig {
 
     const unknownProviders = Object.keys(raw.providers).filter(
       (key) =>
+        key !== "claude" &&
         key !== "codex" &&
         key !== "exa" &&
         key !== "gemini" &&
@@ -323,6 +339,58 @@ function normalizeConfig(raw: unknown, source: string): WebProvidersConfig {
   }
 
   return config;
+}
+
+function normalizeClaudeProvider(
+  raw: unknown,
+  source: string,
+): ClaudeProviderConfig {
+  const provider = parseProviderObject(raw, source, "claude");
+  const defaults = parseOptionalJsonObject(
+    provider.defaults,
+    source,
+    "providers.claude.defaults",
+  );
+
+  return {
+    enabled: parseOptionalBoolean(
+      provider.enabled,
+      source,
+      "providers.claude.enabled",
+    ),
+    tools: parseOptionalProviderTools(
+      "claude",
+      provider.tools,
+      source,
+      "providers.claude.tools",
+    ) as ClaudeProviderConfig["tools"],
+    pathToClaudeCodeExecutable: parseOptionalString(
+      provider.pathToClaudeCodeExecutable,
+      source,
+      "providers.claude.pathToClaudeCodeExecutable",
+    ),
+    defaults:
+      defaults === undefined
+        ? undefined
+        : {
+            model: parseOptionalString(
+              defaults.model,
+              source,
+              "providers.claude.defaults.model",
+            ),
+            effort: parseOptionalLiteral(
+              defaults.effort,
+              source,
+              "providers.claude.defaults.effort",
+              ["low", "medium", "high", "max"] as const,
+            ),
+            maxTurns: parseOptionalInteger(
+              defaults.maxTurns,
+              source,
+              "providers.claude.defaults.maxTurns",
+            ),
+          },
+  };
 }
 
 function normalizeCodexProvider(
@@ -719,6 +787,18 @@ function parseOptionalString(
 function parseString(value: unknown, source: string, field: string): string {
   if (typeof value !== "string") {
     throw new Error(`'${field}' in ${source} must be a string.`);
+  }
+  return value;
+}
+
+function parseOptionalInteger(
+  value: unknown,
+  source: string,
+  field: string,
+): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+    throw new Error(`'${field}' in ${source} must be a positive integer.`);
   }
   return value;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -597,15 +597,11 @@ async function executeProviderTool({
 
   let response: ProviderToolOutput;
   try {
-    response = await invoke(
-      provider,
-      providerConfig as ProviderConfigUnion,
-      {
-        cwd: ctx.cwd,
-        signal: signal ?? undefined,
-        onProgress: progress.report,
-      },
-    );
+    response = await invoke(provider, providerConfig as ProviderConfigUnion, {
+      cwd: ctx.cwd,
+      signal: signal ?? undefined,
+      onProgress: progress.report,
+    });
   } finally {
     progress.stop();
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ import {
 } from "./provider-tools.js";
 import { PROVIDER_MAP, PROVIDERS } from "./providers/index.js";
 import type {
+  ClaudeProviderConfig,
   CodexProviderConfig,
   ExaProviderConfig,
   GeminiProviderConfig,
@@ -755,6 +756,9 @@ interface ProviderMenuOption {
     | "apiKey"
     | "baseUrl"
     | "model"
+    | "claudePathToExecutable"
+    | "claudeEffort"
+    | "claudeMaxTurns"
     | "modelReasoningEffort"
     | "webSearchMode"
     | "networkAccessEnabled"
@@ -812,6 +816,8 @@ function buildProviderMenuOptions(
       | "apiKey"
       | "baseUrl"
       | "model"
+      | "claudePathToExecutable"
+      | "claudeMaxTurns"
       | "additionalDirectories"
       | "geminiSearchModel"
       | "geminiAnswerModel"
@@ -829,6 +835,7 @@ function buildProviderMenuOptions(
 
   const pushValues = (
     key:
+      | "claudeEffort"
       | "modelReasoningEffort"
       | "webSearchMode"
       | "networkAccessEnabled"
@@ -853,6 +860,31 @@ function buildProviderMenuOptions(
       values,
     });
   };
+
+  if (providerId === "claude") {
+    pushText(
+      "model",
+      "Model",
+      "Optional Claude model override. Leave empty to use the local default.",
+    );
+    pushValues(
+      "claudeEffort",
+      "Effort",
+      "How much effort Claude should use. 'default' uses the SDK default.",
+      ["default", "low", "medium", "high", "max"],
+    );
+    pushText(
+      "claudeMaxTurns",
+      "Max turns",
+      "Optional maximum number of Claude turns. Leave empty to use the SDK default.",
+    );
+    pushText(
+      "claudePathToExecutable",
+      "Executable path",
+      "Optional path to the Claude Code executable. Leave empty to use the bundled/default executable.",
+    );
+    return options;
+  }
 
   if (providerId === "codex") {
     pushText(
@@ -1146,6 +1178,7 @@ class WebProvidersSettingsView implements Component {
           this.activeProvider,
           providerConfig,
           option.key as
+            | "claudeEffort"
             | "modelReasoningEffort"
             | "webSearchMode"
             | "networkAccessEnabled"
@@ -1168,22 +1201,30 @@ class WebProvidersSettingsView implements Component {
     if (option.kind === "text") {
       const key = option.key as ProviderMenuOption["key"];
       const currentValue =
-        key === "model" || key === "additionalDirectories"
-          ? getCodexTextSettingValue(
-              providerConfig as CodexProviderConfig | undefined,
+        this.activeProvider === "claude" &&
+        (key === "model" ||
+          key === "claudePathToExecutable" ||
+          key === "claudeMaxTurns")
+          ? getClaudeTextSettingValue(
+              providerConfig as ClaudeProviderConfig | undefined,
               key,
             )
-          : key === "geminiSearchModel" ||
-              key === "geminiAnswerModel" ||
-              key === "geminiResearchAgent"
-            ? getGeminiTextSettingValue(
-                providerConfig as GeminiProviderConfig | undefined,
+          : key === "model" || key === "additionalDirectories"
+            ? getCodexTextSettingValue(
+                providerConfig as CodexProviderConfig | undefined,
                 key,
               )
-            : getProviderStringValue(
-                providerConfig,
-                key as "apiKey" | "baseUrl",
-              );
+            : key === "geminiSearchModel" ||
+                key === "geminiAnswerModel" ||
+                key === "geminiResearchAgent"
+              ? getGeminiTextSettingValue(
+                  providerConfig as GeminiProviderConfig | undefined,
+                  key,
+                )
+              : getProviderStringValue(
+                  providerConfig,
+                  key as "apiKey" | "baseUrl",
+                );
       const secret = key === "apiKey";
       return {
         id: key,
@@ -1345,6 +1386,17 @@ class WebProvidersSettingsView implements Component {
     if (id === "apiKey" || id === "baseUrl") {
       return getProviderStringValue(providerConfig, id);
     }
+    if (
+      this.activeProvider === "claude" &&
+      (id === "model" ||
+        id === "claudePathToExecutable" ||
+        id === "claudeMaxTurns")
+    ) {
+      return getClaudeTextSettingValue(
+        providerConfig as ClaudeProviderConfig | undefined,
+        id,
+      );
+    }
     if (id === "model" || id === "additionalDirectories") {
       return getCodexTextSettingValue(
         providerConfig as CodexProviderConfig | undefined,
@@ -1405,6 +1457,15 @@ class WebProvidersSettingsView implements Component {
 
       if (id === "apiKey" || id === "baseUrl") {
         assignOptionalString(providerConfig, id, value);
+      } else if (
+        this.activeProvider === "claude" &&
+        applyClaudeSettingChange(
+          providerConfig as unknown as ClaudeProviderConfig,
+          id,
+          value,
+        )
+      ) {
+        // handled above
       } else if (
         this.activeProvider === "codex" &&
         applyCodexSettingChange(
@@ -1604,6 +1665,7 @@ function getProviderChoiceValue(
   providerId: ProviderId,
   config: ProviderConfigUnion | undefined,
   key:
+    | "claudeEffort"
     | "modelReasoningEffort"
     | "webSearchMode"
     | "networkAccessEnabled"
@@ -1617,6 +1679,13 @@ function getProviderChoiceValue(
     | "valyuSearchType"
     | "valyuResponseLength",
 ): string {
+  if (providerId === "claude") {
+    const defaults = (config as ClaudeProviderConfig | undefined)?.defaults;
+    if (key === "claudeEffort") {
+      return typeof defaults?.effort === "string" ? defaults.effort : "default";
+    }
+  }
+
   if (providerId === "codex") {
     const defaults = (config as CodexProviderConfig | undefined)?.defaults;
     if (key === "networkAccessEnabled" || key === "webSearchEnabled") {
@@ -1693,6 +1762,24 @@ function getProviderChoiceValue(
   throw new Error(`Unsupported choice setting '${key}' for '${providerId}'.`);
 }
 
+function getClaudeTextSettingValue(
+  config: ClaudeProviderConfig | undefined,
+  key: "model" | "claudePathToExecutable" | "claudeMaxTurns",
+): string | undefined {
+  if (key === "claudePathToExecutable") {
+    return config?.pathToClaudeCodeExecutable;
+  }
+
+  const defaults = config?.defaults;
+  if (!defaults) return undefined;
+  if (key === "claudeMaxTurns") {
+    return typeof defaults.maxTurns === "number"
+      ? String(defaults.maxTurns)
+      : undefined;
+  }
+  return defaults.model;
+}
+
 function getCodexTextSettingValue(
   config: CodexProviderConfig | undefined,
   key: "model" | "additionalDirectories",
@@ -1726,6 +1813,60 @@ function assignOptionalString(
     delete target[key];
   } else {
     target[key] = trimmed;
+  }
+}
+
+function applyClaudeSettingChange(
+  target: ClaudeProviderConfig,
+  key: string,
+  value: string,
+): boolean {
+  target.defaults ??= {};
+
+  switch (key) {
+    case "model":
+      assignOptionalString(
+        target.defaults as Record<
+          string,
+          JsonObject | string | boolean | undefined
+        >,
+        "model",
+        value,
+      );
+      cleanupClaudeDefaults(target);
+      return true;
+    case "claudePathToExecutable":
+      assignOptionalString(
+        target as Record<string, JsonObject | string | boolean | undefined>,
+        "pathToClaudeCodeExecutable",
+        value,
+      );
+      cleanupClaudeDefaults(target);
+      return true;
+    case "claudeMaxTurns": {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        delete target.defaults.maxTurns;
+      } else {
+        const parsed = Number(trimmed);
+        if (!Number.isInteger(parsed) || parsed < 1) {
+          throw new Error("Claude max turns must be a positive integer.");
+        }
+        target.defaults.maxTurns = parsed;
+      }
+      cleanupClaudeDefaults(target);
+      return true;
+    }
+    case "claudeEffort":
+      if (value === "default") {
+        delete target.defaults.effort;
+      } else {
+        target.defaults.effort = value as never;
+      }
+      cleanupClaudeDefaults(target);
+      return true;
+    default:
+      return false;
   }
 }
 
@@ -1945,6 +2086,12 @@ function applyParallelSettingChange(
       return true;
     default:
       return false;
+  }
+}
+
+function cleanupClaudeDefaults(target: ClaudeProviderConfig): void {
+  if (target.defaults && Object.keys(target.defaults).length === 0) {
+    delete target.defaults;
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,7 +142,7 @@ function registerWebSearchTool(
       ),
       provider: providerEnum(
         visibleProviderIds,
-        "Provider override. If omitted, uses the active configured provider or falls back to Codex for search when it is not explicitly disabled.",
+        "Provider override. If omitted, uses the active configured provider or falls back to Codex first and then Claude for search when they are not explicitly disabled.",
       ),
     }),
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,7 +142,7 @@ function registerWebSearchTool(
       ),
       provider: providerEnum(
         visibleProviderIds,
-        "Provider override. If omitted, uses the active configured provider or falls back to Codex first and then Claude for search when they are not explicitly disabled.",
+        "Provider override. If omitted, uses the active configured provider or falls back to Codex for search when it is not explicitly disabled.",
       ),
     }),
 

--- a/src/provider-resolution.ts
+++ b/src/provider-resolution.ts
@@ -6,9 +6,7 @@ import {
 import { PROVIDER_MAP, PROVIDERS } from "./providers/index.js";
 import type { ProviderId, WebProvidersConfig } from "./types.js";
 
-const IMPLICIT_PROVIDER_FALLBACKS: readonly ProviderId[] = [
-  "codex",
-] as const;
+const IMPLICIT_PROVIDER_FALLBACKS: readonly ProviderId[] = ["codex"] as const;
 
 export function resolveProviderChoice(
   config: WebProvidersConfig,

--- a/src/provider-resolution.ts
+++ b/src/provider-resolution.ts
@@ -8,7 +8,6 @@ import type { ProviderId, WebProvidersConfig } from "./types.js";
 
 const IMPLICIT_PROVIDER_FALLBACKS: readonly ProviderId[] = [
   "codex",
-  "claude",
 ] as const;
 
 export function resolveProviderChoice(

--- a/src/provider-resolution.ts
+++ b/src/provider-resolution.ts
@@ -6,6 +6,11 @@ import {
 import { PROVIDER_MAP, PROVIDERS } from "./providers/index.js";
 import type { ProviderId, WebProvidersConfig } from "./types.js";
 
+const IMPLICIT_PROVIDER_FALLBACKS: readonly ProviderId[] = [
+  "codex",
+  "claude",
+] as const;
+
 export function resolveProviderChoice(
   config: WebProvidersConfig,
   explicit: ProviderId | undefined,
@@ -24,8 +29,11 @@ export function getEffectiveProviderConfig(
   if (configured) {
     return configured;
   }
-  if (providerId === "codex") {
-    return PROVIDER_MAP.codex.createTemplate() as ProviderConfigUnion;
+  if (IMPLICIT_PROVIDER_FALLBACKS.includes(providerId)) {
+    return {
+      ...PROVIDER_MAP[providerId].createTemplate(),
+      enabled: true,
+    } as ProviderConfigUnion;
   }
   return undefined;
 }
@@ -75,7 +83,8 @@ export function resolveProviderForCapability(
     if (status.available) return provider;
   }
 
-  for (const provider of PROVIDERS) {
+  for (const providerId of IMPLICIT_PROVIDER_FALLBACKS) {
+    const provider = PROVIDER_MAP[providerId];
     if (typeof provider[capability] !== "function") continue;
     const providerConfig = getEffectiveProviderConfig(config, provider.id);
     if (!isProviderToolEnabled(provider.id, providerConfig, capability)) {

--- a/src/provider-tools.ts
+++ b/src/provider-tools.ts
@@ -1,4 +1,5 @@
 import type {
+  ClaudeProviderConfig,
   CodexProviderConfig,
   ExaProviderConfig,
   GeminiProviderConfig,
@@ -17,6 +18,7 @@ export const PROVIDER_TOOL_IDS = [
 export type ProviderToolId = (typeof PROVIDER_TOOL_IDS)[number];
 
 export const PROVIDER_TOOLS: Record<ProviderId, readonly ProviderToolId[]> = {
+  claude: ["search", "answer"],
   codex: ["search"],
   exa: ["search", "contents", "answer", "research"],
   gemini: ["search", "answer", "research"],
@@ -47,6 +49,7 @@ export const PROVIDER_TOOL_META: Record<
 };
 
 export type ProviderConfigUnion =
+  | ClaudeProviderConfig
   | CodexProviderConfig
   | ExaProviderConfig
   | GeminiProviderConfig

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -93,7 +93,10 @@ export class ClaudeProvider implements WebProvider<ClaudeProviderConfig> {
     };
   }
 
-  getStatus(config: ClaudeProviderConfig | undefined): ProviderStatus {
+  getStatus(
+    config: ClaudeProviderConfig | undefined,
+    _cwd: string,
+  ): ProviderStatus {
     if (!config) {
       return { available: false, summary: "not configured" };
     }
@@ -107,10 +110,6 @@ export class ClaudeProvider implements WebProvider<ClaudeProviderConfig> {
     const authStatus = getClaudeAuthStatus(executablePath);
     if (!authStatus.loggedIn) {
       return { available: false, summary: "missing Claude auth" };
-    }
-    const queryAccessStatus = getClaudeQueryAccessStatus(executablePath);
-    if (!queryAccessStatus.available) {
-      return { available: false, summary: queryAccessStatus.summary };
     }
     return { available: true, summary: "enabled" };
   }
@@ -284,22 +283,10 @@ interface CachedClaudeAuthStatus extends ClaudeAuthStatus {
   checkedAt: number;
 }
 
-interface ClaudeQueryAccessStatus {
-  available: boolean;
-  summary: string;
-}
-
-interface CachedClaudeQueryAccessStatus extends ClaudeQueryAccessStatus {
-  checkedAt: number;
-}
-
 const CLAUDE_AUTH_CACHE_TTL_MS = 5_000;
-const CLAUDE_QUERY_ACCESS_CACHE_TTL_MS = 60_000;
-const CLAUDE_QUERY_ACCESS_PROMPT = "Reply with OK.";
 
 let defaultClaudeExecutablePath: string | undefined;
 const claudeAuthStatusCache = new Map<string, CachedClaudeAuthStatus>();
-const claudeQueryAccessCache = new Map<string, CachedClaudeQueryAccessStatus>();
 
 function resolveClaudeExecutablePath(
   config: ClaudeProviderConfig,
@@ -370,65 +357,9 @@ function cacheClaudeAuthStatus(
   return status;
 }
 
-function getClaudeQueryAccessStatus(
-  executablePath: string | undefined,
-): ClaudeQueryAccessStatus {
-  if (!executablePath) {
-    return {
-      available: false,
-      summary: "missing Claude Code executable",
-    };
-  }
-
-  const cachedStatus = claudeQueryAccessCache.get(executablePath);
-  if (
-    cachedStatus &&
-    Date.now() - cachedStatus.checkedAt < CLAUDE_QUERY_ACCESS_CACHE_TTL_MS
-  ) {
-    return {
-      available: cachedStatus.available,
-      summary: cachedStatus.summary,
-    };
-  }
-
-  const [command, ...args] = getClaudeQueryAccessCommand(executablePath);
-
-  try {
-    execFileSync(command, args, {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-      timeout: 15_000,
-    });
-    return cacheClaudeQueryAccessStatus(executablePath, {
-      available: true,
-      summary: "enabled",
-    });
-  } catch (error) {
-    return cacheClaudeQueryAccessStatus(executablePath, {
-      available: false,
-      summary: parseClaudeQueryAccessFailure(
-        getExecOutput((error as { stdout?: string | Buffer }).stdout),
-        getExecOutput((error as { stderr?: string | Buffer }).stderr),
-      ),
-    });
-  }
-}
-
-function cacheClaudeQueryAccessStatus(
-  executablePath: string,
-  status: ClaudeQueryAccessStatus,
-): ClaudeQueryAccessStatus {
-  claudeQueryAccessCache.set(executablePath, {
-    ...status,
-    checkedAt: Date.now(),
-  });
-  return status;
-}
-
 export function resetClaudeProviderCachesForTests(): void {
   defaultClaudeExecutablePath = undefined;
   claudeAuthStatusCache.clear();
-  claudeQueryAccessCache.clear();
 }
 
 function getClaudeAuthCommand(executablePath: string): string[] {
@@ -437,24 +368,6 @@ function getClaudeAuthCommand(executablePath: string): string[] {
     return [process.execPath, executablePath, "auth", "status", "--json"];
   }
   return [executablePath, "auth", "status", "--json"];
-}
-
-function getClaudeQueryAccessCommand(executablePath: string): string[] {
-  const args = [
-    "-p",
-    "--output-format",
-    "json",
-    "--no-session-persistence",
-    "--tools",
-    "",
-    CLAUDE_QUERY_ACCESS_PROMPT,
-  ];
-
-  const extension = extname(executablePath);
-  if (extension === ".js" || extension === ".cjs" || extension === ".mjs") {
-    return [process.execPath, executablePath, ...args];
-  }
-  return [executablePath, ...args];
 }
 
 function getExecOutput(output: string | Buffer | undefined): string {
@@ -474,20 +387,6 @@ function parseClaudeAuthStatus(raw: string): ClaudeAuthStatus {
   } catch {
     return { loggedIn: false };
   }
-}
-
-function parseClaudeQueryAccessFailure(
-  stdout: string,
-  stderr: string,
-): string {
-  const output = [stderr, stdout].filter(Boolean).join("\n").toLowerCase();
-  if (
-    output.includes("authentication_failed") ||
-    output.includes("does not have access to claude")
-  ) {
-    return "missing Claude query access";
-  }
-  return "Claude query access unavailable";
 }
 
 function handleProgressMessage(

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -231,6 +231,7 @@ export class ClaudeProvider implements WebProvider<ClaudeProviderConfig> {
           schema,
         },
         pathToClaudeCodeExecutable: config.pathToClaudeCodeExecutable,
+        persistSession: false,
         permissionMode: "dontAsk",
         systemPrompt: {
           type: "preset",
@@ -275,7 +276,14 @@ interface ClaudeAuthStatus {
   loggedIn: boolean;
 }
 
+interface CachedClaudeAuthStatus extends ClaudeAuthStatus {
+  checkedAt: number;
+}
+
+const CLAUDE_AUTH_CACHE_TTL_MS = 5_000;
+
 let defaultClaudeExecutablePath: string | undefined;
+const claudeAuthStatusCache = new Map<string, CachedClaudeAuthStatus>();
 
 function resolveClaudeExecutablePath(
   config: ClaudeProviderConfig,
@@ -302,6 +310,14 @@ function getClaudeAuthStatus(
     return { loggedIn: false };
   }
 
+  const cachedStatus = claudeAuthStatusCache.get(executablePath);
+  if (
+    cachedStatus &&
+    Date.now() - cachedStatus.checkedAt < CLAUDE_AUTH_CACHE_TTL_MS
+  ) {
+    return { loggedIn: cachedStatus.loggedIn };
+  }
+
   const [command, ...args] = getClaudeAuthCommand(executablePath);
 
   try {
@@ -309,16 +325,38 @@ function getClaudeAuthStatus(
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
     });
-    return parseClaudeAuthStatus(stdout);
+    return cacheClaudeAuthStatus(
+      executablePath,
+      parseClaudeAuthStatus(stdout),
+    );
   } catch (error) {
     const stdout = getExecOutput(
       (error as { stdout?: string | Buffer }).stdout,
     );
     if (stdout) {
-      return parseClaudeAuthStatus(stdout);
+      return cacheClaudeAuthStatus(
+        executablePath,
+        parseClaudeAuthStatus(stdout),
+      );
     }
-    return { loggedIn: false };
+    return cacheClaudeAuthStatus(executablePath, { loggedIn: false });
   }
+}
+
+function cacheClaudeAuthStatus(
+  executablePath: string,
+  status: ClaudeAuthStatus,
+): ClaudeAuthStatus {
+  claudeAuthStatusCache.set(executablePath, {
+    ...status,
+    checkedAt: Date.now(),
+  });
+  return status;
+}
+
+export function resetClaudeProviderCachesForTests(): void {
+  defaultClaudeExecutablePath = undefined;
+  claudeAuthStatusCache.clear();
 }
 
 function getClaudeAuthCommand(executablePath: string): string[] {

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -108,6 +108,10 @@ export class ClaudeProvider implements WebProvider<ClaudeProviderConfig> {
     if (!authStatus.loggedIn) {
       return { available: false, summary: "missing Claude auth" };
     }
+    const queryAccessStatus = getClaudeQueryAccessStatus(executablePath);
+    if (!queryAccessStatus.available) {
+      return { available: false, summary: queryAccessStatus.summary };
+    }
     return { available: true, summary: "enabled" };
   }
 
@@ -280,10 +284,22 @@ interface CachedClaudeAuthStatus extends ClaudeAuthStatus {
   checkedAt: number;
 }
 
+interface ClaudeQueryAccessStatus {
+  available: boolean;
+  summary: string;
+}
+
+interface CachedClaudeQueryAccessStatus extends ClaudeQueryAccessStatus {
+  checkedAt: number;
+}
+
 const CLAUDE_AUTH_CACHE_TTL_MS = 5_000;
+const CLAUDE_QUERY_ACCESS_CACHE_TTL_MS = 60_000;
+const CLAUDE_QUERY_ACCESS_PROMPT = "Reply with OK.";
 
 let defaultClaudeExecutablePath: string | undefined;
 const claudeAuthStatusCache = new Map<string, CachedClaudeAuthStatus>();
+const claudeQueryAccessCache = new Map<string, CachedClaudeQueryAccessStatus>();
 
 function resolveClaudeExecutablePath(
   config: ClaudeProviderConfig,
@@ -354,9 +370,65 @@ function cacheClaudeAuthStatus(
   return status;
 }
 
+function getClaudeQueryAccessStatus(
+  executablePath: string | undefined,
+): ClaudeQueryAccessStatus {
+  if (!executablePath) {
+    return {
+      available: false,
+      summary: "missing Claude Code executable",
+    };
+  }
+
+  const cachedStatus = claudeQueryAccessCache.get(executablePath);
+  if (
+    cachedStatus &&
+    Date.now() - cachedStatus.checkedAt < CLAUDE_QUERY_ACCESS_CACHE_TTL_MS
+  ) {
+    return {
+      available: cachedStatus.available,
+      summary: cachedStatus.summary,
+    };
+  }
+
+  const [command, ...args] = getClaudeQueryAccessCommand(executablePath);
+
+  try {
+    execFileSync(command, args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 15_000,
+    });
+    return cacheClaudeQueryAccessStatus(executablePath, {
+      available: true,
+      summary: "enabled",
+    });
+  } catch (error) {
+    return cacheClaudeQueryAccessStatus(executablePath, {
+      available: false,
+      summary: parseClaudeQueryAccessFailure(
+        getExecOutput((error as { stdout?: string | Buffer }).stdout),
+        getExecOutput((error as { stderr?: string | Buffer }).stderr),
+      ),
+    });
+  }
+}
+
+function cacheClaudeQueryAccessStatus(
+  executablePath: string,
+  status: ClaudeQueryAccessStatus,
+): ClaudeQueryAccessStatus {
+  claudeQueryAccessCache.set(executablePath, {
+    ...status,
+    checkedAt: Date.now(),
+  });
+  return status;
+}
+
 export function resetClaudeProviderCachesForTests(): void {
   defaultClaudeExecutablePath = undefined;
   claudeAuthStatusCache.clear();
+  claudeQueryAccessCache.clear();
 }
 
 function getClaudeAuthCommand(executablePath: string): string[] {
@@ -365,6 +437,24 @@ function getClaudeAuthCommand(executablePath: string): string[] {
     return [process.execPath, executablePath, "auth", "status", "--json"];
   }
   return [executablePath, "auth", "status", "--json"];
+}
+
+function getClaudeQueryAccessCommand(executablePath: string): string[] {
+  const args = [
+    "-p",
+    "--output-format",
+    "json",
+    "--no-session-persistence",
+    "--tools",
+    "",
+    CLAUDE_QUERY_ACCESS_PROMPT,
+  ];
+
+  const extension = extname(executablePath);
+  if (extension === ".js" || extension === ".cjs" || extension === ".mjs") {
+    return [process.execPath, executablePath, ...args];
+  }
+  return [executablePath, ...args];
 }
 
 function getExecOutput(output: string | Buffer | undefined): string {
@@ -384,6 +474,20 @@ function parseClaudeAuthStatus(raw: string): ClaudeAuthStatus {
   } catch {
     return { loggedIn: false };
   }
+}
+
+function parseClaudeQueryAccessFailure(
+  stdout: string,
+  stderr: string,
+): string {
+  const output = [stderr, stdout].filter(Boolean).join("\n").toLowerCase();
+  if (
+    output.includes("authentication_failed") ||
+    output.includes("does not have access to claude")
+  ) {
+    return "missing Claude query access";
+  }
+  return "Claude query access unavailable";
 }
 
 function handleProgressMessage(

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -1,0 +1,436 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, extname, join } from "node:path";
+import {
+  query,
+  type SDKMessage,
+  type SDKResultMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+import type {
+  ClaudeProviderConfig,
+  ProviderContext,
+  ProviderStatus,
+  ProviderToolOutput,
+  SearchResponse,
+  WebProvider,
+} from "../types.js";
+import { trimSnippet } from "./shared.js";
+
+const require = createRequire(import.meta.url);
+
+const SEARCH_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    sources: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          title: { type: "string" },
+          url: { type: "string" },
+          snippet: { type: "string" },
+        },
+        required: ["title", "url", "snippet"],
+      },
+    },
+  },
+  required: ["sources"],
+} as const;
+
+const ANSWER_OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    answer: { type: "string" },
+    sources: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          title: { type: "string" },
+          url: { type: "string" },
+        },
+        required: ["title", "url"],
+      },
+    },
+  },
+  required: ["answer", "sources"],
+} as const;
+
+interface ClaudeSearchOutput {
+  sources: Array<{
+    title: string;
+    url: string;
+    snippet: string;
+  }>;
+}
+
+interface ClaudeAnswerOutput {
+  answer: string;
+  sources: Array<{
+    title: string;
+    url: string;
+  }>;
+}
+
+export class ClaudeProvider implements WebProvider<ClaudeProviderConfig> {
+  readonly id = "claude";
+  readonly label = "Claude";
+  readonly docsUrl =
+    "https://github.com/anthropics/claude-agent-sdk-typescript";
+
+  createTemplate(): ClaudeProviderConfig {
+    return {
+      enabled: false,
+      tools: {
+        search: true,
+        answer: true,
+      },
+    };
+  }
+
+  getStatus(config: ClaudeProviderConfig | undefined): ProviderStatus {
+    if (!config) {
+      return { available: false, summary: "not configured" };
+    }
+    if (config.enabled === false) {
+      return { available: false, summary: "disabled" };
+    }
+    const executablePath = resolveClaudeExecutablePath(config);
+    if (executablePath && !existsSync(executablePath)) {
+      return { available: false, summary: "missing Claude Code executable" };
+    }
+    const authStatus = getClaudeAuthStatus(executablePath);
+    if (!authStatus.loggedIn) {
+      return { available: false, summary: "missing Claude auth" };
+    }
+    return { available: true, summary: "enabled" };
+  }
+
+  async search(
+    queryText: string,
+    maxResults: number,
+    config: ClaudeProviderConfig,
+    context: ProviderContext,
+  ): Promise<SearchResponse> {
+    const output = parseClaudeSearchOutput(
+      await this.runStructuredQuery<ClaudeSearchOutput>({
+        prompt: [
+          "You are performing web research for another coding agent.",
+          "Use the WebSearch tool to search the public web.",
+          "Return only a JSON object matching the provided schema.",
+          "Do not include markdown fences or extra commentary.",
+          `Return at most ${maxResults} sources.`,
+          "Each snippet should be short, factual, and specific to the result.",
+          "Prefer primary or official sources when they are available.",
+          "",
+          `User query: ${queryText}`,
+        ].join("\n"),
+        schema: SEARCH_OUTPUT_SCHEMA,
+        tools: ["WebSearch"],
+        config,
+        context,
+      }),
+    );
+
+    return {
+      provider: this.id,
+      results: output.sources.slice(0, maxResults).map((source) => ({
+        title: source.title.trim(),
+        url: source.url.trim(),
+        snippet: trimSnippet(source.snippet),
+      })),
+    };
+  }
+
+  async answer(
+    queryText: string,
+    options: Record<string, unknown> | undefined,
+    config: ClaudeProviderConfig,
+    context: ProviderContext,
+  ): Promise<ProviderToolOutput> {
+    const output = parseClaudeAnswerOutput(
+      await this.runStructuredQuery<ClaudeAnswerOutput>({
+        prompt: [
+          "Answer the user's question using current public web information.",
+          "Use WebSearch to find relevant sources and WebFetch when you need to verify important details.",
+          "Return only a JSON object matching the provided schema.",
+          "Do not include markdown fences or extra commentary.",
+          "Keep the answer concise but informative.",
+          "Only cite sources you actually used.",
+          "",
+          `User query: ${queryText}`,
+          options ? `Additional options: ${JSON.stringify(options)}` : "",
+        ]
+          .filter(Boolean)
+          .join("\n"),
+        schema: ANSWER_OUTPUT_SCHEMA,
+        tools: ["WebSearch", "WebFetch"],
+        config,
+        context,
+      }),
+    );
+
+    const lines: string[] = [];
+    lines.push(output.answer.trim() || "No answer returned.");
+
+    if (output.sources.length > 0) {
+      lines.push("");
+      lines.push("Sources:");
+      for (const [index, source] of output.sources.entries()) {
+        lines.push(`${index + 1}. ${source.title}`);
+        lines.push(`   ${source.url}`);
+      }
+    }
+
+    return {
+      provider: this.id,
+      text: lines.join("\n").trimEnd(),
+      summary: `Answer via Claude with ${output.sources.length} source(s)`,
+      itemCount: output.sources.length,
+    };
+  }
+
+  private async runStructuredQuery<T>({
+    prompt,
+    schema,
+    tools,
+    config,
+    context,
+  }: {
+    prompt: string;
+    schema: Record<string, unknown>;
+    tools: string[];
+    config: ClaudeProviderConfig;
+    context: ProviderContext;
+  }): Promise<T> {
+    const abortController = new AbortController();
+    if (context.signal?.aborted) {
+      abortController.abort(context.signal.reason);
+    }
+    const onAbort = () => {
+      abortController.abort(context.signal?.reason);
+    };
+    context.signal?.addEventListener("abort", onAbort, { once: true });
+
+    const stream = query({
+      prompt,
+      options: {
+        abortController,
+        allowedTools: tools,
+        cwd: context.cwd,
+        effort: config.defaults?.effort,
+        maxTurns: config.defaults?.maxTurns,
+        model: config.defaults?.model,
+        outputFormat: {
+          type: "json_schema",
+          schema,
+        },
+        pathToClaudeCodeExecutable: config.pathToClaudeCodeExecutable,
+        permissionMode: "dontAsk",
+        systemPrompt: {
+          type: "preset",
+          preset: "claude_code",
+          append:
+            "Use only the provided web tools. Always produce output that matches the requested JSON schema exactly.",
+        },
+        tools,
+      },
+    });
+
+    const seenToolUseIds = new Set<string>();
+    let finalResult: SDKResultMessage | undefined;
+
+    try {
+      for await (const message of stream) {
+        handleProgressMessage(message, seenToolUseIds, context.onProgress);
+        if (message.type === "result") {
+          finalResult = message;
+        }
+      }
+    } finally {
+      context.signal?.removeEventListener("abort", onAbort);
+      stream.close();
+    }
+
+    if (!finalResult) {
+      throw new Error("Claude returned no result.");
+    }
+    if (finalResult.subtype !== "success") {
+      throw new Error(
+        finalResult.errors.join("\n") ||
+          `Claude query failed (${finalResult.subtype}).`,
+      );
+    }
+
+    return parseStructuredOutput<T>(finalResult);
+  }
+}
+
+interface ClaudeAuthStatus {
+  loggedIn: boolean;
+}
+
+let defaultClaudeExecutablePath: string | undefined;
+
+function resolveClaudeExecutablePath(
+  config: ClaudeProviderConfig,
+): string | undefined {
+  if (config.pathToClaudeCodeExecutable) {
+    return config.pathToClaudeCodeExecutable;
+  }
+  if (defaultClaudeExecutablePath !== undefined) {
+    return defaultClaudeExecutablePath;
+  }
+  try {
+    const sdkEntryPath = require.resolve("@anthropic-ai/claude-agent-sdk");
+    defaultClaudeExecutablePath = join(dirname(sdkEntryPath), "cli.js");
+  } catch {
+    defaultClaudeExecutablePath = undefined;
+  }
+  return defaultClaudeExecutablePath;
+}
+
+function getClaudeAuthStatus(
+  executablePath: string | undefined,
+): ClaudeAuthStatus {
+  if (!executablePath) {
+    return { loggedIn: false };
+  }
+
+  const [command, ...args] = getClaudeAuthCommand(executablePath);
+
+  try {
+    const stdout = execFileSync(command, args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return parseClaudeAuthStatus(stdout);
+  } catch (error) {
+    const stdout = getExecOutput(
+      (error as { stdout?: string | Buffer }).stdout,
+    );
+    if (stdout) {
+      return parseClaudeAuthStatus(stdout);
+    }
+    return { loggedIn: false };
+  }
+}
+
+function getClaudeAuthCommand(executablePath: string): string[] {
+  const extension = extname(executablePath);
+  if (extension === ".js" || extension === ".cjs" || extension === ".mjs") {
+    return [process.execPath, executablePath, "auth", "status", "--json"];
+  }
+  return [executablePath, "auth", "status", "--json"];
+}
+
+function getExecOutput(output: string | Buffer | undefined): string {
+  if (typeof output === "string") {
+    return output;
+  }
+  if (Buffer.isBuffer(output)) {
+    return output.toString("utf8");
+  }
+  return "";
+}
+
+function parseClaudeAuthStatus(raw: string): ClaudeAuthStatus {
+  try {
+    const parsed = JSON.parse(raw) as { loggedIn?: unknown };
+    return { loggedIn: parsed.loggedIn === true };
+  } catch {
+    return { loggedIn: false };
+  }
+}
+
+function handleProgressMessage(
+  message: SDKMessage,
+  seenToolUseIds: Set<string>,
+  onProgress: ((message: string) => void) | undefined,
+): void {
+  if (!onProgress || message.type !== "tool_progress") {
+    return;
+  }
+  if (seenToolUseIds.has(message.tool_use_id)) {
+    return;
+  }
+
+  seenToolUseIds.add(message.tool_use_id);
+  onProgress(`Claude ${formatToolName(message.tool_name)}`);
+}
+
+function formatToolName(toolName: string): string {
+  if (toolName === "WebSearch") return "web search";
+  if (toolName === "WebFetch") return "web fetch";
+  return toolName;
+}
+
+function parseStructuredOutput<T>(result: SDKResultMessage): T {
+  if (result.subtype !== "success") {
+    throw new Error("Claude query did not succeed.");
+  }
+
+  if (result.structured_output !== undefined) {
+    return result.structured_output as T;
+  }
+
+  if (!result.result.trim()) {
+    throw new Error("Claude returned an empty response.");
+  }
+
+  try {
+    return JSON.parse(result.result) as T;
+  } catch {
+    const match = result.result.match(/\{[\s\S]*\}/);
+    if (!match) {
+      throw new Error("Claude returned invalid JSON output.");
+    }
+    return JSON.parse(match[0]) as T;
+  }
+}
+
+function parseClaudeSearchOutput(value: unknown): ClaudeSearchOutput {
+  const sources = readArray(value, "sources").map((entry) => ({
+    title: readString(entry, "title"),
+    url: readString(entry, "url"),
+    snippet: readString(entry, "snippet"),
+  }));
+  return { sources };
+}
+
+function parseClaudeAnswerOutput(value: unknown): ClaudeAnswerOutput {
+  return {
+    answer: readString(value, "answer"),
+    sources: readArray(value, "sources").map((entry) => ({
+      title: readString(entry, "title"),
+      url: readString(entry, "url"),
+    })),
+  };
+}
+
+function readArray(value: unknown, key: string): unknown[] {
+  if (typeof value !== "object" || value === null || !(key in value)) {
+    throw new Error(`Claude output is missing '${key}'.`);
+  }
+  const entry = (value as Record<string, unknown>)[key];
+  if (!Array.isArray(entry)) {
+    throw new Error(`Claude output field '${key}' must be an array.`);
+  }
+  return entry;
+}
+
+function readString(value: unknown, key: string): string {
+  if (typeof value !== "object" || value === null || !(key in value)) {
+    throw new Error(`Claude output is missing '${key}'.`);
+  }
+  const entry = (value as Record<string, unknown>)[key];
+  if (typeof entry !== "string") {
+    throw new Error(`Claude output field '${key}' must be a string.`);
+  }
+  return entry;
+}

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -328,10 +328,7 @@ function getClaudeAuthStatus(
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
     });
-    return cacheClaudeAuthStatus(
-      executablePath,
-      parseClaudeAuthStatus(stdout),
-    );
+    return cacheClaudeAuthStatus(executablePath, parseClaudeAuthStatus(stdout));
   } catch (error) {
     const stdout = getExecOutput(
       (error as { stdout?: string | Buffer }).stdout,

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -68,11 +68,7 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
         .map(async (result) => {
           const resolvedUrl = await resolveGoogleSearchUrl(result.url);
           return {
-            title:
-              result.title ??
-              resolvedUrl ??
-              result.url ??
-              "Untitled",
+            title: result.title ?? resolvedUrl ?? result.url ?? "Untitled",
             url: resolvedUrl ?? result.url ?? "",
             snippet: "",
           };
@@ -314,7 +310,10 @@ function formatInteractionOutputs(outputs: unknown): string {
   return lines.join("\n\n").trim();
 }
 
-function formatGroundingSourceTitle(title: string | undefined, url: string): string {
+function formatGroundingSourceTitle(
+  title: string | undefined,
+  url: string,
+): string {
   const trimmedTitle = title?.trim();
   if (trimmedTitle) {
     return trimmedTitle;

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,11 +1,14 @@
-import type { ProviderId, WebProvider } from "../types.js";
 import type {
+  ClaudeProviderConfig,
   CodexProviderConfig,
   ExaProviderConfig,
   GeminiProviderConfig,
   ParallelProviderConfig,
+  ProviderId,
   ValyuProviderConfig,
+  WebProvider,
 } from "../types.js";
+import { ClaudeProvider } from "./claude.js";
 import { CodexProvider } from "./codex.js";
 import { ExaProvider } from "./exa.js";
 import { GeminiProvider } from "./gemini.js";
@@ -14,6 +17,7 @@ import { ValyuProvider } from "./valyu.js";
 
 export const PROVIDERS: ReadonlyArray<
   WebProvider<
+    | ClaudeProviderConfig
     | CodexProviderConfig
     | ExaProviderConfig
     | GeminiProviderConfig
@@ -21,6 +25,7 @@ export const PROVIDERS: ReadonlyArray<
     | ValyuProviderConfig
   >
 > = [
+  new ClaudeProvider(),
   new CodexProvider(),
   new ExaProvider(),
   new GeminiProvider(),
@@ -31,6 +36,7 @@ export const PROVIDERS: ReadonlyArray<
 export const PROVIDER_MAP: Record<
   ProviderId,
   WebProvider<
+    | ClaudeProviderConfig
     | CodexProviderConfig
     | ExaProviderConfig
     | GeminiProviderConfig
@@ -38,9 +44,10 @@ export const PROVIDER_MAP: Record<
     | ValyuProviderConfig
   >
 > = {
-  codex: PROVIDERS[0],
-  exa: PROVIDERS[1],
-  gemini: PROVIDERS[2],
-  parallel: PROVIDERS[3],
-  valyu: PROVIDERS[4],
+  claude: PROVIDERS[0],
+  codex: PROVIDERS[1],
+  exa: PROVIDERS[2],
+  gemini: PROVIDERS[3],
+  parallel: PROVIDERS[4],
+  valyu: PROVIDERS[5],
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type { ModelReasoningEffort, WebSearchMode } from "@openai/codex-sdk";
 
 export const PROVIDER_IDS = [
+  "claude",
   "codex",
   "exa",
   "gemini",
@@ -52,6 +53,20 @@ export interface ProviderToolDetails {
   provider: ProviderId;
   summary?: string;
   itemCount?: number;
+}
+
+export interface ClaudeProviderConfig {
+  enabled?: boolean;
+  tools?: {
+    search?: boolean;
+    answer?: boolean;
+  };
+  pathToClaudeCodeExecutable?: string;
+  defaults?: {
+    model?: string;
+    effort?: "low" | "medium" | "high" | "max";
+    maxTurns?: number;
+  };
 }
 
 export interface CodexProviderConfig {
@@ -133,6 +148,7 @@ export interface ValyuProviderConfig {
 export interface WebProvidersConfig {
   version: 1;
   providers?: {
+    claude?: ClaudeProviderConfig;
     codex?: CodexProviderConfig;
     exa?: ExaProviderConfig;
     gemini?: GeminiProviderConfig;

--- a/test/claude-provider.test.ts
+++ b/test/claude-provider.test.ts
@@ -20,11 +20,15 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
   query: queryMock,
 }));
 
-import { ClaudeProvider } from "../src/providers/claude.js";
+import {
+  ClaudeProvider,
+  resetClaudeProviderCachesForTests,
+} from "../src/providers/claude.js";
 
 afterEach(() => {
   execFileSyncMock.mockReset();
   queryMock.mockReset();
+  resetClaudeProviderCachesForTests();
 });
 
 describe("ClaudeProvider", () => {
@@ -37,7 +41,12 @@ describe("ClaudeProvider", () => {
 
     const provider = new ClaudeProvider();
 
-    expect(provider.getStatus({ enabled: true })).toEqual({
+    expect(
+      provider.getStatus({
+        enabled: true,
+        pathToClaudeCodeExecutable: process.execPath,
+      }),
+    ).toEqual({
       available: false,
       summary: "missing Claude auth",
     });
@@ -50,10 +59,77 @@ describe("ClaudeProvider", () => {
 
     const provider = new ClaudeProvider();
 
-    expect(provider.getStatus({ enabled: true })).toEqual({
+    expect(
+      provider.getStatus({
+        enabled: true,
+        pathToClaudeCodeExecutable: process.execPath,
+      }),
+    ).toEqual({
       available: true,
       summary: "enabled",
     });
+  });
+
+  it("caches Claude auth status across repeated availability checks", () => {
+    execFileSyncMock.mockReturnValue(
+      '{"loggedIn":true,"authMethod":"claude.ai"}',
+    );
+
+    const config = {
+      enabled: true,
+      pathToClaudeCodeExecutable: process.execPath,
+    };
+
+    expect(new ClaudeProvider().getStatus(config)).toEqual({
+      available: true,
+      summary: "enabled",
+    });
+    expect(new ClaudeProvider().getStatus(config)).toEqual({
+      available: true,
+      summary: "enabled",
+    });
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables Claude session persistence for provider queries", async () => {
+    queryMock.mockImplementation(() => ({
+      async *[Symbol.asyncIterator]() {
+        yield {
+          type: "result",
+          subtype: "success",
+          result: "",
+          structured_output: {
+            sources: [
+              {
+                title: "Claude docs",
+                url: "https://docs.anthropic.com",
+                snippet: "Official documentation",
+              },
+            ],
+          },
+          errors: [],
+        };
+      },
+      close() {},
+    }));
+
+    const provider = new ClaudeProvider();
+    await provider.search(
+      "latest Claude docs",
+      1,
+      { enabled: true },
+      {
+        cwd: process.cwd(),
+      },
+    );
+
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          persistSession: false,
+        }),
+      }),
+    );
   });
 
   it("propagates cancellation into Claude queries", async () => {

--- a/test/claude-provider.test.ts
+++ b/test/claude-provider.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { execFileSyncMock, queryMock } = vi.hoisted(() => ({
+  execFileSyncMock: vi.fn(),
+  queryMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", async () => {
+  const actual =
+    await vi.importActual<typeof import("node:child_process")>(
+      "node:child_process",
+    );
+  return {
+    ...actual,
+    execFileSync: execFileSyncMock,
+  };
+});
+
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
+  query: queryMock,
+}));
+
+import { ClaudeProvider } from "../src/providers/claude.js";
+
+afterEach(() => {
+  execFileSyncMock.mockReset();
+  queryMock.mockReset();
+});
+
+describe("ClaudeProvider", () => {
+  it("reports Claude as unavailable when auth status is logged out", () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw Object.assign(new Error("not logged in"), {
+        stdout: '{"loggedIn":false,"authMethod":"none"}',
+      });
+    });
+
+    const provider = new ClaudeProvider();
+
+    expect(provider.getStatus({ enabled: true })).toEqual({
+      available: false,
+      summary: "missing Claude auth",
+    });
+  });
+
+  it("reports Claude as available when auth status is logged in", () => {
+    execFileSyncMock.mockReturnValue(
+      '{"loggedIn":true,"authMethod":"claude.ai"}',
+    );
+
+    const provider = new ClaudeProvider();
+
+    expect(provider.getStatus({ enabled: true })).toEqual({
+      available: true,
+      summary: "enabled",
+    });
+  });
+
+  it("propagates cancellation into Claude queries", async () => {
+    let capturedAbortSignal: AbortSignal | undefined;
+    let closeCalled = false;
+
+    queryMock.mockImplementation(({ options }) => {
+      capturedAbortSignal = options.abortController.signal;
+      return {
+        async *[Symbol.asyncIterator]() {
+          await new Promise<never>((_, reject) => {
+            if (options.abortController.signal.aborted) {
+              reject(new Error("aborted"));
+              return;
+            }
+            options.abortController.signal.addEventListener(
+              "abort",
+              () => reject(new Error("aborted")),
+              { once: true },
+            );
+          });
+        },
+        close() {
+          closeCalled = true;
+        },
+      };
+    });
+
+    const provider = new ClaudeProvider();
+    const controller = new AbortController();
+    const searchPromise = provider.search(
+      "latest Claude docs",
+      1,
+      { enabled: true },
+      {
+        cwd: process.cwd(),
+        signal: controller.signal,
+      },
+    );
+
+    await Promise.resolve();
+    controller.abort();
+
+    await expect(searchPromise).rejects.toThrow("aborted");
+    expect(capturedAbortSignal?.aborted).toBe(true);
+    expect(closeCalled).toBe(true);
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          abortController: expect.any(AbortController),
+        }),
+      }),
+    );
+  });
+});

--- a/test/claude-provider.test.ts
+++ b/test/claude-provider.test.ts
@@ -33,11 +33,7 @@ afterEach(() => {
 
 describe("ClaudeProvider", () => {
   it("reports Claude as unavailable when auth status is logged out", () => {
-    execFileSyncMock.mockImplementation(() => {
-      throw Object.assign(new Error("not logged in"), {
-        stdout: '{"loggedIn":false,"authMethod":"none"}',
-      });
-    });
+    execFileSyncMock.mockImplementation(mockLoggedOutClaudeStatus);
 
     const provider = new ClaudeProvider();
 
@@ -50,12 +46,11 @@ describe("ClaudeProvider", () => {
       available: false,
       summary: "missing Claude auth",
     });
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
   });
 
-  it("reports Claude as available when auth status is logged in", () => {
-    execFileSyncMock.mockReturnValue(
-      '{"loggedIn":true,"authMethod":"claude.ai"}',
-    );
+  it("reports Claude as available when auth and query access are available", () => {
+    execFileSyncMock.mockImplementation(mockClaudeAvailable);
 
     const provider = new ClaudeProvider();
 
@@ -68,12 +63,27 @@ describe("ClaudeProvider", () => {
       available: true,
       summary: "enabled",
     });
+    expect(execFileSyncMock).toHaveBeenCalledTimes(2);
   });
 
-  it("caches Claude auth status across repeated availability checks", () => {
-    execFileSyncMock.mockReturnValue(
-      '{"loggedIn":true,"authMethod":"claude.ai"}',
-    );
+  it("reports Claude as unavailable when auth succeeds but queries are blocked", () => {
+    execFileSyncMock.mockImplementation(mockClaudeWithoutQueryAccess);
+
+    const provider = new ClaudeProvider();
+
+    expect(
+      provider.getStatus({
+        enabled: true,
+        pathToClaudeCodeExecutable: process.execPath,
+      }),
+    ).toEqual({
+      available: false,
+      summary: "missing Claude query access",
+    });
+  });
+
+  it("caches Claude auth and query access status across repeated availability checks", () => {
+    execFileSyncMock.mockImplementation(mockClaudeAvailable);
 
     const config = {
       enabled: true,
@@ -88,7 +98,7 @@ describe("ClaudeProvider", () => {
       available: true,
       summary: "enabled",
     });
-    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+    expect(execFileSyncMock).toHaveBeenCalledTimes(2);
   });
 
   it("disables Claude session persistence for provider queries", async () => {
@@ -185,3 +195,34 @@ describe("ClaudeProvider", () => {
     );
   });
 });
+
+function mockLoggedOutClaudeStatus(): never {
+  throw Object.assign(new Error("not logged in"), {
+    stdout: '{"loggedIn":false,"authMethod":"none"}',
+  });
+}
+
+function mockClaudeAvailable(_command: string, args: string[]): string {
+  if (args.includes("auth") && args.includes("status")) {
+    return '{"loggedIn":true,"authMethod":"claude.ai"}';
+  }
+  if (args.includes("-p")) {
+    return '{"result":"OK"}';
+  }
+  throw new Error(`Unexpected Claude command: ${args.join(" ")}`);
+}
+
+function mockClaudeWithoutQueryAccess(
+  _command: string,
+  args: string[],
+): string {
+  if (args.includes("auth") && args.includes("status")) {
+    return '{"loggedIn":true,"authMethod":"claude.ai"}';
+  }
+  if (args.includes("-p")) {
+    throw Object.assign(new Error("authentication_failed"), {
+      stderr: "authentication_failed: Your organization does not have access to Claude",
+    });
+  }
+  throw new Error(`Unexpected Claude command: ${args.join(" ")}`);
+}

--- a/test/claude-provider.test.ts
+++ b/test/claude-provider.test.ts
@@ -41,7 +41,7 @@ describe("ClaudeProvider", () => {
       provider.getStatus({
         enabled: true,
         pathToClaudeCodeExecutable: process.execPath,
-      }),
+      }, process.cwd()),
     ).toEqual({
       available: false,
       summary: "missing Claude auth",
@@ -49,7 +49,7 @@ describe("ClaudeProvider", () => {
     expect(execFileSyncMock).toHaveBeenCalledTimes(1);
   });
 
-  it("reports Claude as available when auth and query access are available", () => {
+  it("reports Claude as available when auth is available", () => {
     execFileSyncMock.mockImplementation(mockClaudeAvailable);
 
     const provider = new ClaudeProvider();
@@ -58,31 +58,15 @@ describe("ClaudeProvider", () => {
       provider.getStatus({
         enabled: true,
         pathToClaudeCodeExecutable: process.execPath,
-      }),
+      }, process.cwd()),
     ).toEqual({
       available: true,
       summary: "enabled",
     });
-    expect(execFileSyncMock).toHaveBeenCalledTimes(2);
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
   });
 
-  it("reports Claude as unavailable when auth succeeds but queries are blocked", () => {
-    execFileSyncMock.mockImplementation(mockClaudeWithoutQueryAccess);
-
-    const provider = new ClaudeProvider();
-
-    expect(
-      provider.getStatus({
-        enabled: true,
-        pathToClaudeCodeExecutable: process.execPath,
-      }),
-    ).toEqual({
-      available: false,
-      summary: "missing Claude query access",
-    });
-  });
-
-  it("caches Claude auth and query access status across repeated availability checks", () => {
+  it("caches Claude auth status across repeated availability checks", () => {
     execFileSyncMock.mockImplementation(mockClaudeAvailable);
 
     const config = {
@@ -90,15 +74,15 @@ describe("ClaudeProvider", () => {
       pathToClaudeCodeExecutable: process.execPath,
     };
 
-    expect(new ClaudeProvider().getStatus(config)).toEqual({
+    expect(new ClaudeProvider().getStatus(config, process.cwd())).toEqual({
       available: true,
       summary: "enabled",
     });
-    expect(new ClaudeProvider().getStatus(config)).toEqual({
+    expect(new ClaudeProvider().getStatus(config, process.cwd())).toEqual({
       available: true,
       summary: "enabled",
     });
-    expect(execFileSyncMock).toHaveBeenCalledTimes(2);
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
   });
 
   it("disables Claude session persistence for provider queries", async () => {
@@ -205,24 +189,6 @@ function mockLoggedOutClaudeStatus(): never {
 function mockClaudeAvailable(_command: string, args: string[]): string {
   if (args.includes("auth") && args.includes("status")) {
     return '{"loggedIn":true,"authMethod":"claude.ai"}';
-  }
-  if (args.includes("-p")) {
-    return '{"result":"OK"}';
-  }
-  throw new Error(`Unexpected Claude command: ${args.join(" ")}`);
-}
-
-function mockClaudeWithoutQueryAccess(
-  _command: string,
-  args: string[],
-): string {
-  if (args.includes("auth") && args.includes("status")) {
-    return '{"loggedIn":true,"authMethod":"claude.ai"}';
-  }
-  if (args.includes("-p")) {
-    throw Object.assign(new Error("authentication_failed"), {
-      stderr: "authentication_failed: Your organization does not have access to Claude",
-    });
   }
   throw new Error(`Unexpected Claude command: ${args.join(" ")}`);
 }

--- a/test/claude-provider.test.ts
+++ b/test/claude-provider.test.ts
@@ -38,10 +38,13 @@ describe("ClaudeProvider", () => {
     const provider = new ClaudeProvider();
 
     expect(
-      provider.getStatus({
-        enabled: true,
-        pathToClaudeCodeExecutable: process.execPath,
-      }, process.cwd()),
+      provider.getStatus(
+        {
+          enabled: true,
+          pathToClaudeCodeExecutable: process.execPath,
+        },
+        process.cwd(),
+      ),
     ).toEqual({
       available: false,
       summary: "missing Claude auth",
@@ -55,10 +58,13 @@ describe("ClaudeProvider", () => {
     const provider = new ClaudeProvider();
 
     expect(
-      provider.getStatus({
-        enabled: true,
-        pathToClaudeCodeExecutable: process.execPath,
-      }, process.cwd()),
+      provider.getStatus(
+        {
+          enabled: true,
+          pathToClaudeCodeExecutable: process.execPath,
+        },
+        process.cwd(),
+      ),
     ).toEqual({
       available: true,
       summary: "enabled",

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -67,6 +67,15 @@ describe("config parsing", () => {
     await mkdir(process.env.PI_CODING_AGENT_DIR, { recursive: true });
 
     const config = createDefaultConfig();
+    config.providers!.claude = {
+      enabled: false,
+      pathToClaudeCodeExecutable: "/tmp/claude-code",
+      defaults: {
+        model: "claude-sonnet-4-5",
+        effort: "high",
+        maxTurns: 6,
+      },
+    };
     config.providers!.codex!.defaults!.additionalDirectories = ["docs"];
     config.providers!.exa = {
       enabled: true,
@@ -99,6 +108,12 @@ describe("config parsing", () => {
     await writeFile(getConfigPath(), serializeConfig(config), "utf-8");
 
     const loaded = await loadConfig();
+    expect(loaded.providers?.claude?.pathToClaudeCodeExecutable).toBe(
+      "/tmp/claude-code",
+    );
+    expect(loaded.providers?.claude?.defaults?.model).toBe("claude-sonnet-4-5");
+    expect(loaded.providers?.claude?.defaults?.effort).toBe("high");
+    expect(loaded.providers?.claude?.defaults?.maxTurns).toBe(6);
     expect(loaded.providers?.codex?.defaults?.webSearchMode).toBe("cached");
     expect(loaded.providers?.codex?.defaults?.additionalDirectories).toEqual([
       "notes",

--- a/test/gemini-provider.test.ts
+++ b/test/gemini-provider.test.ts
@@ -80,7 +80,7 @@ describe("GeminiProvider search", () => {
                   title: "Tenzir",
                   url: "https://vertexaisearch.cloud.google.com/grounding-api-redirect/opaque",
                   rendered_content:
-                    '<style>.x{display:none}</style><div>Tenzir &amp; Security</div><svg><text>noise</text></svg><p>Flexible operations</p>',
+                    "<style>.x{display:none}</style><div>Tenzir &amp; Security</div><svg><text>noise</text></svg><p>Flexible operations</p>",
                 },
               ],
             },
@@ -247,7 +247,9 @@ describe("GeminiProvider answer", () => {
     expect(response.text).toContain(
       "Tenzir helps route and transform security telemetry.",
     );
-    expect(response.text).toContain("Sources:\n1. Tenzir overview\n2. Tenzir docs");
+    expect(response.text).toContain(
+      "Sources:\n1. Tenzir overview\n2. Tenzir docs",
+    );
     expect(response.text).toContain("   https://tenzir.com/docs");
     expect(response.text).not.toContain("vertexaisearch.cloud.google.com");
     expect(response.summary).toBe("Answer via Gemini with 2 source(s)");
@@ -303,8 +305,12 @@ describe("GeminiProvider research", () => {
       expect(response.text).toBe("Research result");
       expect(messages).toContain("Starting Gemini deep research");
       expect(messages).toContain("Gemini research started: research-1");
-      expect(messages).toContain("Gemini research status: in_progress (0s elapsed)");
-      expect(messages).toContain("Gemini research status: completed (20s elapsed)");
+      expect(messages).toContain(
+        "Gemini research status: in_progress (0s elapsed)",
+      );
+      expect(messages).toContain(
+        "Gemini research status: completed (20s elapsed)",
+      );
     } finally {
       vi.useRealTimers();
     }

--- a/test/provider-resolution.test.ts
+++ b/test/provider-resolution.test.ts
@@ -54,6 +54,21 @@ describe("provider resolution", () => {
     expect(provider.id).toBe("exa");
   });
 
+  it("rejects Claude when it is explicitly enabled without local auth", () => {
+    const config: WebProvidersConfig = {
+      version: 1,
+      providers: {
+        claude: {
+          enabled: true,
+        },
+      },
+    };
+
+    expect(() =>
+      resolveProviderChoice(config, "claude", process.cwd()),
+    ).toThrow(/Provider 'claude' is not available: missing Claude auth/);
+  });
+
   it("prefers explicitly enabled providers in alphabetical order", () => {
     process.env.EXA_API_KEY = "test-key";
     process.env.GOOGLE_API_KEY = "test-key";

--- a/test/provider-resolution.test.ts
+++ b/test/provider-resolution.test.ts
@@ -1,11 +1,28 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { execFileSyncMock } = vi.hoisted(() => ({
+  execFileSyncMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", async () => {
+  const actual =
+    await vi.importActual<typeof import("node:child_process")>(
+      "node:child_process",
+    );
+  return {
+    ...actual,
+    execFileSync: execFileSyncMock,
+  };
+});
+
 import {
   resolveProviderChoice,
   resolveProviderForCapability,
 } from "../src/provider-resolution.js";
+import { resetClaudeProviderCachesForTests } from "../src/providers/claude.js";
 import type { WebProvidersConfig } from "../src/types.js";
 
 const originalHome = process.env.HOME;
@@ -23,6 +40,8 @@ afterEach(() => {
   delete process.env.GOOGLE_API_KEY;
   delete process.env.PARALLEL_API_KEY;
   delete process.env.VALYU_API_KEY;
+  execFileSyncMock.mockReset();
+  resetClaudeProviderCachesForTests();
   if (originalHome === undefined) {
     delete process.env.HOME;
   } else {
@@ -115,6 +134,33 @@ describe("provider resolution", () => {
     expect(provider.id).toBe("codex");
   });
 
+  it("falls back to implicit Claude search when Codex auth is missing", () => {
+    mockClaudeAvailable();
+
+    const provider = resolveProviderChoice({ version: 1 }, undefined, process.cwd());
+    expect(provider.id).toBe("claude");
+  });
+
+  it("prefers implicit Codex search over implicit Claude when both are available", () => {
+    process.env.CODEX_API_KEY = "test-key";
+    mockClaudeAvailable();
+
+    const provider = resolveProviderChoice({ version: 1 }, undefined, process.cwd());
+    expect(provider.id).toBe("codex");
+  });
+
+  it("falls back to implicit Claude answers when no provider is explicitly enabled", () => {
+    mockClaudeAvailable();
+
+    const provider = resolveProviderForCapability(
+      { version: 1 },
+      undefined,
+      process.cwd(),
+      "answer",
+    );
+    expect(provider.id).toBe("claude");
+  });
+
   it("allows explicit Codex search without a config file entry", () => {
     process.env.CODEX_API_KEY = "test-key";
 
@@ -145,6 +191,14 @@ describe("provider resolution", () => {
   });
 
   it("rejects Codex fallback when the CLI has no configured auth", () => {
+    expect(() =>
+      resolveProviderChoice({ version: 1 }, undefined, process.cwd()),
+    ).toThrow(/No provider is configured for 'search'/);
+  });
+
+  it("rejects implicit Claude fallback when Claude cannot execute queries", () => {
+    mockClaudeWithoutQueryAccess();
+
     expect(() =>
       resolveProviderChoice({ version: 1 }, undefined, process.cwd()),
     ).toThrow(/No provider is configured for 'search'/);
@@ -191,3 +245,29 @@ describe("provider resolution", () => {
     expect(provider.id).toBe("parallel");
   });
 });
+
+function mockClaudeAvailable(): void {
+  execFileSyncMock.mockImplementation((_command, args: string[]) => {
+    if (args.includes("auth") && args.includes("status")) {
+      return '{"loggedIn":true,"authMethod":"claude.ai"}';
+    }
+    if (args.includes("-p")) {
+      return '{"result":"OK"}';
+    }
+    throw new Error(`Unexpected Claude command: ${args.join(" ")}`);
+  });
+}
+
+function mockClaudeWithoutQueryAccess(): void {
+  execFileSyncMock.mockImplementation((_command, args: string[]) => {
+    if (args.includes("auth") && args.includes("status")) {
+      return '{"loggedIn":true,"authMethod":"claude.ai"}';
+    }
+    if (args.includes("-p")) {
+      throw Object.assign(new Error("authentication_failed"), {
+        stderr: "authentication_failed: Your organization does not have access to Claude",
+      });
+    }
+    throw new Error(`Unexpected Claude command: ${args.join(" ")}`);
+  });
+}

--- a/test/provider-resolution.test.ts
+++ b/test/provider-resolution.test.ts
@@ -134,33 +134,6 @@ describe("provider resolution", () => {
     expect(provider.id).toBe("codex");
   });
 
-  it("falls back to implicit Claude search when Codex auth is missing", () => {
-    mockClaudeAvailable();
-
-    const provider = resolveProviderChoice({ version: 1 }, undefined, process.cwd());
-    expect(provider.id).toBe("claude");
-  });
-
-  it("prefers implicit Codex search over implicit Claude when both are available", () => {
-    process.env.CODEX_API_KEY = "test-key";
-    mockClaudeAvailable();
-
-    const provider = resolveProviderChoice({ version: 1 }, undefined, process.cwd());
-    expect(provider.id).toBe("codex");
-  });
-
-  it("falls back to implicit Claude answers when no provider is explicitly enabled", () => {
-    mockClaudeAvailable();
-
-    const provider = resolveProviderForCapability(
-      { version: 1 },
-      undefined,
-      process.cwd(),
-      "answer",
-    );
-    expect(provider.id).toBe("claude");
-  });
-
   it("allows explicit Codex search without a config file entry", () => {
     process.env.CODEX_API_KEY = "test-key";
 
@@ -196,7 +169,7 @@ describe("provider resolution", () => {
     ).toThrow(/No provider is configured for 'search'/);
   });
 
-  it("rejects implicit Claude fallback when Claude cannot execute queries", () => {
+  it("does not implicitly fall back to Claude when Codex auth is missing", () => {
     mockClaudeWithoutQueryAccess();
 
     expect(() =>
@@ -251,9 +224,6 @@ function mockClaudeAvailable(): void {
     if (args.includes("auth") && args.includes("status")) {
       return '{"loggedIn":true,"authMethod":"claude.ai"}';
     }
-    if (args.includes("-p")) {
-      return '{"result":"OK"}';
-    }
     throw new Error(`Unexpected Claude command: ${args.join(" ")}`);
   });
 }
@@ -262,11 +232,6 @@ function mockClaudeWithoutQueryAccess(): void {
   execFileSyncMock.mockImplementation((_command, args: string[]) => {
     if (args.includes("auth") && args.includes("status")) {
       return '{"loggedIn":true,"authMethod":"claude.ai"}';
-    }
-    if (args.includes("-p")) {
-      throw Object.assign(new Error("authentication_failed"), {
-        stderr: "authentication_failed: Your organization does not have access to Claude",
-      });
     }
     throw new Error(`Unexpected Claude command: ${args.join(" ")}`);
   });

--- a/test/tool-availability.test.ts
+++ b/test/tool-availability.test.ts
@@ -130,14 +130,14 @@ describe("managed tool availability", () => {
     ).toEqual(["web_search"]);
   });
 
-  it("keeps web_search and web_answer available via implicit Claude fallback", () => {
+  it("does not expose Claude-managed tools via implicit fallback", () => {
     mockClaudeAvailable();
 
     const config: WebProvidersConfig = { version: 1 };
 
     expect(
       __test__.getAvailableManagedToolNames(config, process.cwd()),
-    ).toEqual(["web_search", "web_answer"]);
+    ).toEqual([]);
   });
 
   it("hides managed tools when no provider is available", () => {
@@ -250,9 +250,6 @@ function mockClaudeAvailable(): void {
   execFileSyncMock.mockImplementation((_command, args: string[]) => {
     if (args.includes("auth") && args.includes("status")) {
       return '{"loggedIn":true,"authMethod":"claude.ai"}';
-    }
-    if (args.includes("-p")) {
-      return '{"result":"OK"}';
     }
     throw new Error(`Unexpected Claude command: ${args.join(" ")}`);
   });

--- a/test/tool-availability.test.ts
+++ b/test/tool-availability.test.ts
@@ -130,6 +130,24 @@ describe("managed tool availability", () => {
     ).toEqual([]);
   });
 
+  it("hides Claude-managed tools when Claude auth is missing", () => {
+    const config: WebProvidersConfig = {
+      version: 1,
+      providers: {
+        claude: {
+          enabled: true,
+        },
+        codex: {
+          enabled: false,
+        },
+      },
+    };
+
+    expect(
+      __test__.getAvailableManagedToolNames(config, process.cwd()),
+    ).toEqual([]);
+  });
+
   it("hides the implicit Codex fallback when Codex auth is missing", () => {
     const config: WebProvidersConfig = { version: 1 };
 

--- a/test/tool-availability.test.ts
+++ b/test/tool-availability.test.ts
@@ -2,8 +2,25 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { execFileSyncMock } = vi.hoisted(() => ({
+  execFileSyncMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", async () => {
+  const actual =
+    await vi.importActual<typeof import("node:child_process")>(
+      "node:child_process",
+    );
+  return {
+    ...actual,
+    execFileSync: execFileSyncMock,
+  };
+});
+
 import webProvidersExtension, { __test__ } from "../src/index.js";
+import { resetClaudeProviderCachesForTests } from "../src/providers/claude.js";
 import type { WebProvidersConfig } from "../src/types.js";
 
 const originalHome = process.env.HOME;
@@ -18,6 +35,8 @@ beforeEach(() => {
 afterEach(() => {
   delete process.env.EXA_API_KEY;
   delete process.env.CODEX_API_KEY;
+  execFileSyncMock.mockReset();
+  resetClaudeProviderCachesForTests();
   if (originalHome === undefined) {
     delete process.env.HOME;
   } else {
@@ -109,6 +128,16 @@ describe("managed tool availability", () => {
     expect(
       __test__.getAvailableManagedToolNames(config, process.cwd()),
     ).toEqual(["web_search"]);
+  });
+
+  it("keeps web_search and web_answer available via implicit Claude fallback", () => {
+    mockClaudeAvailable();
+
+    const config: WebProvidersConfig = { version: 1 };
+
+    expect(
+      __test__.getAvailableManagedToolNames(config, process.cwd()),
+    ).toEqual(["web_search", "web_answer"]);
   });
 
   it("hides managed tools when no provider is available", () => {
@@ -216,3 +245,15 @@ describe("managed tool availability", () => {
     expect(Array.from(activeTools)).toEqual(["web_search"]);
   });
 });
+
+function mockClaudeAvailable(): void {
+  execFileSyncMock.mockImplementation((_command, args: string[]) => {
+    if (args.includes("auth") && args.includes("status")) {
+      return '{"loggedIn":true,"authMethod":"claude.ai"}';
+    }
+    if (args.includes("-p")) {
+      return '{"result":"OK"}';
+    }
+    throw new Error(`Unexpected Claude command: ${args.join(" ")}`);
+  });
+}


### PR DESCRIPTION
## Summary
- add Claude as a configurable provider for `web_search` and `web_answer`
- expose Claude-specific configuration and documentation for local Claude Code usage
- make Claude-backed tool calls stateless and avoid repeated auth probes during provider refreshes

## Testing
- npm run check
- npm test
