### PR TITLE
Add Perplexity provider and search options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ tool prompt aligned with the tools that the agent can actually call.
 
 - **Provider-driven tool surface** — tools are injected based on what the active
   provider actually supports, not a fixed list
-- **Six providers**: Claude, Codex, Exa, Gemini, Parallel, Valyu — each with
+- **Multiple providers**: Claude, Codex, Exa, Gemini, Perplexity, Parallel,
+  Valyu — each with
   its own SDK, strengths, and capability set
 - **One config command** (`/web-providers`) with a TUI that adapts to the
   selected provider
@@ -75,7 +76,8 @@ Find likely sources on the public web and return titles, URLs, and snippets.
 | ------------ | ------- | -------- | ----------------------------------------------------------------------------- |
 | `query`      | string  | required | What to search for                                                            |
 | `maxResults` | integer | `5`      | Result count, clamped to `1–20`                                               |
-| `provider`   | string  | auto     | Optional override: `claude`, `codex`, `exa`, `gemini`, `parallel`, or `valyu` |
+| `options`    | object  | —        | Provider-specific search options                                              |
+| `provider`   | string  | auto     | Optional override: `claude`, `codex`, `exa`, `gemini`, `perplexity`, `parallel`, or `valyu` |
 
 ### `web_contents`
 
@@ -118,6 +120,7 @@ summarises which capabilities each provider exposes:
 | **Codex**    |   ✓    |          |        |          | Local Codex CLI auth   |
 | **Exa**      |   ✓    |    ✓     |   ✓    |    ✓     | `EXA_API_KEY`          |
 | **Gemini**   |   ✓    |    ✓     |   ✓    |    ✓     | `GOOGLE_API_KEY`       |
+| **Perplexity** | ✓    |          |   ✓    |    ✓     | `PERPLEXITY_API_KEY`   |
 | **Parallel** |   ✓    |    ✓     |        |          | `PARALLEL_API_KEY`     |
 | **Valyu**    |   ✓    |    ✓     |   ✓    |    ✓     | `VALYU_API_KEY`        |
 
@@ -145,6 +148,14 @@ summarises which capabilities each provider exposes:
 - SDK: `@google/genai`
 - Google Search grounding for answers and URL Context extraction for page contents
 - Deep-research agents via Google's Gemini API
+
+### Perplexity
+
+- SDK: `@perplexity-ai/perplexity_ai`
+- Uses Perplexity Search for `web_search`
+- Uses Sonar for `web_answer` and `sonar-deep-research` for `web_research`
+- Supports provider-specific `web_search.options` such as `country`,
+  `search_mode`, `search_domain_filter`, and `search_recency_filter`
 
 ### Parallel
 
@@ -231,6 +242,26 @@ Example:
         "contentsModel": "gemini-2.5-flash",
         "answerModel": "gemini-2.5-flash",
         "researchAgent": "deep-research-pro-preview-12-2025"
+      }
+    },
+    "perplexity": {
+      "enabled": false,
+      "tools": {
+        "search": true,
+        "answer": true,
+        "research": true
+      },
+      "apiKey": "PERPLEXITY_API_KEY",
+      "defaults": {
+        "search": {
+          "country": "US"
+        },
+        "answer": {
+          "model": "sonar"
+        },
+        "research": {
+          "model": "sonar-deep-research"
+        }
       }
     },
     "parallel": {

--- a/changelog/unreleased/perplexity-provider-for-grounded-web-workflows.md
+++ b/changelog/unreleased/perplexity-provider-for-grounded-web-workflows.md
@@ -1,0 +1,13 @@
+---
+title: Perplexity provider for grounded web workflows
+type: feature
+authors:
+  - mavam
+  - codex
+pr: 2
+created: 2026-03-10T08:28:16.118911Z
+---
+
+`pi-web-providers` now supports Perplexity as a provider for `web_search`, `web_answer`, and `web_research`. You can enable it from `/web-providers`, authenticate it with `PERPLEXITY_API_KEY`, and use Perplexity-specific defaults such as Sonar for grounded answers and `sonar-deep-research` for longer investigations.
+
+This matters if you want a provider that combines direct search results with grounded model responses without switching to a separate extension.

--- a/changelog/unreleased/provider-specific-search-options-for-web-search.md
+++ b/changelog/unreleased/provider-specific-search-options-for-web-search.md
@@ -1,0 +1,13 @@
+---
+title: Provider-specific search options for web_search
+type: feature
+authors:
+  - mavam
+  - codex
+pr: 2
+created: 2026-03-10T08:28:16.86975Z
+---
+
+`web_search` now accepts a provider-specific `options` object, so providers can expose richer search controls without forcing every feature into the generic top-level tool shape. For example, Perplexity-backed searches can now pass values such as `country`, `search_mode`, `search_domain_filter`, and `search_recency_filter` through the same managed tool.
+
+This keeps `pi-web-providers` flexible as more providers are added, while preserving a stable shared interface for search queries and result limits.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@anthropic-ai/claude-agent-sdk": "^0.2.71",
         "@google/genai": "^1.44.0",
         "@openai/codex-sdk": "^0.111.0",
+        "@perplexity-ai/perplexity_ai": "^0.26.1",
         "exa-js": "^2.7.0",
         "parallel-web": "^0.3.1",
         "valyu-js": "^2.5.9",
@@ -2283,6 +2284,12 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/@perplexity-ai/perplexity_ai": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/@perplexity-ai/perplexity_ai/-/perplexity_ai-0.26.1.tgz",
+      "integrity": "sha512-hl4skz3TCK/wECEZ0DFVboUD5MZOD7xssRB7276mCTRK61x2kzPuIOVaRjtmDjCAeTfcJ0UnAqAi6MbaHAr+ng==",
+      "license": "Apache-2.0"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-web-providers",
   "version": "0.2.0",
-  "description": "Configurable web access extension for pi that routes search, contents, answers, and research across Claude, Codex, Exa, Gemini, Parallel, and Valyu providers.",
+  "description": "Configurable web access extension for pi that routes search, contents, answers, and research across Claude, Codex, Exa, Gemini, Perplexity, Parallel, and Valyu providers.",
   "type": "module",
   "files": [
     "dist",
@@ -17,6 +17,7 @@
     "codex",
     "exa",
     "gemini",
+    "perplexity",
     "parallel",
     "valyu"
   ],
@@ -38,7 +39,7 @@
     ]
   },
   "scripts": {
-    "build": "rm -rf dist && esbuild src/index.ts --bundle --format=esm --platform=node --outfile=dist/index.js --external:@mariozechner/pi-coding-agent --external:@mariozechner/pi-ai --external:@mariozechner/pi-tui --external:@sinclair/typebox --external:@anthropic-ai/claude-agent-sdk --external:@google/genai --external:@openai/codex-sdk --external:exa-js --external:parallel-web --external:valyu-js",
+    "build": "rm -rf dist && esbuild src/index.ts --bundle --format=esm --platform=node --outfile=dist/index.js --external:@mariozechner/pi-coding-agent --external:@mariozechner/pi-ai --external:@mariozechner/pi-tui --external:@sinclair/typebox --external:@anthropic-ai/claude-agent-sdk --external:@google/genai --external:@openai/codex-sdk --external:@perplexity-ai/perplexity_ai --external:exa-js --external:parallel-web --external:valyu-js",
     "prepare": "npm run build",
     "prepack": "npm run build",
     "check": "tsc --noEmit",
@@ -51,6 +52,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.2.71",
     "@google/genai": "^1.44.0",
     "@openai/codex-sdk": "^0.111.0",
+    "@perplexity-ai/perplexity_ai": "^0.26.1",
     "exa-js": "^2.7.0",
     "parallel-web": "^0.3.1",
     "valyu-js": "^2.5.9",

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,7 @@ import type {
   ExaProviderConfig,
   GeminiProviderConfig,
   JsonObject,
+  PerplexityProviderConfig,
   ParallelProviderConfig,
   ProviderId,
   ValyuProviderConfig,
@@ -93,6 +94,23 @@ export function createDefaultConfig(): WebProvidersConfig {
           contentsModel: "gemini-2.5-flash",
           answerModel: "gemini-2.5-flash",
           researchAgent: "deep-research-pro-preview-12-2025",
+        },
+      },
+      perplexity: {
+        enabled: false,
+        tools: {
+          search: true,
+          answer: true,
+          research: true,
+        },
+        apiKey: "PERPLEXITY_API_KEY",
+        defaults: {
+          answer: {
+            model: "sonar",
+          },
+          research: {
+            model: "sonar-deep-research",
+          },
         },
       },
       parallel: {
@@ -180,6 +198,7 @@ export function parseProviderConfig(
   | CodexProviderConfig
   | ExaProviderConfig
   | GeminiProviderConfig
+  | PerplexityProviderConfig
   | ParallelProviderConfig
   | ValyuProviderConfig {
   let raw: unknown;
@@ -311,6 +330,12 @@ function normalizeConfig(raw: unknown, source: string): WebProvidersConfig {
         source,
       );
     }
+    if (raw.providers.perplexity !== undefined) {
+      config.providers.perplexity = normalizePerplexityProvider(
+        raw.providers.perplexity,
+        source,
+      );
+    }
     if (raw.providers.parallel !== undefined) {
       config.providers.parallel = normalizeParallelProvider(
         raw.providers.parallel,
@@ -330,6 +355,7 @@ function normalizeConfig(raw: unknown, source: string): WebProvidersConfig {
         key !== "codex" &&
         key !== "exa" &&
         key !== "gemini" &&
+        key !== "perplexity" &&
         key !== "parallel" &&
         key !== "valyu",
     );
@@ -601,6 +627,62 @@ function normalizeGeminiProvider(
               defaults.researchAgent,
               source,
               "providers.gemini.defaults.researchAgent",
+            ),
+          },
+  };
+}
+
+function normalizePerplexityProvider(
+  raw: unknown,
+  source: string,
+): PerplexityProviderConfig {
+  const provider = parseProviderObject(raw, source, "perplexity");
+  const defaults = parseOptionalJsonObject(
+    provider.defaults,
+    source,
+    "providers.perplexity.defaults",
+  );
+
+  return {
+    enabled: parseOptionalBoolean(
+      provider.enabled,
+      source,
+      "providers.perplexity.enabled",
+    ),
+    tools: parseOptionalProviderTools(
+      "perplexity",
+      provider.tools,
+      source,
+      "providers.perplexity.tools",
+    ) as PerplexityProviderConfig["tools"],
+    apiKey: parseOptionalString(
+      provider.apiKey,
+      source,
+      "providers.perplexity.apiKey",
+    ),
+    baseUrl: parseOptionalString(
+      provider.baseUrl,
+      source,
+      "providers.perplexity.baseUrl",
+    ),
+    defaults:
+      defaults === undefined
+        ? undefined
+        : {
+            search: parseOptionalJsonObject(
+              defaults.search,
+              source,
+              "providers.perplexity.defaults.search",
+            ),
+            answer: parseOptionalJsonObject(
+              defaults.answer,
+              source,
+              "providers.perplexity.defaults.answer",
+            ),
+            research: parseOptionalJsonObject(
+              defaults.research,
+              source,
+              "providers.perplexity.defaults.research",
             ),
           },
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ import type {
   ExaProviderConfig,
   GeminiProviderConfig,
   JsonObject,
+  PerplexityProviderConfig,
   ParallelProviderConfig,
   ProviderId,
   ProviderToolDetails,
@@ -139,6 +140,7 @@ function registerWebSearchTool(
           description: `Maximum number of results to return (default: ${DEFAULT_MAX_RESULTS})`,
         }),
       ),
+      options: jsonOptionsSchema("Provider-specific search options."),
       provider: providerEnum(
         visibleProviderIds,
         "Provider override. If omitted, uses the active configured provider or falls back to Codex for search when it is not explicitly disabled.",
@@ -158,6 +160,7 @@ function registerWebSearchTool(
       const response = await provider.search!(
         params.query,
         maxResults,
+        normalizeOptions(params.options),
         providerConfig as never,
         {
           cwd: ctx.cwd,
@@ -979,6 +982,10 @@ function buildProviderMenuOptions(
       "Research agent",
       "Agent used for Gemini deep research runs.",
     );
+    return options;
+  }
+
+  if (providerId === "perplexity") {
     return options;
   }
 

--- a/src/provider-tools.ts
+++ b/src/provider-tools.ts
@@ -3,6 +3,7 @@ import type {
   CodexProviderConfig,
   ExaProviderConfig,
   GeminiProviderConfig,
+  PerplexityProviderConfig,
   ParallelProviderConfig,
   ProviderId,
   ValyuProviderConfig,
@@ -22,6 +23,7 @@ export const PROVIDER_TOOLS: Record<ProviderId, readonly ProviderToolId[]> = {
   codex: ["search"],
   exa: ["search", "contents", "answer", "research"],
   gemini: ["search", "contents", "answer", "research"],
+  perplexity: ["search", "answer", "research"],
   parallel: ["search", "contents"],
   valyu: ["search", "contents", "answer", "research"],
 };
@@ -53,6 +55,7 @@ export type ProviderConfigUnion =
   | CodexProviderConfig
   | ExaProviderConfig
   | GeminiProviderConfig
+  | PerplexityProviderConfig
   | ParallelProviderConfig
   | ValyuProviderConfig;
 

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -117,6 +117,7 @@ export class ClaudeProvider implements WebProvider<ClaudeProviderConfig> {
   async search(
     queryText: string,
     maxResults: number,
+    _options: Record<string, unknown> | undefined,
     config: ClaudeProviderConfig,
     context: ProviderContext,
   ): Promise<SearchResponse> {

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -90,6 +90,7 @@ export class CodexProvider implements WebProvider<CodexProviderConfig> {
   async search(
     query: string,
     maxResults: number,
+    _options: Record<string, unknown> | undefined,
     config: CodexProviderConfig,
     context: ProviderContext,
   ): Promise<SearchResponse> {

--- a/src/providers/exa.ts
+++ b/src/providers/exa.ts
@@ -51,6 +51,7 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
   async search(
     query: string,
     maxResults: number,
+    searchOptions: Record<string, unknown> | undefined,
     config: ExaProviderConfig,
     context: ProviderContext,
   ): Promise<SearchResponse> {
@@ -62,6 +63,7 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
     const client = new Exa(apiKey, config.baseUrl);
     const options = {
       ...asJsonObject(config.defaults),
+      ...(searchOptions ?? {}),
       numResults: maxResults,
     };
 

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -57,6 +57,7 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
   async search(
     query: string,
     maxResults: number,
+    _options: Record<string, unknown> | undefined,
     config: GeminiProviderConfig,
     context: ProviderContext,
   ): Promise<SearchResponse> {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -3,6 +3,7 @@ import type {
   CodexProviderConfig,
   ExaProviderConfig,
   GeminiProviderConfig,
+  PerplexityProviderConfig,
   ParallelProviderConfig,
   ProviderId,
   ValyuProviderConfig,
@@ -12,6 +13,7 @@ import { ClaudeProvider } from "./claude.js";
 import { CodexProvider } from "./codex.js";
 import { ExaProvider } from "./exa.js";
 import { GeminiProvider } from "./gemini.js";
+import { PerplexityProvider } from "./perplexity.js";
 import { ParallelProvider } from "./parallel.js";
 import { ValyuProvider } from "./valyu.js";
 
@@ -21,6 +23,7 @@ export const PROVIDERS: ReadonlyArray<
     | CodexProviderConfig
     | ExaProviderConfig
     | GeminiProviderConfig
+    | PerplexityProviderConfig
     | ParallelProviderConfig
     | ValyuProviderConfig
   >
@@ -29,6 +32,7 @@ export const PROVIDERS: ReadonlyArray<
   new CodexProvider(),
   new ExaProvider(),
   new GeminiProvider(),
+  new PerplexityProvider(),
   new ParallelProvider(),
   new ValyuProvider(),
 ];
@@ -40,6 +44,7 @@ export const PROVIDER_MAP: Record<
     | CodexProviderConfig
     | ExaProviderConfig
     | GeminiProviderConfig
+    | PerplexityProviderConfig
     | ParallelProviderConfig
     | ValyuProviderConfig
   >
@@ -48,6 +53,7 @@ export const PROVIDER_MAP: Record<
   codex: PROVIDERS[1],
   exa: PROVIDERS[2],
   gemini: PROVIDERS[3],
-  parallel: PROVIDERS[4],
-  valyu: PROVIDERS[5],
+  perplexity: PROVIDERS[4],
+  parallel: PROVIDERS[5],
+  valyu: PROVIDERS[6],
 };

--- a/src/providers/parallel.ts
+++ b/src/providers/parallel.ts
@@ -52,6 +52,7 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
   async search(
     query: string,
     maxResults: number,
+    options: Record<string, unknown> | undefined,
     config: ParallelProviderConfig,
     context: ProviderContext,
   ): Promise<SearchResponse> {
@@ -61,6 +62,7 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
     context.onProgress?.(`Searching Parallel for: ${query}`);
     const response = await client.beta.search({
       ...defaults,
+      ...(options ?? {}),
       objective: query,
       max_results: maxResults,
     });

--- a/src/providers/perplexity.ts
+++ b/src/providers/perplexity.ts
@@ -160,17 +160,7 @@ export class PerplexityProvider
       buildRequestOptions(context),
     );
     const content = extractMessageText(response.choices[0]?.message?.content);
-    const sources = dedupeSources(
-      response.search_results?.map((result) => ({
-        title: result.title,
-        url: result.url,
-      })) ??
-        response.citations?.map((citation) => ({
-          title: citation,
-          url: citation,
-        })) ??
-        [],
-    );
+    const sources = dedupeSources(extractSources(response));
 
     const lines: string[] = [];
     lines.push(content || `No ${label.toLowerCase()} returned.`);
@@ -265,6 +255,32 @@ function dedupeSources(
   }
 
   return unique;
+}
+
+function extractSources(response: {
+  search_results?: Array<{ title?: string | null; url?: string | null }> | null;
+  citations?: Array<string | null> | null;
+}): Array<{ title: string; url: string }> {
+  const searchResults =
+    response.search_results?.flatMap((result) => {
+      const url = result.url?.trim() ?? "";
+      if (!url) {
+        return [];
+      }
+      return [{ title: result.title?.trim() ?? url, url }];
+    }) ?? [];
+
+  if (searchResults.length > 0) {
+    return searchResults;
+  }
+
+  return (
+    response.citations?.flatMap((citation) => {
+      const url = citation?.trim() ?? "";
+      return url ? [{ title: url, url }] : [];
+    }) ??
+    []
+  );
 }
 
 function buildRequestOptions(

--- a/src/providers/perplexity.ts
+++ b/src/providers/perplexity.ts
@@ -1,0 +1,274 @@
+import Perplexity from "@perplexity-ai/perplexity_ai";
+import { resolveConfigValue } from "../config.js";
+import type {
+  PerplexityProviderConfig,
+  ProviderContext,
+  ProviderStatus,
+  ProviderToolOutput,
+  SearchResponse,
+  WebProvider,
+} from "../types.js";
+import { asJsonObject, trimSnippet } from "./shared.js";
+
+const DEFAULT_ANSWER_MODEL = "sonar";
+const DEFAULT_RESEARCH_MODEL = "sonar-deep-research";
+
+export class PerplexityProvider
+  implements WebProvider<PerplexityProviderConfig>
+{
+  readonly id = "perplexity";
+  readonly label = "Perplexity";
+  readonly docsUrl = "https://docs.perplexity.ai/docs/sdk/overview.md";
+
+  createTemplate(): PerplexityProviderConfig {
+    return {
+      enabled: false,
+      tools: {
+        search: true,
+        answer: true,
+        research: true,
+      },
+      apiKey: "PERPLEXITY_API_KEY",
+      defaults: {
+        answer: {
+          model: DEFAULT_ANSWER_MODEL,
+        },
+        research: {
+          model: DEFAULT_RESEARCH_MODEL,
+        },
+      },
+    };
+  }
+
+  getStatus(config: PerplexityProviderConfig | undefined): ProviderStatus {
+    if (!config) {
+      return { available: false, summary: "not configured" };
+    }
+    if (config.enabled === false) {
+      return { available: false, summary: "disabled" };
+    }
+    const apiKey = resolveConfigValue(config.apiKey);
+    if (!apiKey) {
+      return { available: false, summary: "missing apiKey" };
+    }
+    return { available: true, summary: "enabled" };
+  }
+
+  async search(
+    query: string,
+    maxResults: number,
+    options: Record<string, unknown> | undefined,
+    config: PerplexityProviderConfig,
+    context: ProviderContext,
+  ): Promise<SearchResponse> {
+    const client = this.createClient(config);
+    const request = {
+      ...asJsonObject(config.defaults?.search),
+      ...(options ?? {}),
+      query,
+      max_results: maxResults,
+    };
+
+    context.onProgress?.(`Searching Perplexity for: ${query}`);
+    const response = await client.search.create(
+      request as never,
+      buildRequestOptions(context),
+    );
+
+    return {
+      provider: this.id,
+      results: response.results.slice(0, maxResults).map((result) => ({
+        title: result.title,
+        url: result.url,
+        snippet: trimSnippet(result.snippet),
+        metadata:
+          result.date || result.last_updated
+            ? {
+                ...(result.date ? { date: result.date } : {}),
+                ...(result.last_updated
+                  ? { last_updated: result.last_updated }
+                  : {}),
+              }
+            : undefined,
+      })),
+    };
+  }
+
+  async answer(
+    query: string,
+    options: Record<string, unknown> | undefined,
+    config: PerplexityProviderConfig,
+    context: ProviderContext,
+  ): Promise<ProviderToolOutput> {
+    context.onProgress?.(`Getting Perplexity answer for: ${query}`);
+    return this.runChatTool(
+      query,
+      options,
+      config,
+      context,
+      DEFAULT_ANSWER_MODEL,
+      "Answer",
+    );
+  }
+
+  async research(
+    input: string,
+    options: Record<string, unknown> | undefined,
+    config: PerplexityProviderConfig,
+    context: ProviderContext,
+  ): Promise<ProviderToolOutput> {
+    context.onProgress?.("Starting Perplexity research");
+    return this.runChatTool(
+      input,
+      options,
+      config,
+      context,
+      DEFAULT_RESEARCH_MODEL,
+      "Research",
+      true,
+    );
+  }
+
+  private async runChatTool(
+    input: string,
+    options: Record<string, unknown> | undefined,
+    config: PerplexityProviderConfig,
+    context: ProviderContext,
+    fallbackModel: string,
+    label: "Answer" | "Research",
+    isResearch = false,
+  ): Promise<ProviderToolOutput> {
+    const client = this.createClient(config);
+    const defaults = isResearch
+      ? config.defaults?.research
+      : config.defaults?.answer;
+    const request = {
+      ...asJsonObject(defaults),
+      ...(options ?? {}),
+      messages: [{ role: "user", content: input }],
+      model:
+        resolveModel(
+          (options ?? {}).model,
+          asJsonObject(defaults).model,
+          fallbackModel,
+        ) ?? fallbackModel,
+      stream: false,
+    };
+
+    const response = await client.chat.completions.create(
+      request as never,
+      buildRequestOptions(context),
+    );
+    const content = extractMessageText(response.choices[0]?.message?.content);
+    const sources = dedupeSources(
+      response.search_results?.map((result) => ({
+        title: result.title,
+        url: result.url,
+      })) ??
+        response.citations?.map((citation) => ({
+          title: citation,
+          url: citation,
+        })) ??
+        [],
+    );
+
+    const lines: string[] = [];
+    lines.push(content || `No ${label.toLowerCase()} returned.`);
+
+    if (sources.length > 0) {
+      lines.push("");
+      lines.push("Sources:");
+      for (const [index, source] of sources.entries()) {
+        lines.push(`${index + 1}. ${source.title}`);
+        lines.push(`   ${source.url}`);
+      }
+    }
+
+    return {
+      provider: this.id,
+      text: lines.join("\n").trimEnd(),
+      summary: `${label} via Perplexity with ${sources.length} source(s)`,
+      itemCount: sources.length,
+    };
+  }
+
+  private createClient(config: PerplexityProviderConfig): Perplexity {
+    const apiKey = resolveConfigValue(config.apiKey);
+    if (!apiKey) {
+      throw new Error("Perplexity is missing an API key.");
+    }
+
+    return new Perplexity({
+      apiKey,
+      baseURL: resolveConfigValue(config.baseUrl),
+    });
+  }
+}
+
+function resolveModel(
+  optionModel: unknown,
+  defaultModel: unknown,
+  fallbackModel: string,
+): string {
+  if (typeof optionModel === "string" && optionModel.trim().length > 0) {
+    return optionModel;
+  }
+  if (typeof defaultModel === "string" && defaultModel.trim().length > 0) {
+    return defaultModel;
+  }
+  return fallbackModel;
+}
+
+function extractMessageText(content: unknown): string {
+  if (typeof content === "string") {
+    return content.trim();
+  }
+
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  return content
+    .flatMap((chunk) => {
+      if (
+        typeof chunk === "object" &&
+        chunk !== null &&
+        "type" in chunk &&
+        chunk.type === "text" &&
+        "text" in chunk &&
+        typeof chunk.text === "string"
+      ) {
+        return [chunk.text.trim()];
+      }
+      return [];
+    })
+    .filter((text) => text.length > 0)
+    .join("\n\n")
+    .trim();
+}
+
+function dedupeSources(
+  sources: Array<{ title: string; url: string }>,
+): Array<{ title: string; url: string }> {
+  const seen = new Set<string>();
+  const unique: Array<{ title: string; url: string }> = [];
+
+  for (const source of sources) {
+    const title = source.title.trim() || source.url.trim() || "Untitled";
+    const url = source.url.trim();
+    if (!url) continue;
+
+    const key = `${title.toLowerCase()}::${url.toLowerCase()}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push({ title, url });
+  }
+
+  return unique;
+}
+
+function buildRequestOptions(
+  context: ProviderContext,
+): { signal: AbortSignal } | undefined {
+  return context.signal ? { signal: context.signal } : undefined;
+}

--- a/src/providers/valyu.ts
+++ b/src/providers/valyu.ts
@@ -49,6 +49,7 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
   async search(
     query: string,
     maxResults: number,
+    searchOptions: Record<string, unknown> | undefined,
     config: ValyuProviderConfig,
     context: ProviderContext,
   ): Promise<SearchResponse> {
@@ -60,6 +61,7 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
     const client = new Valyu(apiKey, config.baseUrl);
     const options = {
       ...asJsonObject(config.defaults),
+      ...(searchOptions ?? {}),
       maxNumResults: maxResults,
     };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export const PROVIDER_IDS = [
   "codex",
   "exa",
   "gemini",
+  "perplexity",
   "parallel",
   "valyu",
 ] as const;
@@ -120,6 +121,22 @@ export interface GeminiProviderConfig {
   };
 }
 
+export interface PerplexityProviderConfig {
+  enabled?: boolean;
+  tools?: {
+    search?: boolean;
+    answer?: boolean;
+    research?: boolean;
+  };
+  apiKey?: string;
+  baseUrl?: string;
+  defaults?: {
+    search?: JsonObject;
+    answer?: JsonObject;
+    research?: JsonObject;
+  };
+}
+
 export interface ParallelProviderConfig {
   enabled?: boolean;
   tools?: {
@@ -154,6 +171,7 @@ export interface WebProvidersConfig {
     codex?: CodexProviderConfig;
     exa?: ExaProviderConfig;
     gemini?: GeminiProviderConfig;
+    perplexity?: PerplexityProviderConfig;
     parallel?: ParallelProviderConfig;
     valyu?: ValyuProviderConfig;
   };
@@ -180,6 +198,7 @@ export interface WebProvider<TConfig> {
   search?(
     query: string,
     maxResults: number,
+    options: JsonObject | undefined,
     config: TConfig,
     context: ProviderContext,
   ): Promise<SearchResponse>;

--- a/test/claude-provider.test.ts
+++ b/test/claude-provider.test.ts
@@ -117,6 +117,7 @@ describe("ClaudeProvider", () => {
     await provider.search(
       "latest Claude docs",
       1,
+      undefined,
       { enabled: true },
       {
         cwd: process.cwd(),
@@ -163,6 +164,7 @@ describe("ClaudeProvider", () => {
     const searchPromise = provider.search(
       "latest Claude docs",
       1,
+      undefined,
       { enabled: true },
       {
         cwd: process.cwd(),

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -24,6 +24,7 @@ afterEach(async () => {
   delete process.env.PI_CODING_AGENT_DIR;
   delete process.env.GOOGLE_API_KEY;
   delete process.env.PARALLEL_API_KEY;
+  delete process.env.PERPLEXITY_API_KEY;
 });
 
 describe("config parsing", () => {
@@ -102,6 +103,21 @@ describe("config parsing", () => {
         contentsModel: "gemini-2.5-pro",
       },
     };
+    config.providers!.perplexity = {
+      enabled: true,
+      apiKey: "PERPLEXITY_API_KEY",
+      defaults: {
+        search: {
+          country: "US",
+        },
+        answer: {
+          model: "sonar",
+        },
+        research: {
+          model: "sonar-deep-research",
+        },
+      },
+    };
 
     config.providers!.codex!.defaults!.webSearchMode = "cached";
     config.providers!.codex!.defaults!.additionalDirectories = ["notes"];
@@ -123,6 +139,10 @@ describe("config parsing", () => {
     expect(loaded.providers?.gemini?.defaults?.apiVersion).toBe("v1alpha");
     expect(loaded.providers?.gemini?.defaults?.contentsModel).toBe(
       "gemini-2.5-pro",
+    );
+    expect(loaded.providers?.perplexity?.defaults?.search?.country).toBe("US");
+    expect(loaded.providers?.perplexity?.defaults?.research?.model).toBe(
+      "sonar-deep-research",
     );
     expect(loaded.providers?.parallel?.defaults?.search?.mode).toBe("one-shot");
   });

--- a/test/gemini-provider.test.ts
+++ b/test/gemini-provider.test.ts
@@ -33,6 +33,7 @@ describe("GeminiProvider search", () => {
     const response = await provider.search(
       "example query",
       5,
+      undefined,
       createConfig(),
       createContext(),
     );
@@ -92,6 +93,7 @@ describe("GeminiProvider search", () => {
     const response = await provider.search(
       "tenzir",
       5,
+      undefined,
       createConfig(),
       createContext(),
     );
@@ -132,6 +134,7 @@ describe("GeminiProvider search", () => {
     const response = await provider.search(
       "fallback query",
       5,
+      undefined,
       createConfig(),
       createContext(),
     );
@@ -187,6 +190,7 @@ describe("GeminiProvider search", () => {
     const response = await provider.search(
       "example query",
       1,
+      undefined,
       createConfig(),
       createContext(),
     );

--- a/test/perplexity-provider.test.ts
+++ b/test/perplexity-provider.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { searchCreateMock, chatCreateMock, perplexityCtorMock } = vi.hoisted(
+  () => ({
+    searchCreateMock: vi.fn(),
+    chatCreateMock: vi.fn(),
+    perplexityCtorMock: vi.fn(),
+  }),
+);
+
+vi.mock("@perplexity-ai/perplexity_ai", () => ({
+  default: perplexityCtorMock.mockImplementation(function MockPerplexity() {
+    return {
+      search: {
+        create: searchCreateMock,
+      },
+      chat: {
+        completions: {
+          create: chatCreateMock,
+        },
+      },
+    };
+  }),
+}));
+
+import { PerplexityProvider } from "../src/providers/perplexity.js";
+
+afterEach(() => {
+  delete process.env.PERPLEXITY_API_KEY;
+  searchCreateMock.mockReset();
+  chatCreateMock.mockReset();
+  perplexityCtorMock.mockClear();
+});
+
+describe("PerplexityProvider", () => {
+  it("forwards merged search options and preserves date metadata", async () => {
+    process.env.PERPLEXITY_API_KEY = "test-key";
+    searchCreateMock.mockResolvedValue({
+      results: [
+        {
+          title: "Energy policy",
+          url: "https://example.com/policy",
+          snippet: "Recent policy changes",
+          date: "2026-03-01",
+          last_updated: "2026-03-05",
+        },
+      ],
+    });
+
+    const provider = new PerplexityProvider();
+    const response = await provider.search(
+      "government policies on renewable energy",
+      5,
+      {
+        country: "US",
+        max_results: 99,
+      },
+      {
+        enabled: true,
+        apiKey: "PERPLEXITY_API_KEY",
+        defaults: {
+          search: {
+            search_mode: "academic",
+          },
+        },
+      },
+      { cwd: process.cwd() },
+    );
+
+    expect(perplexityCtorMock).toHaveBeenCalledWith({
+      apiKey: "test-key",
+      baseURL: undefined,
+    });
+    expect(searchCreateMock).toHaveBeenCalledWith(
+      {
+        search_mode: "academic",
+        country: "US",
+        query: "government policies on renewable energy",
+        max_results: 5,
+      },
+      undefined,
+    );
+    expect(response.results).toEqual([
+      {
+        title: "Energy policy",
+        url: "https://example.com/policy",
+        snippet: "Recent policy changes",
+        metadata: {
+          date: "2026-03-01",
+          last_updated: "2026-03-05",
+        },
+      },
+    ]);
+  });
+
+  it("defaults answer calls to sonar and dedupes repeated sources", async () => {
+    process.env.PERPLEXITY_API_KEY = "test-key";
+    chatCreateMock.mockResolvedValue({
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: "Perplexity answer",
+          },
+        },
+      ],
+      search_results: [
+        {
+          title: "Source A",
+          url: "https://example.com/a",
+        },
+        {
+          title: "Source A",
+          url: "https://example.com/a",
+        },
+      ],
+    });
+
+    const provider = new PerplexityProvider();
+    const response = await provider.answer(
+      "What changed?",
+      { country: "US" },
+      {
+        enabled: true,
+        apiKey: "PERPLEXITY_API_KEY",
+      },
+      { cwd: process.cwd() },
+    );
+
+    expect(chatCreateMock).toHaveBeenCalledWith(
+      {
+        country: "US",
+        messages: [{ role: "user", content: "What changed?" }],
+        model: "sonar",
+        stream: false,
+      },
+      undefined,
+    );
+    expect(response.text).toBe(
+      "Perplexity answer\n\nSources:\n1. Source A\n   https://example.com/a",
+    );
+    expect(response.summary).toBe("Answer via Perplexity with 1 source(s)");
+    expect(response.itemCount).toBe(1);
+  });
+
+  it("defaults research calls to sonar-deep-research", async () => {
+    process.env.PERPLEXITY_API_KEY = "test-key";
+    chatCreateMock.mockResolvedValue({
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "Research result" }],
+          },
+        },
+      ],
+      citations: ["https://example.com/research"],
+    });
+
+    const provider = new PerplexityProvider();
+    const response = await provider.research(
+      "Investigate the topic",
+      undefined,
+      {
+        enabled: true,
+        apiKey: "PERPLEXITY_API_KEY",
+      },
+      { cwd: process.cwd() },
+    );
+
+    expect(chatCreateMock).toHaveBeenCalledWith(
+      {
+        messages: [{ role: "user", content: "Investigate the topic" }],
+        model: "sonar-deep-research",
+        stream: false,
+      },
+      undefined,
+    );
+    expect(response.text).toBe(
+      "Research result\n\nSources:\n1. https://example.com/research\n   https://example.com/research",
+    );
+    expect(response.summary).toBe("Research via Perplexity with 1 source(s)");
+  });
+});

--- a/test/perplexity-provider.test.ts
+++ b/test/perplexity-provider.test.ts
@@ -181,4 +181,37 @@ describe("PerplexityProvider", () => {
     );
     expect(response.summary).toBe("Research via Perplexity with 1 source(s)");
   });
+
+  it("falls back to citations when search_results is empty", async () => {
+    process.env.PERPLEXITY_API_KEY = "test-key";
+    chatCreateMock.mockResolvedValue({
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: "Answer with citations fallback",
+          },
+        },
+      ],
+      search_results: [],
+      citations: ["https://example.com/fallback"],
+    });
+
+    const provider = new PerplexityProvider();
+    const response = await provider.answer(
+      "What changed?",
+      undefined,
+      {
+        enabled: true,
+        apiKey: "PERPLEXITY_API_KEY",
+      },
+      { cwd: process.cwd() },
+    );
+
+    expect(response.text).toBe(
+      "Answer with citations fallback\n\nSources:\n1. https://example.com/fallback\n   https://example.com/fallback",
+    );
+    expect(response.summary).toBe("Answer via Perplexity with 1 source(s)");
+    expect(response.itemCount).toBe(1);
+  });
 });

--- a/test/provider-resolution.test.ts
+++ b/test/provider-resolution.test.ts
@@ -38,6 +38,7 @@ afterEach(() => {
   delete process.env.CODEX_API_KEY;
   delete process.env.EXA_API_KEY;
   delete process.env.GOOGLE_API_KEY;
+  delete process.env.PERPLEXITY_API_KEY;
   delete process.env.PARALLEL_API_KEY;
   delete process.env.VALYU_API_KEY;
   execFileSyncMock.mockReset();

--- a/test/tool-availability.test.ts
+++ b/test/tool-availability.test.ts
@@ -35,6 +35,7 @@ beforeEach(() => {
 afterEach(() => {
   delete process.env.EXA_API_KEY;
   delete process.env.CODEX_API_KEY;
+  delete process.env.PERPLEXITY_API_KEY;
   execFileSyncMock.mockReset();
   resetClaudeProviderCachesForTests();
   if (originalHome === undefined) {
@@ -52,7 +53,11 @@ afterEach(() => {
 
 describe("managed tool availability", () => {
   it("keeps tool descriptions concise and capability-specific", () => {
-    const tools: Array<{ name: string; description: string }> = [];
+    const tools: Array<{
+      name: string;
+      description: string;
+      parameters?: { properties?: Record<string, unknown> };
+    }> = [];
 
     webProvidersExtension({
       registerTool(tool: { name: string; description: string }) {
@@ -75,6 +80,7 @@ describe("managed tool availability", () => {
       "Find likely sources on the public web",
     );
     expect(webSearch?.description).toContain("titles, URLs, and snippets");
+    expect(webSearch?.parameters?.properties).toHaveProperty("options");
     expect(webContents?.description).toBe(
       "Read and extract the main contents of one or more web pages.",
     );
@@ -235,6 +241,28 @@ describe("managed tool availability", () => {
     );
 
     expect(Array.from(activeTools)).toEqual(["web_search"]);
+  });
+
+  it("surfaces Perplexity overrides when Perplexity is available", () => {
+    process.env.PERPLEXITY_API_KEY = "test-key";
+
+    const config: WebProvidersConfig = {
+      version: 1,
+      providers: {
+        perplexity: {
+          enabled: true,
+          apiKey: "PERPLEXITY_API_KEY",
+        },
+      },
+    };
+
+    expect(
+      __test__.getAvailableProviderIdsForCapability(
+        config,
+        process.cwd(),
+        "answer",
+      ),
+    ).toEqual(["perplexity"]);
   });
 });
 


### PR DESCRIPTION
## Summary
- add Perplexity as a configurable provider for `web_search`, `web_answer`, and `web_research`
- extend `web_search` with provider-specific `options`
- document and test the new provider and tool contract

## Verification
- npm run check
- npm test
- npm run format:check