### PR TITLE
Broaden provider runtime options support

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Investigate a topic across web sources and produce a longer report.
 | `options`  | object | —        | Provider-specific research options                      |
 | `provider` | string | auto     | Optional override among providers that support research |
 
+`options` are provider-native and provider-specific. Equivalent concepts can
+use different field names across SDKs, for example Perplexity uses `country`,
+Exa uses `userLocation`, and Valyu uses `countryCode`. Runtime `options`
+override provider defaults, but managed tool inputs and tool wiring stay fixed.
+
 ## 🔌 Providers
 
 Every provider is a thin adapter around an official SDK. The table below
@@ -129,12 +134,16 @@ summarises which capabilities each provider exposes:
 - SDK: `@anthropic-ai/claude-agent-sdk`
 - Uses Claude Code's built-in `WebSearch` and `WebFetch` tools behind a
   structured JSON adapter
+- Supports request-shaping `options` such as `model`, `thinking`, `effort`, and
+  `maxTurns`
 - Great for search plus grounded answers if you already use Claude Code locally
 
 ### Codex
 
 - SDK: `@openai/codex-sdk`
 - Runs in read-only mode with web search enabled
+- Supports request-shaping `web_search.options` such as `model`,
+  `modelReasoningEffort`, and `webSearchMode`
 - Best if you already use the local Codex CLI and auth flow
 
 ### Exa
@@ -148,6 +157,8 @@ summarises which capabilities each provider exposes:
 - SDK: `@google/genai`
 - Google Search grounding for answers and URL Context extraction for page contents
 - Deep-research agents via Google's Gemini API
+- Supports provider-native request options such as `model`, `config`,
+  `generation_config`, and `agent_config` depending on the tool
 
 ### Perplexity
 
@@ -162,11 +173,14 @@ summarises which capabilities each provider exposes:
 - SDK: `parallel-web`
 - Agentic and one-shot search modes
 - Page content extraction with excerpt and full-content toggles
+- Supports provider-native search and extraction options from the Parallel SDK
 
 ### Valyu
 
 - SDK: `valyu-js`
 - Web, proprietary, and news search types
+- Supports provider-native options such as `countryCode`, `responseLength`, and
+  search/source filters
 - Configurable response length for answers and research
 
 ## 📝 Config Notes

--- a/changelog/unreleased/broaden-runtime-options-to-claude-codex-and-gemini.md
+++ b/changelog/unreleased/broaden-runtime-options-to-claude-codex-and-gemini.md
@@ -12,9 +12,9 @@ each request without changing the shared tool interface.
 
 Claude supports `model`, `effort`, `maxTurns`, `maxThinkingTokens`,
 `maxBudgetUsd`, and a `thinking` object. Codex supports `model`,
-`modelReasoningEffort`, and `webSearchMode`. Gemini supports `model`, `config`,
-`labels`, and `metadata` (merged into `config.labels`) for search, answer, and
-contents tools; research passes all caller-supplied options through to the
+`modelReasoningEffort`, and `webSearchMode`. Gemini supports provider-native
+options: `model` plus `generation_config` for search, `model` plus `config` for
+answer and contents, and caller-supplied research options passed through to the
 underlying API.
 
 Runtime options override provider defaults from the config, but managed tool

--- a/changelog/unreleased/broaden-runtime-options-to-claude-codex-and-gemini.md
+++ b/changelog/unreleased/broaden-runtime-options-to-claude-codex-and-gemini.md
@@ -1,0 +1,21 @@
+---
+title: Broaden runtime options to Claude, Codex, and Gemini
+type: feature
+authors:
+  - mavam
+created: 2026-03-10T16:47:00.000000Z
+---
+
+The `options` object that tools accept at call time is now forwarded to the
+Claude, Codex, and Gemini providers, giving callers fine-grained control over
+each request without changing the shared tool interface.
+
+Claude supports `model`, `effort`, `maxTurns`, `maxThinkingTokens`,
+`maxBudgetUsd`, and a `thinking` object. Codex supports `model`,
+`modelReasoningEffort`, and `webSearchMode`. Gemini supports `model`, `config`,
+`labels`, and `metadata` (merged into `config.labels`) for search, answer, and
+contents tools; research passes all caller-supplied options through to the
+underlying API.
+
+Runtime options override provider defaults from the config, but managed tool
+inputs and tool wiring stay fixed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-web-providers",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-web-providers",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.71",

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -117,7 +117,7 @@ export class ClaudeProvider implements WebProvider<ClaudeProviderConfig> {
   async search(
     queryText: string,
     maxResults: number,
-    _options: Record<string, unknown> | undefined,
+    options: Record<string, unknown> | undefined,
     config: ClaudeProviderConfig,
     context: ProviderContext,
   ): Promise<SearchResponse> {
@@ -138,6 +138,7 @@ export class ClaudeProvider implements WebProvider<ClaudeProviderConfig> {
         tools: ["WebSearch"],
         config,
         context,
+        options,
       }),
     );
 
@@ -168,14 +169,12 @@ export class ClaudeProvider implements WebProvider<ClaudeProviderConfig> {
           "Only cite sources you actually used.",
           "",
           `User query: ${queryText}`,
-          options ? `Additional options: ${JSON.stringify(options)}` : "",
-        ]
-          .filter(Boolean)
-          .join("\n"),
+        ].join("\n"),
         schema: ANSWER_OUTPUT_SCHEMA,
         tools: ["WebSearch", "WebFetch"],
         config,
         context,
+        options,
       }),
     );
 
@@ -205,12 +204,14 @@ export class ClaudeProvider implements WebProvider<ClaudeProviderConfig> {
     tools,
     config,
     context,
+    options,
   }: {
     prompt: string;
     schema: Record<string, unknown>;
     tools: string[];
     config: ClaudeProviderConfig;
     context: ProviderContext;
+    options: Record<string, unknown> | undefined;
   }): Promise<T> {
     const abortController = new AbortController();
     if (context.signal?.aborted) {
@@ -227,9 +228,7 @@ export class ClaudeProvider implements WebProvider<ClaudeProviderConfig> {
         abortController,
         allowedTools: tools,
         cwd: context.cwd,
-        effort: config.defaults?.effort,
-        maxTurns: config.defaults?.maxTurns,
-        model: config.defaults?.model,
+        ...getClaudeRuntimeOptions(config, options),
         outputFormat: {
           type: "json_schema",
           schema,
@@ -431,6 +430,70 @@ function parseStructuredOutput<T>(result: SDKResultMessage): T {
     }
     return JSON.parse(match[0]) as T;
   }
+}
+
+function getClaudeRuntimeOptions(
+  config: ClaudeProviderConfig,
+  options: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  const model = readNonEmptyString(options?.model) ?? config.defaults?.model;
+  const effort = readEnum(options?.effort, ["low", "medium", "high", "max"]);
+  const maxTurns = readPositiveInteger(options?.maxTurns);
+  const maxThinkingTokens = readNonNegativeInteger(options?.maxThinkingTokens);
+  const maxBudgetUsd = readPositiveNumber(options?.maxBudgetUsd);
+  const thinking = isPlainObject(options?.thinking)
+    ? options?.thinking
+    : undefined;
+
+  return {
+    ...(model ? { model } : {}),
+    ...((effort ?? config.defaults?.effort)
+      ? { effort: effort ?? config.defaults?.effort }
+      : {}),
+    ...((maxTurns ?? config.defaults?.maxTurns)
+      ? { maxTurns: maxTurns ?? config.defaults?.maxTurns }
+      : {}),
+    ...(maxThinkingTokens !== undefined ? { maxThinkingTokens } : {}),
+    ...(maxBudgetUsd !== undefined ? { maxBudgetUsd } : {}),
+    ...(thinking ? { thinking } : {}),
+  };
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
+}
+
+function readPositiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value > 0
+    ? value
+    : undefined;
+}
+
+function readNonNegativeInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+function readPositiveNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : undefined;
+}
+
+function readEnum<const TValue extends string>(
+  value: unknown,
+  values: readonly TValue[],
+): TValue | undefined {
+  return typeof value === "string" && values.includes(value as TValue)
+    ? (value as TValue)
+    : undefined;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function parseClaudeSearchOutput(value: unknown): ClaudeSearchOutput {

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -90,7 +90,7 @@ export class CodexProvider implements WebProvider<CodexProviderConfig> {
   async search(
     query: string,
     maxResults: number,
-    _options: Record<string, unknown> | undefined,
+    options: Record<string, unknown> | undefined,
     config: CodexProviderConfig,
     context: ProviderContext,
   ): Promise<SearchResponse> {
@@ -102,18 +102,9 @@ export class CodexProvider implements WebProvider<CodexProviderConfig> {
       env: resolveEnvMap(config.env),
     });
 
-    const thread = codex.startThread({
-      additionalDirectories: config.defaults?.additionalDirectories,
-      approvalPolicy: "never",
-      model: config.defaults?.model,
-      modelReasoningEffort: config.defaults?.modelReasoningEffort,
-      networkAccessEnabled: config.defaults?.networkAccessEnabled ?? true,
-      sandboxMode: "read-only",
-      skipGitRepoCheck: true,
-      webSearchEnabled: config.defaults?.webSearchEnabled ?? true,
-      webSearchMode: config.defaults?.webSearchMode ?? "live",
-      workingDirectory: context.cwd,
-    });
+    const thread = codex.startThread(
+      buildCodexSearchThreadOptions(config, context.cwd, options),
+    );
 
     const prompt = [
       "You are performing web research for another coding agent.",
@@ -158,6 +149,77 @@ export class CodexProvider implements WebProvider<CodexProviderConfig> {
       })),
     };
   }
+}
+
+function buildCodexSearchThreadOptions(
+  config: CodexProviderConfig,
+  cwd: string,
+  options: Record<string, unknown> | undefined,
+) {
+  const runtimeOptions = getCodexSearchRuntimeOptions(options);
+
+  return {
+    additionalDirectories: config.defaults?.additionalDirectories,
+    approvalPolicy: "never" as const,
+    model: runtimeOptions.model ?? config.defaults?.model,
+    modelReasoningEffort:
+      runtimeOptions.modelReasoningEffort ??
+      config.defaults?.modelReasoningEffort,
+    networkAccessEnabled: config.defaults?.networkAccessEnabled ?? true,
+    sandboxMode: "read-only" as const,
+    skipGitRepoCheck: true,
+    webSearchEnabled: config.defaults?.webSearchEnabled ?? true,
+    webSearchMode:
+      runtimeOptions.webSearchMode ?? config.defaults?.webSearchMode ?? "live",
+    workingDirectory: cwd,
+  };
+}
+
+function getCodexSearchRuntimeOptions(
+  options: Record<string, unknown> | undefined,
+): {
+  model?: string;
+  modelReasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh";
+  webSearchMode?: "disabled" | "cached" | "live";
+} {
+  if (!options) {
+    return {};
+  }
+
+  const model = readNonEmptyString(options.model);
+  const modelReasoningEffort = readEnum(options.modelReasoningEffort, [
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+  ]);
+  const webSearchMode = readEnum(options.webSearchMode, [
+    "disabled",
+    "cached",
+    "live",
+  ]);
+
+  return {
+    ...(model ? { model } : {}),
+    ...(modelReasoningEffort ? { modelReasoningEffort } : {}),
+    ...(webSearchMode ? { webSearchMode } : {}),
+  };
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
+}
+
+function readEnum<const TValue extends string>(
+  value: unknown,
+  values: readonly TValue[],
+): TValue | undefined {
+  return typeof value === "string" && values.includes(value as TValue)
+    ? (value as TValue)
+    : undefined;
 }
 
 function hasCodexCredentials(config: CodexProviderConfig): boolean {

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -97,7 +97,6 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
     context: ProviderContext,
   ): Promise<ProviderToolOutput> {
     const ai = this.createClient(config);
-    const model = config.defaults?.contentsModel ?? DEFAULT_CONTENTS_MODEL;
 
     context.onProgress?.(
       `Fetching contents from Gemini for ${urls.length} URL(s)`,
@@ -656,31 +655,12 @@ function buildGeminiGenerateContentRequest({
   const explicitConfig = isPlainObject(requestOptions.config)
     ? requestOptions.config
     : {};
-  const legacyLabels = readStringRecord(requestOptions.labels);
-  const explicitLabels = readStringRecord(explicitConfig.labels);
-  const metadataLabels = readStringRecord(requestOptions.metadata);
-  const legacyConfig = Object.fromEntries(
-    Object.entries(requestOptions).filter(
-      ([key]) =>
-        key !== "config" &&
-        key !== "contents" &&
-        key !== "metadata" &&
-        key !== "model",
-    ),
-  );
-  const labels = mergeStringRecords(
-    legacyLabels,
-    metadataLabels,
-    explicitLabels,
-  );
 
   return {
     model: readNonEmptyString(requestOptions.model) ?? defaultModel,
     contents: prompt,
     config: {
-      ...legacyConfig,
       ...explicitConfig,
-      ...(labels ? { labels } : {}),
       tools: [toolConfig],
     },
   };
@@ -715,23 +695,4 @@ function readNonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0
     ? value
     : undefined;
-}
-
-function readStringRecord(value: unknown): Record<string, string> | undefined {
-  if (!isPlainObject(value)) {
-    return undefined;
-  }
-
-  const entries = Object.entries(value).filter(
-    (entry): entry is [string, string] => typeof entry[1] === "string",
-  );
-
-  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
-}
-
-function mergeStringRecords(
-  ...records: Array<Record<string, string> | undefined>
-): Record<string, string> | undefined {
-  const merged = Object.assign({}, ...records.filter(Boolean));
-  return Object.keys(merged).length > 0 ? merged : undefined;
 }

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -57,15 +57,19 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
   async search(
     query: string,
     maxResults: number,
-    _options: Record<string, unknown> | undefined,
+    options: Record<string, unknown> | undefined,
     config: GeminiProviderConfig,
     context: ProviderContext,
   ): Promise<SearchResponse> {
     const ai = this.createClient(config);
-    const model = config.defaults?.searchModel ?? DEFAULT_SEARCH_MODEL;
+    const request = buildGeminiSearchRequest(
+      query,
+      config.defaults?.searchModel ?? DEFAULT_SEARCH_MODEL,
+      options,
+    );
 
     context.onProgress?.(`Searching Gemini for: ${query}`);
-    const interaction = await createSearchInteraction(ai, model, query);
+    const interaction = await createSearchInteraction(ai, request);
 
     const results = await Promise.all(
       extractGoogleSearchResults(interaction.outputs)
@@ -100,18 +104,20 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
     );
 
     const urlList = urls.map((url) => `- ${url}`).join("\n");
-    const response = await ai.models.generateContent({
-      model,
-      contents: [
+    const request = buildGeminiGenerateContentRequest({
+      defaultModel: config.defaults?.contentsModel ?? DEFAULT_CONTENTS_MODEL,
+      prompt:
         `Extract the main textual content from each of the following URLs. ` +
-          `For each URL, return the page title followed by the cleaned body text. ` +
-          `Preserve the original structure (headings, paragraphs, lists) but remove ` +
-          `navigation, ads, and boilerplate.\n\n${urlList}`,
-      ],
-      config: {
-        ...(options ?? {}),
-        tools: [{ urlContext: {} }],
-      },
+        `For each URL, return the page title followed by the cleaned body text. ` +
+        `Preserve the original structure (headings, paragraphs, lists) but remove ` +
+        `navigation, ads, and boilerplate.\n\n${urlList}`,
+      options,
+      toolConfig: { urlContext: {} },
+    });
+    const response = await ai.models.generateContent({
+      model: request.model,
+      contents: [request.contents],
+      config: request.config,
     });
 
     const text = response.text?.trim() || "";
@@ -158,16 +164,18 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
     context: ProviderContext,
   ): Promise<ProviderToolOutput> {
     const ai = this.createClient(config);
-    const model = config.defaults?.answerModel ?? DEFAULT_ANSWER_MODEL;
+    const request = buildGeminiGenerateContentRequest({
+      defaultModel: config.defaults?.answerModel ?? DEFAULT_ANSWER_MODEL,
+      prompt: query,
+      options,
+      toolConfig: { googleSearch: {} },
+    });
 
     context.onProgress?.(`Getting Gemini answer for: ${query}`);
     const response = await ai.models.generateContent({
-      model,
-      contents: query,
-      config: {
-        ...(options ?? {}),
-        tools: [{ googleSearch: {} }],
-      },
+      model: request.model,
+      contents: request.contents,
+      config: request.config,
     });
 
     const lines: string[] = [];
@@ -204,7 +212,9 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
     const ai = this.createClient(config);
     const agent = config.defaults?.researchAgent ?? DEFAULT_RESEARCH_AGENT;
     const pollIntervalMs = getPollInterval(options);
-    const requestOptions = stripPollIntervalOption(options);
+    const requestOptions = getGeminiResearchRequestOptions(
+      stripPollIntervalOption(options),
+    );
     const startedAt = Date.now();
     let lastStatus: string | undefined;
 
@@ -469,28 +479,43 @@ function isGoogleGroundingRedirect(url: string): boolean {
 
 async function createSearchInteraction(
   ai: GoogleGenAI,
-  model: string,
-  query: string,
+  request: {
+    model: string;
+    input: string;
+    tools: Array<{ type: "google_search" }>;
+    generation_config?: Record<string, unknown>;
+  },
 ) {
-  const request = {
-    model,
-    input: query,
-    tools: [{ type: "google_search" as const }],
+  const forcedRequest = {
+    ...request,
+    ...(request.generation_config
+      ? {
+          generation_config: {
+            ...request.generation_config,
+            tool_choice: "any" as const,
+          },
+        }
+      : {
+          generation_config: {
+            tool_choice: "any" as const,
+          },
+        }),
   };
 
   try {
-    return await ai.interactions.create({
-      ...request,
-      generation_config: {
-        tool_choice: "any",
-      },
-    });
+    return await ai.interactions.create(forcedRequest);
   } catch (error) {
     if (!isBuiltInToolChoiceError(error)) {
       throw error;
     }
 
-    return ai.interactions.create(request);
+    const fallbackGenerationConfig = stripToolChoice(request.generation_config);
+    return ai.interactions.create({
+      ...request,
+      ...(fallbackGenerationConfig
+        ? { generation_config: fallbackGenerationConfig }
+        : {}),
+    });
   }
 }
 
@@ -590,4 +615,123 @@ function stripPollIntervalOption(
 
   const { pollIntervalMs: _ignored, ...rest } = options;
   return rest;
+}
+
+function buildGeminiSearchRequest(
+  query: string,
+  defaultModel: string,
+  options: Record<string, unknown> | undefined,
+): {
+  model: string;
+  input: string;
+  tools: Array<{ type: "google_search" }>;
+  generation_config?: Record<string, unknown>;
+} {
+  return {
+    model: readNonEmptyString(options?.model) ?? defaultModel,
+    input: query,
+    tools: [{ type: "google_search" }],
+    ...(isPlainObject(options?.generation_config)
+      ? { generation_config: options.generation_config }
+      : {}),
+  };
+}
+
+function buildGeminiGenerateContentRequest({
+  defaultModel,
+  prompt,
+  options,
+  toolConfig,
+}: {
+  defaultModel: string;
+  prompt: string;
+  options: Record<string, unknown> | undefined;
+  toolConfig: { urlContext: {} } | { googleSearch: {} };
+}): {
+  model: string;
+  contents: string;
+  config: Record<string, unknown>;
+} {
+  const requestOptions = isPlainObject(options) ? options : {};
+  const explicitConfig = isPlainObject(requestOptions.config)
+    ? requestOptions.config
+    : {};
+  const legacyLabels = readStringRecord(requestOptions.labels);
+  const explicitLabels = readStringRecord(explicitConfig.labels);
+  const metadataLabels = readStringRecord(requestOptions.metadata);
+  const legacyConfig = Object.fromEntries(
+    Object.entries(requestOptions).filter(
+      ([key]) =>
+        key !== "config" &&
+        key !== "contents" &&
+        key !== "metadata" &&
+        key !== "model",
+    ),
+  );
+  const labels = mergeStringRecords(
+    legacyLabels,
+    metadataLabels,
+    explicitLabels,
+  );
+
+  return {
+    model: readNonEmptyString(requestOptions.model) ?? defaultModel,
+    contents: prompt,
+    config: {
+      ...legacyConfig,
+      ...explicitConfig,
+      ...(labels ? { labels } : {}),
+      tools: [toolConfig],
+    },
+  };
+}
+
+function getGeminiResearchRequestOptions(
+  options: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (!isPlainObject(options)) {
+    return {};
+  }
+
+  return { ...options };
+}
+
+function stripToolChoice(
+  generationConfig: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!generationConfig || !Object.hasOwn(generationConfig, "tool_choice")) {
+    return generationConfig;
+  }
+
+  const { tool_choice: _ignored, ...rest } = generationConfig;
+  return Object.keys(rest).length > 0 ? rest : undefined;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
+}
+
+function readStringRecord(value: unknown): Record<string, string> | undefined {
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+
+  const entries = Object.entries(value).filter(
+    (entry): entry is [string, string] => typeof entry[1] === "string",
+  );
+
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function mergeStringRecords(
+  ...records: Array<Record<string, string> | undefined>
+): Record<string, string> | undefined {
+  const merged = Object.assign({}, ...records.filter(Boolean));
+  return Object.keys(merged).length > 0 ? merged : undefined;
 }

--- a/src/providers/perplexity.ts
+++ b/src/providers/perplexity.ts
@@ -278,8 +278,7 @@ function extractSources(response: {
     response.citations?.flatMap((citation) => {
       const url = citation?.trim() ?? "";
       return url ? [{ title: url, url }] : [];
-    }) ??
-    []
+    }) ?? []
   );
 }
 

--- a/test/claude-provider.test.ts
+++ b/test/claude-provider.test.ts
@@ -186,6 +186,109 @@ describe("ClaudeProvider", () => {
       }),
     );
   });
+
+  it("forwards only allowed runtime options for Claude search", async () => {
+    queryMock.mockImplementation(() =>
+      createQueryResult({
+        sources: [
+          {
+            title: "Claude docs",
+            url: "https://docs.anthropic.com",
+            snippet: "Official docs",
+          },
+        ],
+      }),
+    );
+
+    const provider = new ClaudeProvider();
+    await provider.search(
+      "latest Claude docs",
+      1,
+      {
+        model: "claude-opus-4-6",
+        thinking: { type: "adaptive" },
+        effort: "max",
+        maxThinkingTokens: 1234,
+        maxTurns: 7,
+        maxBudgetUsd: 3.5,
+        cwd: "/tmp/override",
+        permissionMode: "default",
+        plugins: [{ type: "local", path: "/tmp/plugin" }],
+      },
+      {
+        enabled: true,
+        defaults: {
+          model: "claude-sonnet-4-6",
+          effort: "medium",
+          maxTurns: 3,
+        },
+      },
+      {
+        cwd: process.cwd(),
+      },
+    );
+
+    const [searchCall] = queryMock.mock.calls;
+    expect(searchCall[0].prompt).toContain("User query: latest Claude docs");
+    expect(searchCall[0].options).toMatchObject({
+      model: "claude-opus-4-6",
+      thinking: { type: "adaptive" },
+      effort: "max",
+      maxThinkingTokens: 1234,
+      maxTurns: 7,
+      maxBudgetUsd: 3.5,
+      allowedTools: ["WebSearch"],
+      cwd: process.cwd(),
+      permissionMode: "dontAsk",
+      persistSession: false,
+      tools: ["WebSearch"],
+    });
+    expect(searchCall[0].options).not.toHaveProperty("plugins");
+  });
+
+  it("uses real Claude SDK options for answer calls instead of prompt text", async () => {
+    queryMock.mockImplementation(() =>
+      createQueryResult({
+        answer: "Claude answer",
+        sources: [
+          {
+            title: "Claude docs",
+            url: "https://docs.anthropic.com",
+          },
+        ],
+      }),
+    );
+
+    const provider = new ClaudeProvider();
+    const response = await provider.answer(
+      "What changed?",
+      {
+        model: "claude-opus-4-6",
+        maxTurns: 5,
+        allowedTools: ["Bash"],
+      },
+      {
+        enabled: true,
+        defaults: {
+          model: "claude-sonnet-4-6",
+          maxTurns: 2,
+        },
+      },
+      {
+        cwd: process.cwd(),
+      },
+    );
+
+    const [answerCall] = queryMock.mock.calls;
+    expect(answerCall[0].prompt).not.toContain("Additional options:");
+    expect(answerCall[0].options).toMatchObject({
+      model: "claude-opus-4-6",
+      maxTurns: 5,
+      allowedTools: ["WebSearch", "WebFetch"],
+      tools: ["WebSearch", "WebFetch"],
+    });
+    expect(response.text).toContain("Claude answer");
+  });
 });
 
 function mockLoggedOutClaudeStatus(): never {
@@ -199,4 +302,19 @@ function mockClaudeAvailable(_command: string, args: string[]): string {
     return '{"loggedIn":true,"authMethod":"claude.ai"}';
   }
   throw new Error(`Unexpected Claude command: ${args.join(" ")}`);
+}
+
+function createQueryResult(structuredOutput: unknown) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield {
+        type: "result",
+        subtype: "success",
+        result: "",
+        structured_output: structuredOutput,
+        errors: [],
+      };
+    },
+    close() {},
+  };
 }

--- a/test/codex-provider.test.ts
+++ b/test/codex-provider.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { codexCtorMock, startThreadMock, runStreamedMock } = vi.hoisted(() => ({
+  codexCtorMock: vi.fn(),
+  startThreadMock: vi.fn(),
+  runStreamedMock: vi.fn(),
+}));
+
+vi.mock("@openai/codex-sdk", () => ({
+  Codex: codexCtorMock.mockImplementation(function MockCodex() {
+    return {
+      startThread: startThreadMock,
+    };
+  }),
+}));
+
+import { CodexProvider } from "../src/providers/codex.js";
+
+afterEach(() => {
+  codexCtorMock.mockClear();
+  startThreadMock.mockReset();
+  runStreamedMock.mockReset();
+});
+
+describe("CodexProvider", () => {
+  it("forwards only user-facing search options and keeps managed thread settings fixed", async () => {
+    startThreadMock.mockReturnValue({
+      runStreamed: runStreamedMock.mockResolvedValue({
+        events: createEvents([
+          {
+            type: "item.completed",
+            item: {
+              type: "agent_message",
+              text: JSON.stringify({
+                sources: [
+                  {
+                    title: "Official docs",
+                    url: "https://example.com/docs",
+                    snippet: "Primary documentation",
+                  },
+                ],
+              }),
+            },
+          },
+        ]),
+      }),
+    });
+
+    const provider = new CodexProvider();
+    const response = await provider.search(
+      "latest docs",
+      5,
+      {
+        model: "gpt-5-codex",
+        modelReasoningEffort: "high",
+        webSearchMode: "cached",
+        sandboxMode: "danger-full-access",
+        workingDirectory: "/tmp/override",
+        skipGitRepoCheck: false,
+        approvalPolicy: "on-request",
+        networkAccessEnabled: false,
+        webSearchEnabled: false,
+        additionalDirectories: ["tmp"],
+      },
+      {
+        enabled: true,
+        apiKey: "literal-key",
+        defaults: {
+          model: "gpt-4.1",
+          modelReasoningEffort: "low",
+          webSearchMode: "live",
+          networkAccessEnabled: true,
+          webSearchEnabled: true,
+          additionalDirectories: ["docs"],
+        },
+      },
+      {
+        cwd: "/repo",
+      },
+    );
+
+    expect(startThreadMock).toHaveBeenCalledWith({
+      additionalDirectories: ["docs"],
+      approvalPolicy: "never",
+      model: "gpt-5-codex",
+      modelReasoningEffort: "high",
+      networkAccessEnabled: true,
+      sandboxMode: "read-only",
+      skipGitRepoCheck: true,
+      webSearchEnabled: true,
+      webSearchMode: "cached",
+      workingDirectory: "/repo",
+    });
+    expect(response.results).toEqual([
+      {
+        title: "Official docs",
+        url: "https://example.com/docs",
+        snippet: "Primary documentation",
+      },
+    ]);
+  });
+});
+
+function createEvents(events: unknown[]) {
+  return (async function* () {
+    for (const event of events) {
+      yield event;
+    }
+  })();
+}

--- a/test/gemini-provider.test.ts
+++ b/test/gemini-provider.test.ts
@@ -203,9 +203,93 @@ describe("GeminiProvider search", () => {
       },
     ]);
   });
+
+  it("forwards only model and generation_config for Gemini search", async () => {
+    const create = vi.fn().mockResolvedValue({
+      outputs: [
+        {
+          type: "google_search_result",
+          result: [
+            {
+              title: "Configured",
+              url: "https://example.com/configured",
+            },
+          ],
+        },
+      ],
+    });
+
+    const provider = createProvider({ interactions: { create } });
+    await provider.search(
+      "configured query",
+      5,
+      {
+        model: "gemini-2.5-pro",
+        generation_config: {
+          temperature: 0.1,
+          tool_choice: "none",
+        },
+        background: true,
+        store: true,
+      },
+      createConfig(),
+      createContext(),
+    );
+
+    expect(create).toHaveBeenCalledWith({
+      model: "gemini-2.5-pro",
+      input: "configured query",
+      tools: [{ type: "google_search" }],
+      generation_config: {
+        temperature: 0.1,
+        tool_choice: "any",
+      },
+    });
+  });
 });
 
 describe("GeminiProvider answer", () => {
+  it("supports request-level model overrides while keeping Google Search grounding enabled", async () => {
+    const generateContent = vi.fn().mockResolvedValue({
+      text: "Grounded answer",
+      candidates: [],
+    });
+
+    const provider = createProvider({ models: { generateContent } });
+    await provider.answer(
+      "What changed?",
+      {
+        model: "gemini-2.5-pro",
+        config: {
+          labels: {
+            route: "answer",
+          },
+          temperature: 0.1,
+          tools: [{ urlContext: {} }],
+        },
+        metadata: {
+          request_id: "answer-1",
+        },
+        contents: "override",
+      },
+      createConfig(),
+      createContext(),
+    );
+
+    expect(generateContent).toHaveBeenCalledWith({
+      model: "gemini-2.5-pro",
+      contents: "What changed?",
+      config: {
+        labels: {
+          request_id: "answer-1",
+          route: "answer",
+        },
+        temperature: 0.1,
+        tools: [{ googleSearch: {} }],
+      },
+    });
+  });
+
   it("suppresses opaque grounding redirect URLs and dedupes source display", async () => {
     const provider = createProvider({
       models: {
@@ -430,6 +514,42 @@ describe("GeminiProvider contents", () => {
     );
   });
 
+  it("supports request-level options for contents while preserving urlContext", async () => {
+    const generateContent = vi.fn().mockResolvedValue({
+      text: "Result.",
+      candidates: [],
+    });
+
+    const provider = createProvider({ models: { generateContent } });
+    await provider.contents(
+      ["https://example.com"],
+      {
+        model: "gemini-2.5-pro",
+        config: {
+          topK: 3,
+          tools: [{ googleSearch: {} }],
+        },
+        metadata: {
+          request_id: "contents-1",
+        },
+      },
+      createConfig(),
+      createContext(),
+    );
+
+    expect(generateContent).toHaveBeenCalledWith({
+      model: "gemini-2.5-pro",
+      contents: [expect.stringContaining("https://example.com")],
+      config: {
+        labels: {
+          request_id: "contents-1",
+        },
+        topK: 3,
+        tools: [{ urlContext: {} }],
+      },
+    });
+  });
+
   it("returns fallback text when response is empty", async () => {
     const generateContent = vi.fn().mockResolvedValue({
       text: "",
@@ -505,6 +625,59 @@ describe("GeminiProvider research", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("forwards Gemini research request options and strips pollIntervalMs", async () => {
+    const create = vi.fn().mockResolvedValue({ id: "research-1" });
+    const get = vi.fn().mockResolvedValue({
+      status: "completed",
+      outputs: [{ type: "text", text: "Research result" }],
+    });
+
+    const provider = createProvider({
+      interactions: {
+        create,
+        get,
+      },
+    });
+
+    await provider.research(
+      "Investigate Tenzir use cases",
+      {
+        agent_config: {
+          response_length: "short",
+        },
+        store: true,
+        response_format: {
+          type: "json_schema",
+        },
+        response_modalities: ["TEXT"],
+        system_instruction: "Focus on official sources.",
+        pollIntervalMs: 5000,
+        agent: "override-agent",
+        background: false,
+        input: "override",
+        tools: [{ urlContext: {} }],
+      },
+      createConfig(),
+      createContext(),
+    );
+
+    expect(create).toHaveBeenCalledWith({
+      agent_config: {
+        response_length: "short",
+      },
+      store: true,
+      response_format: {
+        type: "json_schema",
+      },
+      response_modalities: ["TEXT"],
+      system_instruction: "Focus on official sources.",
+      tools: [{ urlContext: {} }],
+      input: "Investigate Tenzir use cases",
+      agent: "deep-research-pro-preview-12-2025",
+      background: true,
+    });
   });
 });
 

--- a/test/gemini-provider.test.ts
+++ b/test/gemini-provider.test.ts
@@ -249,7 +249,7 @@ describe("GeminiProvider search", () => {
 });
 
 describe("GeminiProvider answer", () => {
-  it("supports request-level model overrides while keeping Google Search grounding enabled", async () => {
+  it("supports provider-native request options for answers while keeping Google Search grounding enabled", async () => {
     const generateContent = vi.fn().mockResolvedValue({
       text: "Grounded answer",
       candidates: [],
@@ -267,10 +267,6 @@ describe("GeminiProvider answer", () => {
           temperature: 0.1,
           tools: [{ urlContext: {} }],
         },
-        metadata: {
-          request_id: "answer-1",
-        },
-        contents: "override",
       },
       createConfig(),
       createContext(),
@@ -281,7 +277,6 @@ describe("GeminiProvider answer", () => {
       contents: "What changed?",
       config: {
         labels: {
-          request_id: "answer-1",
           route: "answer",
         },
         temperature: 0.1,
@@ -490,7 +485,7 @@ describe("GeminiProvider contents", () => {
     );
   });
 
-  it("passes extra options to generateContent config", async () => {
+  it("passes provider-native generateContent config for contents", async () => {
     const generateContent = vi.fn().mockResolvedValue({
       text: "Result.",
       candidates: [],
@@ -499,7 +494,11 @@ describe("GeminiProvider contents", () => {
     const provider = createProvider({ models: { generateContent } });
     await provider.contents(
       ["https://example.com"],
-      { temperature: 0.2 },
+      {
+        config: {
+          temperature: 0.2,
+        },
+      },
       createConfig(),
       createContext(),
     );
@@ -514,7 +513,7 @@ describe("GeminiProvider contents", () => {
     );
   });
 
-  it("supports request-level options for contents while preserving urlContext", async () => {
+  it("supports provider-native request options for contents while preserving urlContext", async () => {
     const generateContent = vi.fn().mockResolvedValue({
       text: "Result.",
       candidates: [],
@@ -526,11 +525,11 @@ describe("GeminiProvider contents", () => {
       {
         model: "gemini-2.5-pro",
         config: {
+          labels: {
+            request_id: "contents-1",
+          },
           topK: 3,
           tools: [{ googleSearch: {} }],
-        },
-        metadata: {
-          request_id: "contents-1",
         },
       },
       createConfig(),


### PR DESCRIPTION
The `options` object that tools accept at call time is now forwarded to the Claude, Codex, and Gemini providers, giving callers fine-grained control over each request without changing the shared tool interface.

**Claude** supports `model`, `effort`, `maxTurns`, `maxThinkingTokens`, `maxBudgetUsd`, and a `thinking` object.

**Codex** supports `model`, `modelReasoningEffort`, and `webSearchMode`.

**Gemini** supports `model`, `config`, `labels`, and `metadata` (merged into `config.labels`) for search, answer, and contents tools; research passes all caller-supplied options through to the underlying API.

Runtime options override provider defaults from the config, but managed tool inputs and tool wiring stay fixed.