### PR TITLE
Centralize provider timeout handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,17 +123,40 @@ The extension also accepts a few local control fields for robustness:
 plus `pollIntervalMs`, `timeoutMs`, `maxConsecutivePollErrors`, and `resumeId`
 on `web_research` for lifecycle-based research providers. The overall research
 `timeoutMs` starts when the research request begins, including background job
-creation. Perplexity research runs synchronously, so it only supports
-`requestTimeoutMs`, `retryCount`, and `retryDelayMs`; lifecycle fields are
-rejected instead of being silently ignored. Exa and Valyu research support
-polling, overall deadlines, and resume IDs after job creation, but reject
-`requestTimeoutMs` because their current SDK lifecycles do not safely support
-per-request local timeouts. Their research start requests also do not use
-automatic start retries, because retrying a non-idempotent background-job
-creation call could create duplicate jobs. If an overall research timeout fires
-before a job ID is returned, the extension fails fast but cannot offer a
-`resumeId`. These fields are handled by the extension and are not forwarded
-into the provider SDK call.
+creation. Perplexity research currently runs in streaming foreground mode, so
+it only supports `requestTimeoutMs`, `retryCount`, and `retryDelayMs`;
+lifecycle fields are rejected instead of being silently ignored. Exa and Valyu
+research support polling, overall deadlines, and resume IDs after job
+creation, but reject `requestTimeoutMs` because their current SDK lifecycles do
+not safely support per-request local timeouts. Their research start requests
+also do not use automatic start retries, because retrying a non-idempotent
+background-job creation call could create duplicate jobs. If an overall
+research timeout fires before a job ID is returned, the extension fails fast
+but cannot offer a `resumeId`. These fields are handled by the extension and
+are not forwarded into the provider SDK call.
+
+> [!NOTE]
+> Providers can deliver tool results in one of three modes, depending on what
+> they support.
+>
+> **Silent foreground.** The tool stays open with no intermediate output while
+> it runs, and the result is only usable after the tool finishes and returns
+> the final result.
+>
+> **Streaming foreground.** The tool stays open and shows progress updates or
+> partial output while the provider works, but the result is still only usable
+> after the tool finishes and returns the final result. Streaming changes what
+> you can see while waiting, not when the result is handed back.
+>
+> **Background research.** The tool can show research progress while the
+> provider keeps the run alive in the background, and the result becomes usable
+> when the current run reaches a final result. If the local run is interrupted
+> first, pi can resume the same research later with `resumeId` instead of
+> starting over.
+
+You still call `web_search`, `web_contents`, `web_answer`, and
+`web_research` the same way. What changes is how much feedback you get while a
+tool is running, and whether an interrupted research run can be resumed later.
 
 ## 🔌 Providers
 
@@ -155,6 +178,7 @@ summarises which capabilities each provider exposes:
 - SDK: `@anthropic-ai/claude-agent-sdk`
 - Uses Claude Code's built-in `WebSearch` and `WebFetch` tools behind a
   structured JSON adapter
+- Runs in **silent foreground** mode
 - Supports request-shaping `options` such as `model`, `thinking`, `effort`, and
   `maxTurns`
 - Great for search plus grounded answers if you already use Claude Code locally
@@ -163,6 +187,7 @@ summarises which capabilities each provider exposes:
 
 - SDK: `@openai/codex-sdk`
 - Runs in read-only mode with web search enabled
+- Runs in **silent foreground** mode
 - Supports request-shaping `web_search.options` such as `model`,
   `modelReasoningEffort`, and `webSearchMode`
 - Best if you already use the local Codex CLI and auth flow
@@ -170,12 +195,16 @@ summarises which capabilities each provider exposes:
 ### Exa
 
 - SDK: `exa-js`
+- Search, contents, and answer run in **silent foreground** mode
+- Research runs in **background research** mode and supports `resumeId`
 - Neural, keyword, hybrid, and deep-research search modes
 - Inline text-content extraction on search results
 
 ### Gemini
 
 - SDK: `@google/genai`
+- Search, contents, and answer run in **silent foreground** mode
+- Research runs in **background research** mode and supports `resumeId`
 - Google Search grounding for answers and URL Context extraction for page
   contents
 - Deep-research agents via Google's Gemini API
@@ -190,17 +219,19 @@ summarises which capabilities each provider exposes:
 ### Perplexity
 
 - SDK: `@perplexity-ai/perplexity_ai`
+- `web_search` and `web_answer` run in **silent foreground** mode
+- `web_research` runs in **streaming foreground** mode: it can show partial
+  output while it runs, but it does not support `resumeId`, polling intervals,
+  or parent-managed research deadlines
 - Uses Perplexity Search for `web_search`
 - Uses Sonar for `web_answer` and `sonar-deep-research` for `web_research`
-- `web_research` is synchronous with the current Perplexity SDK, so it may
-  block until completion and does not support `resumeId`, polling intervals, or
-  parent-managed research deadlines
 - Supports provider-specific `web_search.options` such as `country`,
   `search_mode`, `search_domain_filter`, and `search_recency_filter`
 
 ### Parallel
 
 - SDK: `parallel-web`
+- Runs in **silent foreground** mode
 - Agentic and one-shot search modes
 - Page content extraction with excerpt and full-content toggles
 - Supports provider-native search and extraction options from the Parallel SDK
@@ -208,6 +239,8 @@ summarises which capabilities each provider exposes:
 ### Valyu
 
 - SDK: `valyu-js`
+- Search, contents, and answer run in **silent foreground** mode
+- Research runs in **background research** mode and supports `resumeId`
 - Web, proprietary, and news search types
 - Supports provider-native options such as `countryCode`, `responseLength`, and
   search/source filters

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ tool prompt aligned with the tools that the agent can actually call.
 - **Per-provider tool toggles** — disable individual capabilities you don't need
   without switching providers
 - **Parent-managed timeout and retry controls** — the extension can enforce
-  request timeouts and retries across all tools, plus polling intervals and
-  resumable background job IDs for lifecycle-based research providers
+  request timeouts across request/response tools, plus research polling,
+  deadlines, and resumable background job IDs for lifecycle-based providers
 - **Truncated output with temp-file spillover** for large results
 
 ## 📦 Install
@@ -121,13 +121,19 @@ fixed.
 The extension also accepts a few local control fields for robustness:
 `requestTimeoutMs`, `retryCount`, and `retryDelayMs` on request/response tools,
 plus `pollIntervalMs`, `timeoutMs`, `maxConsecutivePollErrors`, and `resumeId`
-on `web_research` for lifecycle-based research providers. Perplexity research
-runs synchronously, so it only supports `requestTimeoutMs`, `retryCount`, and
-`retryDelayMs`; lifecycle fields are rejected instead of being silently ignored.
-Exa and Valyu research support retries, polling, deadlines, and resume IDs, but
-reject `requestTimeoutMs` because their current SDK lifecycles do not safely
-support per-request local timeouts. These fields are handled by the extension
-and are not forwarded into the provider SDK call.
+on `web_research` for lifecycle-based research providers. The overall research
+`timeoutMs` starts when the research request begins, including background job
+creation. Perplexity research runs synchronously, so it only supports
+`requestTimeoutMs`, `retryCount`, and `retryDelayMs`; lifecycle fields are
+rejected instead of being silently ignored. Exa and Valyu research support
+polling, overall deadlines, and resume IDs after job creation, but reject
+`requestTimeoutMs` because their current SDK lifecycles do not safely support
+per-request local timeouts. Their research start requests also do not use
+automatic start retries, because retrying a non-idempotent background-job
+creation call could create duplicate jobs. If an overall research timeout fires
+before a job ID is returned, the extension fails fast but cannot offer a
+`resumeId`. These fields are handled by the extension and are not forwarded
+into the provider SDK call.
 
 ## 🔌 Providers
 

--- a/README.md
+++ b/README.md
@@ -119,13 +119,15 @@ override provider-native config, but managed tool inputs and tool wiring stay
 fixed.
 
 The extension also accepts a few local control fields for robustness:
-`requestTimeoutMs`, `retryCount`, and `retryDelayMs` on all tools, plus
-`pollIntervalMs`, `timeoutMs`, `maxConsecutivePollErrors`, and `resumeId` on
-`web_research` for lifecycle-based research providers. Perplexity research runs
-synchronously, so it only supports `requestTimeoutMs`, `retryCount`, and
+`requestTimeoutMs`, `retryCount`, and `retryDelayMs` on request/response tools,
+plus `pollIntervalMs`, `timeoutMs`, `maxConsecutivePollErrors`, and `resumeId`
+on `web_research` for lifecycle-based research providers. Perplexity research
+runs synchronously, so it only supports `requestTimeoutMs`, `retryCount`, and
 `retryDelayMs`; lifecycle fields are rejected instead of being silently ignored.
-These fields are handled by the extension and are not forwarded into the
-provider SDK call.
+Exa and Valyu research support retries, polling, deadlines, and resume IDs, but
+reject `requestTimeoutMs` because their current SDK lifecycles do not safely
+support per-request local timeouts. These fields are handled by the extension
+and are not forwarded into the provider SDK call.
 
 ## 🔌 Providers
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ Investigate a topic across web sources and produce a longer report.
 `options` are provider-native and provider-specific. Equivalent concepts can
 use different field names across SDKs, for example Perplexity uses `country`,
 Exa uses `userLocation`, and Valyu uses `countryCode`. Runtime `options`
-override provider defaults, but managed tool inputs and tool wiring stay fixed.
+override provider-native config, but managed tool inputs and tool wiring stay
+fixed.
 
 The extension also accepts a few local control fields for robustness:
 `requestTimeoutMs`, `retryCount`, and `retryDelayMs` on all tools, plus
@@ -210,6 +211,8 @@ summarises which capabilities each provider exposes:
   for the selected provider and `enabled: false` for the others
 - Each provider can also enable or disable its individual tools through a `tools`
   block
+- Provider configuration is split into `native` settings that are forwarded to
+  the SDK and `policy` settings that are enforced by the extension runtime
 - Managed tools are registered from available provider capabilities, but the
   active tool set can still be narrower if you removed a tool from the session
 - If no provider is explicitly enabled for search, the extension falls back to
@@ -223,6 +226,8 @@ summarises which capabilities each provider exposes:
   - literal strings
   - environment variable names such as `EXA_API_KEY`
   - shell commands prefixed with `!`
+- Legacy `defaults` blocks are still accepted when reading config files, but the
+  extension now writes split `native` and `policy` blocks
 
 Example:
 
@@ -242,9 +247,14 @@ Example:
       "tools": {
         "search": true
       },
-      "defaults": {
+      "native": {
         "webSearchMode": "live",
         "networkAccessEnabled": true
+      },
+      "policy": {
+        "requestTimeoutMs": 30000,
+        "retryCount": 3,
+        "retryDelayMs": 2000
       }
     },
     "exa": {
@@ -256,11 +266,19 @@ Example:
         "research": true
       },
       "apiKey": "EXA_API_KEY",
-      "defaults": {
+      "native": {
         "type": "auto",
         "contents": {
           "text": true
         }
+      },
+      "policy": {
+        "requestTimeoutMs": 30000,
+        "retryCount": 3,
+        "retryDelayMs": 2000,
+        "researchPollIntervalMs": 3000,
+        "researchTimeoutMs": 21600000,
+        "researchMaxConsecutivePollErrors": 3
       }
     },
     "gemini": {
@@ -272,11 +290,13 @@ Example:
         "research": true
       },
       "apiKey": "GOOGLE_API_KEY",
-      "defaults": {
+      "native": {
         "searchModel": "gemini-2.5-flash",
         "contentsModel": "gemini-2.5-flash",
         "answerModel": "gemini-2.5-flash",
-        "researchAgent": "deep-research-pro-preview-12-2025",
+        "researchAgent": "deep-research-pro-preview-12-2025"
+      },
+      "policy": {
         "requestTimeoutMs": 30000,
         "retryCount": 3,
         "retryDelayMs": 2000,
@@ -293,7 +313,7 @@ Example:
         "research": true
       },
       "apiKey": "PERPLEXITY_API_KEY",
-      "defaults": {
+      "native": {
         "search": {
           "country": "US"
         },
@@ -303,6 +323,11 @@ Example:
         "research": {
           "model": "sonar-deep-research"
         }
+      },
+      "policy": {
+        "requestTimeoutMs": 30000,
+        "retryCount": 3,
+        "retryDelayMs": 2000
       }
     },
     "parallel": {
@@ -312,7 +337,7 @@ Example:
         "contents": true
       },
       "apiKey": "PARALLEL_API_KEY",
-      "defaults": {
+      "native": {
         "search": {
           "mode": "agentic"
         },
@@ -320,6 +345,11 @@ Example:
           "excerpts": true,
           "full_content": false
         }
+      },
+      "policy": {
+        "requestTimeoutMs": 30000,
+        "retryCount": 3,
+        "retryDelayMs": 2000
       }
     },
     "valyu": {
@@ -331,9 +361,17 @@ Example:
         "research": true
       },
       "apiKey": "VALYU_API_KEY",
-      "defaults": {
+      "native": {
         "searchType": "all",
         "responseLength": "short"
+      },
+      "policy": {
+        "requestTimeoutMs": 30000,
+        "retryCount": 3,
+        "retryDelayMs": 2000,
+        "researchPollIntervalMs": 3000,
+        "researchTimeoutMs": 21600000,
+        "researchMaxConsecutivePollErrors": 3
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ tool prompt aligned with the tools that the agent can actually call.
 - **Per-provider tool toggles** — disable individual capabilities you don't need
   without switching providers
 - **Parent-managed timeout and retry controls** — the extension can enforce
-  request timeouts, retries, polling intervals, and resumable background job
-  IDs without pushing that logic into each provider adapter
+  request timeouts and retries across all tools, plus polling intervals and
+  resumable background job IDs for lifecycle-based research providers
 - **Truncated output with temp-file spillover** for large results
 
 ## 📦 Install
@@ -119,10 +119,12 @@ override provider defaults, but managed tool inputs and tool wiring stay fixed.
 
 The extension also accepts a few local control fields for robustness:
 `requestTimeoutMs`, `retryCount`, and `retryDelayMs` on all tools, plus
-`pollIntervalMs`, `timeoutMs`, `maxConsecutivePollErrors`, and `resumeId`
-(on Gemini, `resumeInteractionId` is accepted as a legacy alias) on
-`web_research`. These fields are handled by the extension and are not forwarded
-into the provider SDK call.
+`pollIntervalMs`, `timeoutMs`, `maxConsecutivePollErrors`, and `resumeId` on
+`web_research` for lifecycle-based research providers. Perplexity research runs
+synchronously, so it only supports `requestTimeoutMs`, `retryCount`, and
+`retryDelayMs`; lifecycle fields are rejected instead of being silently ignored.
+These fields are handled by the extension and are not forwarded into the
+provider SDK call.
 
 ## 🔌 Providers
 
@@ -172,7 +174,7 @@ summarises which capabilities each provider exposes:
   timeouts, retry/backoff behavior, research polling, and total research
   deadlines
 - Can resume polling an existing background research interaction via
-  `options.resumeId` (or legacy `options.resumeInteractionId`)
+  `options.resumeId`
 - Supports provider-native request options such as `model`, `config`,
   `generation_config`, and `agent_config` depending on the tool
 
@@ -181,6 +183,9 @@ summarises which capabilities each provider exposes:
 - SDK: `@perplexity-ai/perplexity_ai`
 - Uses Perplexity Search for `web_search`
 - Uses Sonar for `web_answer` and `sonar-deep-research` for `web_research`
+- `web_research` is synchronous with the current Perplexity SDK, so it may
+  block until completion and does not support `resumeId`, polling intervals, or
+  parent-managed research deadlines
 - Supports provider-specific `web_search.options` such as `country`,
   `search_mode`, `search_domain_filter`, and `search_recency_filter`
 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,11 @@ Example:
       "tools": {
         "search": true,
         "answer": true
+      },
+      "policy": {
+        "requestTimeoutMs": 30000,
+        "retryCount": 3,
+        "retryDelayMs": 2000
       }
     },
     "codex": {

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ tool prompt aligned with the tools that the agent can actually call.
   explicitly enabled and the local CLI is installed and authenticated
 - **Per-provider tool toggles** — disable individual capabilities you don't need
   without switching providers
+- **Parent-managed timeout and retry controls** — the extension can enforce
+  request timeouts, retries, polling intervals, and resumable background job
+  IDs without pushing that logic into each provider adapter
 - **Truncated output with temp-file spillover** for large results
 
 ## 📦 Install
@@ -72,11 +75,11 @@ corresponding tool is never exposed to the agent.
 
 Find likely sources on the public web and return titles, URLs, and snippets.
 
-| Parameter    | Type    | Default  | Description                                                                   |
-| ------------ | ------- | -------- | ----------------------------------------------------------------------------- |
-| `query`      | string  | required | What to search for                                                            |
-| `maxResults` | integer | `5`      | Result count, clamped to `1–20`                                               |
-| `options`    | object  | —        | Provider-specific search options                                              |
+| Parameter    | Type    | Default  | Description                                                                                 |
+| ------------ | ------- | -------- | ------------------------------------------------------------------------------------------- |
+| `query`      | string  | required | What to search for                                                                          |
+| `maxResults` | integer | `5`      | Result count, clamped to `1–20`                                                             |
+| `options`    | object  | —        | Provider-specific search options                                                            |
 | `provider`   | string  | auto     | Optional override: `claude`, `codex`, `exa`, `gemini`, `perplexity`, `parallel`, or `valyu` |
 
 ### `web_contents`
@@ -114,20 +117,27 @@ use different field names across SDKs, for example Perplexity uses `country`,
 Exa uses `userLocation`, and Valyu uses `countryCode`. Runtime `options`
 override provider defaults, but managed tool inputs and tool wiring stay fixed.
 
+The extension also accepts a few local control fields for robustness:
+`requestTimeoutMs`, `retryCount`, and `retryDelayMs` on all tools, plus
+`pollIntervalMs`, `timeoutMs`, `maxConsecutivePollErrors`, and `resumeId`
+(on Gemini, `resumeInteractionId` is accepted as a legacy alias) on
+`web_research`. These fields are handled by the extension and are not forwarded
+into the provider SDK call.
+
 ## 🔌 Providers
 
 Every provider is a thin adapter around an official SDK. The table below
 summarises which capabilities each provider exposes:
 
-| Provider     | search | contents | answer | research | Auth                   |
-| ------------ | :----: | :------: | :----: | :------: | ---------------------- |
-| **Claude**   |   ✓    |          |   ✓    |          | Local Claude Code auth |
-| **Codex**    |   ✓    |          |        |          | Local Codex CLI auth   |
-| **Exa**      |   ✓    |    ✓     |   ✓    |    ✓     | `EXA_API_KEY`          |
-| **Gemini**   |   ✓    |    ✓     |   ✓    |    ✓     | `GOOGLE_API_KEY`       |
-| **Perplexity** | ✓    |          |   ✓    |    ✓     | `PERPLEXITY_API_KEY`   |
-| **Parallel** |   ✓    |    ✓     |        |          | `PARALLEL_API_KEY`     |
-| **Valyu**    |   ✓    |    ✓     |   ✓    |    ✓     | `VALYU_API_KEY`        |
+| Provider       | search | contents | answer | research | Auth                   |
+| -------------- | :----: | :------: | :----: | :------: | ---------------------- |
+| **Claude**     |   ✓    |          |   ✓    |          | Local Claude Code auth |
+| **Codex**      |   ✓    |          |        |          | Local Codex CLI auth   |
+| **Exa**        |   ✓    |    ✓     |   ✓    |    ✓     | `EXA_API_KEY`          |
+| **Gemini**     |   ✓    |    ✓     |   ✓    |    ✓     | `GOOGLE_API_KEY`       |
+| **Perplexity** |   ✓    |          |   ✓    |    ✓     | `PERPLEXITY_API_KEY`   |
+| **Parallel**   |   ✓    |    ✓     |        |          | `PARALLEL_API_KEY`     |
+| **Valyu**      |   ✓    |    ✓     |   ✓    |    ✓     | `VALYU_API_KEY`        |
 
 ### Claude
 
@@ -155,8 +165,14 @@ summarises which capabilities each provider exposes:
 ### Gemini
 
 - SDK: `@google/genai`
-- Google Search grounding for answers and URL Context extraction for page contents
+- Google Search grounding for answers and URL Context extraction for page
+  contents
 - Deep-research agents via Google's Gemini API
+- Works with the extension's parent-managed timeout/retry controls for request
+  timeouts, retry/backoff behavior, research polling, and total research
+  deadlines
+- Can resume polling an existing background research interaction via
+  `options.resumeId` (or legacy `options.resumeInteractionId`)
 - Supports provider-native request options such as `model`, `config`,
   `generation_config`, and `agent_config` depending on the tool
 
@@ -255,7 +271,13 @@ Example:
         "searchModel": "gemini-2.5-flash",
         "contentsModel": "gemini-2.5-flash",
         "answerModel": "gemini-2.5-flash",
-        "researchAgent": "deep-research-pro-preview-12-2025"
+        "researchAgent": "deep-research-pro-preview-12-2025",
+        "requestTimeoutMs": 30000,
+        "retryCount": 3,
+        "retryDelayMs": 2000,
+        "researchPollIntervalMs": 3000,
+        "researchTimeoutMs": 21600000,
+        "researchMaxConsecutivePollErrors": 10
       }
     },
     "perplexity": {

--- a/changelog/unreleased/parent-managed-timeout-and-retry-controls.md
+++ b/changelog/unreleased/parent-managed-timeout-and-retry-controls.md
@@ -17,7 +17,9 @@ can safely enforce them:
 - `retryDelayMs` — base delay between retries (doubles on each attempt, capped
   at 30 s)
 
-The `web_research` tool adds controls for long-running investigations:
+The `web_research` tool adds controls for long-running investigations. The
+overall `timeoutMs` starts when the research request begins, including
+background job creation:
 
 - `pollIntervalMs` — how often to check for completion
 - `timeoutMs` — overall deadline for the research job
@@ -27,9 +29,11 @@ The `web_research` tool adds controls for long-running investigations:
 
 Perplexity research remains synchronous, so it only supports
 `requestTimeoutMs`, `retryCount`, and `retryDelayMs`. Exa and Valyu research
-support retries, polling, deadlines, and resume IDs, but reject
-`requestTimeoutMs` because their current SDK lifecycles do not safely support
-per-request local timeouts.
+support polling, overall deadlines, and resume IDs after job creation, but
+reject `requestTimeoutMs` because their current SDK lifecycles do not safely
+support per-request local timeouts. Their research start requests also avoid
+automatic start retries, because retrying a non-idempotent background-job
+creation call could create duplicate jobs.
 
 When a research job times out, the error message includes the job ID so you can
 pick up where it left off:

--- a/changelog/unreleased/parent-managed-timeout-and-retry-controls.md
+++ b/changelog/unreleased/parent-managed-timeout-and-retry-controls.md
@@ -7,8 +7,9 @@ authors:
 created: 2026-03-13T16:14:46.000000Z
 ---
 
-All web tools now support per-call timeout, retry, and backoff settings through
-the `options` object:
+Web tools now support parent-managed retry and backoff settings through the
+`options` object, plus per-call timeouts where the selected provider lifecycle
+can safely enforce them:
 
 - `requestTimeoutMs` — per-request timeout
 - `retryCount` — number of retries on transient errors (429, 5xx, network
@@ -23,6 +24,12 @@ The `web_research` tool adds controls for long-running investigations:
 - `maxConsecutivePollErrors` — consecutive poll failures to tolerate before
   aborting
 - `resumeId` — resume a previously timed-out research job by its ID
+
+Perplexity research remains synchronous, so it only supports
+`requestTimeoutMs`, `retryCount`, and `retryDelayMs`. Exa and Valyu research
+support retries, polling, deadlines, and resume IDs, but reject
+`requestTimeoutMs` because their current SDK lifecycles do not safely support
+per-request local timeouts.
 
 When a research job times out, the error message includes the job ID so you can
 pick up where it left off:

--- a/changelog/unreleased/parent-managed-timeout-and-retry-controls.md
+++ b/changelog/unreleased/parent-managed-timeout-and-retry-controls.md
@@ -1,0 +1,36 @@
+---
+title: Timeout, retry, and resume controls for all web tools
+type: feature
+authors:
+  - mavam
+  - claude
+created: 2026-03-13T16:14:46.000000Z
+---
+
+All web tools now support per-call timeout, retry, and backoff settings through
+the `options` object:
+
+- `requestTimeoutMs` — per-request timeout
+- `retryCount` — number of retries on transient errors (429, 5xx, network
+  failures)
+- `retryDelayMs` — base delay between retries (doubles on each attempt, capped
+  at 30 s)
+
+The `web_research` tool adds controls for long-running investigations:
+
+- `pollIntervalMs` — how often to check for completion
+- `timeoutMs` — overall deadline for the research job
+- `maxConsecutivePollErrors` — consecutive poll failures to tolerate before
+  aborting
+- `resumeId` — resume a previously timed-out research job by its ID
+
+When a research job times out, the error message includes the job ID so you can
+pick up where it left off:
+
+```
+Gemini research exceeded 6h. Resume the background job with
+options.resumeId="abc123".
+```
+
+Defaults for all settings are configurable per provider in
+`~/.pi/agent/web-providers.json`.

--- a/changelog/unreleased/parent-managed-timeout-and-retry-controls.md
+++ b/changelog/unreleased/parent-managed-timeout-and-retry-controls.md
@@ -32,5 +32,6 @@ Gemini research exceeded 6h. Resume the background job with
 options.resumeId="abc123".
 ```
 
-Defaults for all settings are configurable per provider in
-`~/.pi/agent/web-providers.json`.
+All settings are configurable per provider in
+`~/.pi/agent/web-providers.json`, with provider-native knobs under `native`
+and parent-managed runtime controls under `policy`.

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,8 +13,8 @@ import type {
   ExaProviderConfig,
   GeminiProviderConfig,
   JsonObject,
-  PerplexityProviderConfig,
   ParallelProviderConfig,
+  PerplexityProviderConfig,
   ProviderId,
   ValyuProviderConfig,
   WebProvidersConfig,
@@ -94,6 +94,12 @@ export function createDefaultConfig(): WebProvidersConfig {
           contentsModel: "gemini-2.5-flash",
           answerModel: "gemini-2.5-flash",
           researchAgent: "deep-research-pro-preview-12-2025",
+          requestTimeoutMs: 30000,
+          retryCount: 3,
+          retryDelayMs: 2000,
+          researchPollIntervalMs: 3000,
+          researchTimeoutMs: 21600000,
+          researchMaxConsecutivePollErrors: 10,
         },
       },
       perplexity: {
@@ -628,6 +634,36 @@ function normalizeGeminiProvider(
               source,
               "providers.gemini.defaults.researchAgent",
             ),
+            requestTimeoutMs: parseOptionalInteger(
+              defaults.requestTimeoutMs,
+              source,
+              "providers.gemini.defaults.requestTimeoutMs",
+            ),
+            retryCount: parseOptionalNonNegativeInteger(
+              defaults.retryCount,
+              source,
+              "providers.gemini.defaults.retryCount",
+            ),
+            retryDelayMs: parseOptionalInteger(
+              defaults.retryDelayMs,
+              source,
+              "providers.gemini.defaults.retryDelayMs",
+            ),
+            researchPollIntervalMs: parseOptionalInteger(
+              defaults.researchPollIntervalMs,
+              source,
+              "providers.gemini.defaults.researchPollIntervalMs",
+            ),
+            researchTimeoutMs: parseOptionalInteger(
+              defaults.researchTimeoutMs,
+              source,
+              "providers.gemini.defaults.researchTimeoutMs",
+            ),
+            researchMaxConsecutivePollErrors: parseOptionalInteger(
+              defaults.researchMaxConsecutivePollErrors,
+              source,
+              "providers.gemini.defaults.researchMaxConsecutivePollErrors",
+            ),
           },
   };
 }
@@ -888,6 +924,18 @@ function parseOptionalInteger(
   if (value === undefined) return undefined;
   if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
     throw new Error(`'${field}' in ${source} must be a positive integer.`);
+  }
+  return value;
+}
+
+function parseOptionalNonNegativeInteger(
+  value: unknown,
+  source: string,
+  field: string,
+): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw new Error(`'${field}' in ${source} must be a non-negative integer.`);
   }
   return value;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,11 @@ import { execSync } from "node:child_process";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { getAgentDir } from "@mariozechner/pi-coding-agent";
+import {
+  createDefaultLifecyclePolicy,
+  createDefaultRequestPolicy,
+  DEFAULT_GEMINI_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS,
+} from "./execution-policy-defaults.js";
 import { type ProviderToolId, supportsProviderTool } from "./provider-tools.js";
 import type {
   ClaudeProviderConfig,
@@ -38,6 +43,7 @@ export function createDefaultConfig(): WebProvidersConfig {
           search: true,
           answer: true,
         },
+        policy: createDefaultRequestPolicy(),
       },
       codex: {
         enabled: true,
@@ -49,6 +55,7 @@ export function createDefaultConfig(): WebProvidersConfig {
           webSearchEnabled: true,
           webSearchMode: "live",
         },
+        policy: createDefaultRequestPolicy(),
       },
       exa: {
         enabled: false,
@@ -65,6 +72,7 @@ export function createDefaultConfig(): WebProvidersConfig {
             text: true,
           },
         },
+        policy: createDefaultLifecyclePolicy(),
       },
       gemini: {
         enabled: false,
@@ -81,14 +89,10 @@ export function createDefaultConfig(): WebProvidersConfig {
           answerModel: "gemini-2.5-flash",
           researchAgent: "deep-research-pro-preview-12-2025",
         },
-        policy: {
-          requestTimeoutMs: 30000,
-          retryCount: 3,
-          retryDelayMs: 2000,
-          researchPollIntervalMs: 3000,
-          researchTimeoutMs: 21600000,
-          researchMaxConsecutivePollErrors: 10,
-        },
+        policy: createDefaultLifecyclePolicy({
+          researchMaxConsecutivePollErrors:
+            DEFAULT_GEMINI_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS,
+        }),
       },
       perplexity: {
         enabled: false,
@@ -106,6 +110,7 @@ export function createDefaultConfig(): WebProvidersConfig {
             model: "sonar-deep-research",
           },
         },
+        policy: createDefaultRequestPolicy(),
       },
       parallel: {
         enabled: false,
@@ -123,6 +128,7 @@ export function createDefaultConfig(): WebProvidersConfig {
             full_content: false,
           },
         },
+        policy: createDefaultRequestPolicy(),
       },
       valyu: {
         enabled: false,
@@ -137,6 +143,7 @@ export function createDefaultConfig(): WebProvidersConfig {
           searchType: "all",
           responseLength: "short",
         },
+        policy: createDefaultLifecyclePolicy(),
       },
     },
   };

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,11 +2,7 @@ import { execSync } from "node:child_process";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { getAgentDir } from "@mariozechner/pi-coding-agent";
-import {
-  PROVIDER_TOOLS,
-  type ProviderToolId,
-  supportsProviderTool,
-} from "./provider-tools.js";
+import { type ProviderToolId, supportsProviderTool } from "./provider-tools.js";
 import type {
   ClaudeProviderConfig,
   CodexProviderConfig,
@@ -19,17 +15,6 @@ import type {
   ValyuProviderConfig,
   WebProvidersConfig,
 } from "./types.js";
-
-const LEGACY_TOOL_ALIASES: Partial<
-  Record<ProviderId, Partial<Record<string, ProviderToolId | null>>>
-> = {
-  exa: {
-    websetsPreview: null,
-  },
-  valyu: {
-    deepResearch: "research",
-  },
-};
 
 const CONFIG_FILE_NAME = "web-providers.json";
 const VERSION = 1 as const;
@@ -811,41 +796,17 @@ function parseOptionalProviderTools(
 
   const parsed: Partial<Record<ProviderToolId, boolean>> = {};
   for (const [key, entry] of Object.entries(value)) {
-    const normalizedKey = normalizeProviderToolKey(providerId, key);
-    if (normalizedKey === null) {
-      continue;
-    }
-    if (!supportsProviderTool(providerId, normalizedKey)) {
+    if (!supportsProviderTool(providerId, key as ProviderToolId)) {
       throw new Error(`Unknown tools for ${providerId} in ${source}: ${key}.`);
     }
-    parsed[normalizedKey] = parseBoolean(entry, source, `${field}.${key}`);
-  }
-
-  const unknownTools = Object.keys(value).filter((toolId) => {
-    const normalizedKey = normalizeProviderToolKey(providerId, toolId);
-    return (
-      normalizedKey !== null &&
-      !PROVIDER_TOOLS[providerId].includes(normalizedKey)
-    );
-  });
-  if (unknownTools.length > 0) {
-    throw new Error(
-      `Unknown tools for ${providerId} in ${source}: ${unknownTools.join(", ")}.`,
+    parsed[key as ProviderToolId] = parseBoolean(
+      entry,
+      source,
+      `${field}.${key}`,
     );
   }
 
   return parsed;
-}
-
-function normalizeProviderToolKey(
-  providerId: ProviderId,
-  key: string,
-): ProviderToolId | null {
-  const alias = LEGACY_TOOL_ALIASES[providerId]?.[key];
-  if (alias !== undefined) {
-    return alias;
-  }
-  return key as ProviderToolId;
 }
 
 function parseOptionalStringMap(

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ import type {
   ClaudeProviderConfig,
   CodexProviderConfig,
   ExaProviderConfig,
+  ExecutionPolicyDefaults,
   GeminiProviderConfig,
   JsonObject,
   ParallelProviderConfig,
@@ -43,7 +44,7 @@ export function createDefaultConfig(): WebProvidersConfig {
         tools: {
           search: true,
         },
-        defaults: {
+        native: {
           networkAccessEnabled: true,
           webSearchEnabled: true,
           webSearchMode: "live",
@@ -58,7 +59,7 @@ export function createDefaultConfig(): WebProvidersConfig {
           research: true,
         },
         apiKey: "EXA_API_KEY",
-        defaults: {
+        native: {
           type: "auto",
           contents: {
             text: true,
@@ -74,11 +75,13 @@ export function createDefaultConfig(): WebProvidersConfig {
           research: true,
         },
         apiKey: "GOOGLE_API_KEY",
-        defaults: {
+        native: {
           searchModel: "gemini-2.5-flash",
           contentsModel: "gemini-2.5-flash",
           answerModel: "gemini-2.5-flash",
           researchAgent: "deep-research-pro-preview-12-2025",
+        },
+        policy: {
           requestTimeoutMs: 30000,
           retryCount: 3,
           retryDelayMs: 2000,
@@ -95,7 +98,7 @@ export function createDefaultConfig(): WebProvidersConfig {
           research: true,
         },
         apiKey: "PERPLEXITY_API_KEY",
-        defaults: {
+        native: {
           answer: {
             model: "sonar",
           },
@@ -111,7 +114,7 @@ export function createDefaultConfig(): WebProvidersConfig {
           contents: true,
         },
         apiKey: "PARALLEL_API_KEY",
-        defaults: {
+        native: {
           search: {
             mode: "agentic",
           },
@@ -130,7 +133,7 @@ export function createDefaultConfig(): WebProvidersConfig {
           research: true,
         },
         apiKey: "VALYU_API_KEY",
-        defaults: {
+        native: {
           searchType: "all",
           responseLength: "short",
         },
@@ -365,10 +368,12 @@ function normalizeClaudeProvider(
   source: string,
 ): ClaudeProviderConfig {
   const provider = parseProviderObject(raw, source, "claude");
-  const defaults = parseOptionalJsonObject(
-    provider.defaults,
+  const native = parseOptionalJsonObject(
+    getProviderNativeSource(provider),
     source,
-    "providers.claude.defaults",
+    provider.native !== undefined
+      ? "providers.claude.native"
+      : "providers.claude.defaults",
   );
 
   return {
@@ -388,27 +393,34 @@ function normalizeClaudeProvider(
       source,
       "providers.claude.pathToClaudeCodeExecutable",
     ),
-    defaults:
-      defaults === undefined
+    native:
+      native === undefined
         ? undefined
         : {
             model: parseOptionalString(
-              defaults.model,
+              native.model,
               source,
-              "providers.claude.defaults.model",
+              "providers.claude.native.model",
             ),
             effort: parseOptionalLiteral(
-              defaults.effort,
+              native.effort,
               source,
-              "providers.claude.defaults.effort",
+              "providers.claude.native.effort",
               ["low", "medium", "high", "max"] as const,
             ),
             maxTurns: parseOptionalInteger(
-              defaults.maxTurns,
+              native.maxTurns,
               source,
-              "providers.claude.defaults.maxTurns",
+              "providers.claude.native.maxTurns",
             ),
           },
+    policy: parseOptionalExecutionPolicy(
+      getProviderPolicySource(provider),
+      source,
+      provider.policy !== undefined
+        ? "providers.claude.policy"
+        : "providers.claude.defaults",
+    ),
   };
 }
 
@@ -417,10 +429,12 @@ function normalizeCodexProvider(
   source: string,
 ): CodexProviderConfig {
   const provider = parseProviderObject(raw, source, "codex");
-  const defaults = parseOptionalJsonObject(
-    provider.defaults,
+  const native = parseOptionalJsonObject(
+    getProviderNativeSource(provider),
     source,
-    "providers.codex.defaults",
+    provider.native !== undefined
+      ? "providers.codex.native"
+      : "providers.codex.defaults",
   );
   return {
     enabled: parseOptionalBoolean(
@@ -455,43 +469,50 @@ function normalizeCodexProvider(
       source,
       "providers.codex.config",
     ),
-    defaults:
-      defaults === undefined
+    native:
+      native === undefined
         ? undefined
         : {
             model: parseOptionalString(
-              defaults.model,
+              native.model,
               source,
-              "providers.codex.defaults.model",
+              "providers.codex.native.model",
             ),
             modelReasoningEffort: parseOptionalLiteral(
-              defaults.modelReasoningEffort,
+              native.modelReasoningEffort,
               source,
-              "providers.codex.defaults.modelReasoningEffort",
+              "providers.codex.native.modelReasoningEffort",
               ["minimal", "low", "medium", "high", "xhigh"] as const,
             ),
             networkAccessEnabled: parseOptionalBoolean(
-              defaults.networkAccessEnabled,
+              native.networkAccessEnabled,
               source,
-              "providers.codex.defaults.networkAccessEnabled",
+              "providers.codex.native.networkAccessEnabled",
             ),
             webSearchMode: parseOptionalLiteral(
-              defaults.webSearchMode,
+              native.webSearchMode,
               source,
-              "providers.codex.defaults.webSearchMode",
+              "providers.codex.native.webSearchMode",
               ["disabled", "cached", "live"] as const,
             ),
             webSearchEnabled: parseOptionalBoolean(
-              defaults.webSearchEnabled,
+              native.webSearchEnabled,
               source,
-              "providers.codex.defaults.webSearchEnabled",
+              "providers.codex.native.webSearchEnabled",
             ),
             additionalDirectories: parseOptionalStringArray(
-              defaults.additionalDirectories,
+              native.additionalDirectories,
               source,
-              "providers.codex.defaults.additionalDirectories",
+              "providers.codex.native.additionalDirectories",
             ),
           },
+    policy: parseOptionalExecutionPolicy(
+      getProviderPolicySource(provider),
+      source,
+      provider.policy !== undefined
+        ? "providers.codex.policy"
+        : "providers.codex.defaults",
+    ),
   };
 }
 
@@ -519,10 +540,19 @@ function normalizeExaProvider(raw: unknown, source: string): ExaProviderConfig {
       source,
       "providers.exa.baseUrl",
     ),
-    defaults: parseOptionalJsonObject(
-      provider.defaults,
+    native: parseOptionalJsonObject(
+      stripPolicyFields(getProviderNativeSource(provider)),
       source,
-      "providers.exa.defaults",
+      provider.native !== undefined
+        ? "providers.exa.native"
+        : "providers.exa.defaults",
+    ),
+    policy: parseOptionalExecutionPolicy(
+      getProviderPolicySource(provider),
+      source,
+      provider.policy !== undefined
+        ? "providers.exa.policy"
+        : "providers.exa.defaults",
     ),
   };
 }
@@ -554,10 +584,19 @@ function normalizeValyuProvider(
       source,
       "providers.valyu.baseUrl",
     ),
-    defaults: parseOptionalJsonObject(
-      provider.defaults,
+    native: parseOptionalJsonObject(
+      stripPolicyFields(getProviderNativeSource(provider)),
       source,
-      "providers.valyu.defaults",
+      provider.native !== undefined
+        ? "providers.valyu.native"
+        : "providers.valyu.defaults",
+    ),
+    policy: parseOptionalExecutionPolicy(
+      getProviderPolicySource(provider),
+      source,
+      provider.policy !== undefined
+        ? "providers.valyu.policy"
+        : "providers.valyu.defaults",
     ),
   };
 }
@@ -567,10 +606,12 @@ function normalizeGeminiProvider(
   source: string,
 ): GeminiProviderConfig {
   const provider = parseProviderObject(raw, source, "gemini");
-  const defaults = parseOptionalJsonObject(
-    provider.defaults,
+  const native = parseOptionalJsonObject(
+    stripPolicyFields(getProviderNativeSource(provider)),
     source,
-    "providers.gemini.defaults",
+    provider.native !== undefined
+      ? "providers.gemini.native"
+      : "providers.gemini.defaults",
   );
 
   return {
@@ -590,66 +631,43 @@ function normalizeGeminiProvider(
       source,
       "providers.gemini.apiKey",
     ),
-    defaults:
-      defaults === undefined
+    native:
+      native === undefined
         ? undefined
         : {
             apiVersion: parseOptionalString(
-              defaults.apiVersion,
+              native.apiVersion,
               source,
-              "providers.gemini.defaults.apiVersion",
+              "providers.gemini.native.apiVersion",
             ),
             searchModel: parseOptionalString(
-              defaults.searchModel,
+              native.searchModel,
               source,
-              "providers.gemini.defaults.searchModel",
+              "providers.gemini.native.searchModel",
             ),
             contentsModel: parseOptionalString(
-              defaults.contentsModel,
+              native.contentsModel,
               source,
-              "providers.gemini.defaults.contentsModel",
+              "providers.gemini.native.contentsModel",
             ),
             answerModel: parseOptionalString(
-              defaults.answerModel,
+              native.answerModel,
               source,
-              "providers.gemini.defaults.answerModel",
+              "providers.gemini.native.answerModel",
             ),
             researchAgent: parseOptionalString(
-              defaults.researchAgent,
+              native.researchAgent,
               source,
-              "providers.gemini.defaults.researchAgent",
-            ),
-            requestTimeoutMs: parseOptionalInteger(
-              defaults.requestTimeoutMs,
-              source,
-              "providers.gemini.defaults.requestTimeoutMs",
-            ),
-            retryCount: parseOptionalNonNegativeInteger(
-              defaults.retryCount,
-              source,
-              "providers.gemini.defaults.retryCount",
-            ),
-            retryDelayMs: parseOptionalInteger(
-              defaults.retryDelayMs,
-              source,
-              "providers.gemini.defaults.retryDelayMs",
-            ),
-            researchPollIntervalMs: parseOptionalInteger(
-              defaults.researchPollIntervalMs,
-              source,
-              "providers.gemini.defaults.researchPollIntervalMs",
-            ),
-            researchTimeoutMs: parseOptionalInteger(
-              defaults.researchTimeoutMs,
-              source,
-              "providers.gemini.defaults.researchTimeoutMs",
-            ),
-            researchMaxConsecutivePollErrors: parseOptionalInteger(
-              defaults.researchMaxConsecutivePollErrors,
-              source,
-              "providers.gemini.defaults.researchMaxConsecutivePollErrors",
+              "providers.gemini.native.researchAgent",
             ),
           },
+    policy: parseOptionalExecutionPolicy(
+      getProviderPolicySource(provider),
+      source,
+      provider.policy !== undefined
+        ? "providers.gemini.policy"
+        : "providers.gemini.defaults",
+    ),
   };
 }
 
@@ -658,10 +676,12 @@ function normalizePerplexityProvider(
   source: string,
 ): PerplexityProviderConfig {
   const provider = parseProviderObject(raw, source, "perplexity");
-  const defaults = parseOptionalJsonObject(
-    provider.defaults,
+  const native = parseOptionalJsonObject(
+    stripPolicyFields(getProviderNativeSource(provider)),
     source,
-    "providers.perplexity.defaults",
+    provider.native !== undefined
+      ? "providers.perplexity.native"
+      : "providers.perplexity.defaults",
   );
 
   return {
@@ -686,26 +706,33 @@ function normalizePerplexityProvider(
       source,
       "providers.perplexity.baseUrl",
     ),
-    defaults:
-      defaults === undefined
+    native:
+      native === undefined
         ? undefined
         : {
             search: parseOptionalJsonObject(
-              defaults.search,
+              native.search,
               source,
-              "providers.perplexity.defaults.search",
+              "providers.perplexity.native.search",
             ),
             answer: parseOptionalJsonObject(
-              defaults.answer,
+              native.answer,
               source,
-              "providers.perplexity.defaults.answer",
+              "providers.perplexity.native.answer",
             ),
             research: parseOptionalJsonObject(
-              defaults.research,
+              native.research,
               source,
-              "providers.perplexity.defaults.research",
+              "providers.perplexity.native.research",
             ),
           },
+    policy: parseOptionalExecutionPolicy(
+      getProviderPolicySource(provider),
+      source,
+      provider.policy !== undefined
+        ? "providers.perplexity.policy"
+        : "providers.perplexity.defaults",
+    ),
   };
 }
 
@@ -714,10 +741,12 @@ function normalizeParallelProvider(
   source: string,
 ): ParallelProviderConfig {
   const provider = parseProviderObject(raw, source, "parallel");
-  const defaults = parseOptionalJsonObject(
-    provider.defaults,
+  const native = parseOptionalJsonObject(
+    stripPolicyFields(getProviderNativeSource(provider)),
     source,
-    "providers.parallel.defaults",
+    provider.native !== undefined
+      ? "providers.parallel.native"
+      : "providers.parallel.defaults",
   );
 
   return {
@@ -742,22 +771,107 @@ function normalizeParallelProvider(
       source,
       "providers.parallel.baseUrl",
     ),
-    defaults:
-      defaults === undefined
+    native:
+      native === undefined
         ? undefined
         : {
             search: parseOptionalJsonObject(
-              defaults.search,
+              native.search,
               source,
-              "providers.parallel.defaults.search",
+              "providers.parallel.native.search",
             ),
             extract: parseOptionalJsonObject(
-              defaults.extract,
+              native.extract,
               source,
-              "providers.parallel.defaults.extract",
+              "providers.parallel.native.extract",
             ),
           },
+    policy: parseOptionalExecutionPolicy(
+      getProviderPolicySource(provider),
+      source,
+      provider.policy !== undefined
+        ? "providers.parallel.policy"
+        : "providers.parallel.defaults",
+    ),
   };
+}
+
+function getProviderNativeSource(provider: JsonObject): unknown {
+  return provider.native ?? provider.defaults;
+}
+
+function getProviderPolicySource(provider: JsonObject): unknown {
+  return provider.policy ?? provider.defaults;
+}
+
+function stripPolicyFields(value: unknown): JsonObject | undefined {
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+
+  const {
+    requestTimeoutMs: _requestTimeoutMs,
+    retryCount: _retryCount,
+    retryDelayMs: _retryDelayMs,
+    researchPollIntervalMs: _researchPollIntervalMs,
+    researchTimeoutMs: _researchTimeoutMs,
+    researchMaxConsecutivePollErrors: _researchMaxConsecutivePollErrors,
+    ...native
+  } = value;
+
+  return Object.keys(native).length > 0 ? native : undefined;
+}
+
+function parseOptionalExecutionPolicy(
+  value: unknown,
+  source: string,
+  field: string,
+): ExecutionPolicyDefaults | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const policy = parseOptionalJsonObject(value, source, field);
+  if (!policy) {
+    return undefined;
+  }
+
+  const parsed: ExecutionPolicyDefaults = {
+    requestTimeoutMs: parseOptionalInteger(
+      policy.requestTimeoutMs,
+      source,
+      `${field}.requestTimeoutMs`,
+    ),
+    retryCount: parseOptionalNonNegativeInteger(
+      policy.retryCount,
+      source,
+      `${field}.retryCount`,
+    ),
+    retryDelayMs: parseOptionalInteger(
+      policy.retryDelayMs,
+      source,
+      `${field}.retryDelayMs`,
+    ),
+    researchPollIntervalMs: parseOptionalInteger(
+      policy.researchPollIntervalMs,
+      source,
+      `${field}.researchPollIntervalMs`,
+    ),
+    researchTimeoutMs: parseOptionalInteger(
+      policy.researchTimeoutMs,
+      source,
+      `${field}.researchTimeoutMs`,
+    ),
+    researchMaxConsecutivePollErrors: parseOptionalInteger(
+      policy.researchMaxConsecutivePollErrors,
+      source,
+      `${field}.researchMaxConsecutivePollErrors`,
+    ),
+  };
+
+  return Object.values(parsed).some((entry) => entry !== undefined)
+    ? parsed
+    : undefined;
 }
 
 function parseProviderObject(

--- a/src/execution-policy-defaults.ts
+++ b/src/execution-policy-defaults.ts
@@ -1,0 +1,40 @@
+import type { ExecutionPolicyDefaults } from "./types.js";
+
+export const DEFAULT_REQUEST_TIMEOUT_MS = 30000;
+export const DEFAULT_RETRY_COUNT = 3;
+export const DEFAULT_RETRY_DELAY_MS = 2000;
+export const DEFAULT_RESEARCH_POLL_INTERVAL_MS = 3000;
+export const DEFAULT_RESEARCH_TIMEOUT_MS = 21600000;
+export const DEFAULT_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS = 3;
+export const DEFAULT_GEMINI_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS = 10;
+
+export function createDefaultRequestPolicy(): ExecutionPolicyDefaults {
+  return {
+    requestTimeoutMs: DEFAULT_REQUEST_TIMEOUT_MS,
+    retryCount: DEFAULT_RETRY_COUNT,
+    retryDelayMs: DEFAULT_RETRY_DELAY_MS,
+  };
+}
+
+export function createDefaultLifecyclePolicy(
+  overrides: Partial<
+    Pick<
+      ExecutionPolicyDefaults,
+      | "requestTimeoutMs"
+      | "retryCount"
+      | "retryDelayMs"
+      | "researchPollIntervalMs"
+      | "researchTimeoutMs"
+      | "researchMaxConsecutivePollErrors"
+    >
+  > = {},
+): ExecutionPolicyDefaults {
+  return {
+    ...createDefaultRequestPolicy(),
+    researchPollIntervalMs: DEFAULT_RESEARCH_POLL_INTERVAL_MS,
+    researchTimeoutMs: DEFAULT_RESEARCH_TIMEOUT_MS,
+    researchMaxConsecutivePollErrors:
+      DEFAULT_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS,
+    ...overrides,
+  };
+}

--- a/src/execution-policy.ts
+++ b/src/execution-policy.ts
@@ -28,6 +28,10 @@ class RequestTimeoutError extends Error {
   override name = "RequestTimeoutError";
 }
 
+class NonResumableResearchError extends Error {
+  override name = "NonResumableResearchError";
+}
+
 export function stripLocalExecutionOptions(
   options: JsonObject | undefined,
 ): JsonObject | undefined {
@@ -105,7 +109,7 @@ export function resolveResearchExecutionPolicy(
 
 export async function runWithExecutionPolicy<T>(
   label: string,
-  operation: () => Promise<T>,
+  operation: (context: ProviderContext) => Promise<T>,
   policy: RequestExecutionPolicy,
   context: ProviderContext,
 ): Promise<T> {
@@ -114,16 +118,24 @@ export async function runWithExecutionPolicy<T>(
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     throwIfAborted(context.signal);
 
+    const {
+      context: attemptContext,
+      abort,
+      cleanup,
+    } = createAttemptContext(context);
+
     try {
-      const result = operation();
+      const result = operation(attemptContext);
       if (policy.requestTimeoutMs === undefined) {
         return await result;
       }
+      const timeoutMessage = `${label} timed out after ${formatDuration(policy.requestTimeoutMs)}.`;
       return await withTimeout(
         result,
         policy.requestTimeoutMs,
         context.signal,
-        `${label} timed out after ${formatDuration(policy.requestTimeoutMs)}.`,
+        timeoutMessage,
+        () => abort(new RequestTimeoutError(timeoutMessage)),
       );
     } catch (error) {
       if (!isRetryableError(error) || attempt >= maxAttempts) {
@@ -138,6 +150,8 @@ export async function runWithExecutionPolicy<T>(
         `${label} failed (${formatErrorMessage(error)}). Retrying in ${formatDuration(delayMs)} (attempt ${attempt + 1}/${maxAttempts}).`,
       );
       await sleep(delayMs, context.signal);
+    } finally {
+      cleanup();
     }
   }
 
@@ -182,8 +196,11 @@ export async function executeResearchWithLifecycle({
     context.onProgress?.(`Starting ${providerLabel} research`);
     const job = await runWithExecutionPolicy(
       `${providerLabel} research start`,
-      () => start(input, providerOptions, context),
-      policy,
+      (attemptContext) => start(input, providerOptions, attemptContext),
+      {
+        ...policy,
+        retryCount: 0,
+      },
       context,
     );
     jobId = job.id;
@@ -208,7 +225,7 @@ export async function executeResearchWithLifecycle({
     try {
       const result = await runWithExecutionPolicy(
         `${providerLabel} research poll`,
-        () => poll(jobId, providerOptions, context),
+        (attemptContext) => poll(jobId, providerOptions, attemptContext),
         policy,
         context,
       );
@@ -232,12 +249,14 @@ export async function executeResearchWithLifecycle({
       }
 
       if (result.status === "failed" || result.status === "cancelled") {
-        throw buildResumeError(
+        throw new NonResumableResearchError(
           result.error || `${providerLabel} research ${result.status}.`,
-          jobId,
         );
       }
     } catch (error) {
+      if (error instanceof NonResumableResearchError) {
+        throw error;
+      }
       if (!isRetryableError(error)) {
         throw buildResumeError(error, jobId);
       }
@@ -261,7 +280,7 @@ export async function executeResearchWithLifecycle({
 
 export function isRetryableError(error: unknown): boolean {
   if (error instanceof RequestTimeoutError) {
-    return true;
+    return false;
   }
 
   const message = formatErrorMessage(error).toLowerCase();
@@ -344,16 +363,45 @@ export function throwIfAborted(
   }
 }
 
+function createAttemptContext(context: ProviderContext): {
+  context: ProviderContext;
+  abort: (reason?: unknown) => void;
+  cleanup: () => void;
+} {
+  const controller = new AbortController();
+
+  if (context.signal?.aborted) {
+    controller.abort(context.signal.reason);
+  }
+
+  const onAbort = () => {
+    controller.abort(context.signal?.reason);
+  };
+
+  context.signal?.addEventListener("abort", onAbort, { once: true });
+
+  return {
+    context: {
+      ...context,
+      signal: controller.signal,
+    },
+    abort: (reason?: unknown) => controller.abort(reason),
+    cleanup: () => context.signal?.removeEventListener("abort", onAbort),
+  };
+}
+
 async function withTimeout<T>(
   promise: Promise<T>,
   timeoutMs: number,
   signal: AbortSignal | undefined,
   message: string,
+  onTimeout?: () => void,
 ): Promise<T> {
   throwIfAborted(signal);
 
   return await new Promise<T>((resolve, reject) => {
     const timer = setTimeout(() => {
+      onTimeout?.();
       cleanup();
       reject(new RequestTimeoutError(message));
     }, timeoutMs);

--- a/src/execution-policy.ts
+++ b/src/execution-policy.ts
@@ -1,5 +1,5 @@
 import type {
-  GeminiProviderConfig,
+  ExecutionPolicyDefaults,
   JsonObject,
   ProviderContext,
   ProviderId,
@@ -34,7 +34,7 @@ class NonResumableResearchError extends Error {
 }
 
 export function stripLocalExecutionOptions(
-  options: JsonObject | undefined,
+  options: Record<string, unknown> | JsonObject | undefined,
 ): JsonObject | undefined {
   if (!options) {
     return undefined;
@@ -51,55 +51,66 @@ export function stripLocalExecutionOptions(
     ...rest
   } = options;
 
-  return Object.keys(rest).length > 0 ? rest : undefined;
+  return Object.keys(rest).length > 0 ? (rest as JsonObject) : undefined;
+}
+
+export function extractExecutionPolicyDefaults(
+  options: Record<string, unknown> | JsonObject | undefined,
+): ExecutionPolicyDefaults | undefined {
+  if (!options) {
+    return undefined;
+  }
+
+  const defaults: ExecutionPolicyDefaults = {
+    requestTimeoutMs: readPositiveInteger(options.requestTimeoutMs),
+    retryCount: readNonNegativeInteger(options.retryCount),
+    retryDelayMs: readPositiveInteger(options.retryDelayMs),
+    researchPollIntervalMs: readPositiveInteger(options.pollIntervalMs),
+    researchTimeoutMs: readPositiveInteger(options.timeoutMs),
+    researchMaxConsecutivePollErrors: readPositiveInteger(
+      options.maxConsecutivePollErrors,
+    ),
+  };
+
+  return Object.values(defaults).some((value) => value !== undefined)
+    ? defaults
+    : undefined;
 }
 
 export function resolveRequestExecutionPolicy(
-  providerId: ProviderId,
-  providerConfig: unknown,
   options: JsonObject | undefined,
+  defaults: ExecutionPolicyDefaults | undefined,
 ): RequestExecutionPolicy {
-  const geminiDefaults = getGeminiDefaults(providerId, providerConfig);
-
   return {
     requestTimeoutMs:
       readPositiveInteger(options?.requestTimeoutMs) ??
-      geminiDefaults?.requestTimeoutMs,
+      defaults?.requestTimeoutMs,
     retryCount:
-      readNonNegativeInteger(options?.retryCount) ??
-      geminiDefaults?.retryCount ??
-      0,
+      readNonNegativeInteger(options?.retryCount) ?? defaults?.retryCount ?? 0,
     retryDelayMs:
       readPositiveInteger(options?.retryDelayMs) ??
-      geminiDefaults?.retryDelayMs ??
+      defaults?.retryDelayMs ??
       2000,
   };
 }
 
 export function resolveResearchExecutionPolicy(
-  providerId: ProviderId,
-  providerConfig: unknown,
   options: JsonObject | undefined,
+  defaults: ExecutionPolicyDefaults | undefined,
 ): ResearchExecutionPolicy {
-  const request = resolveRequestExecutionPolicy(
-    providerId,
-    providerConfig,
-    options,
-  );
-  const geminiDefaults = getGeminiDefaults(providerId, providerConfig);
+  const request = resolveRequestExecutionPolicy(options, defaults);
 
   return {
     ...request,
     pollIntervalMs:
       readPositiveInteger(options?.pollIntervalMs) ??
-      geminiDefaults?.researchPollIntervalMs ??
+      defaults?.researchPollIntervalMs ??
       DEFAULT_RESEARCH_POLL_INTERVAL_MS,
     timeoutMs:
-      readPositiveInteger(options?.timeoutMs) ??
-      geminiDefaults?.researchTimeoutMs,
+      readPositiveInteger(options?.timeoutMs) ?? defaults?.researchTimeoutMs,
     maxConsecutivePollErrors:
       readPositiveInteger(options?.maxConsecutivePollErrors) ??
-      geminiDefaults?.researchMaxConsecutivePollErrors ??
+      defaults?.researchMaxConsecutivePollErrors ??
       3,
     resumeId: readNonEmptyString(options?.resumeId),
   };
@@ -161,8 +172,6 @@ export async function runWithExecutionPolicy<T>(
 export async function executeResearchWithLifecycle({
   providerLabel,
   providerId,
-  input,
-  options,
   context,
   policy,
   startRetryCount = 0,
@@ -177,8 +186,6 @@ export async function executeResearchWithLifecycle({
 }: {
   providerLabel: string;
   providerId: ProviderId;
-  input: string;
-  options: JsonObject | undefined;
   context: ProviderContext;
   policy: ResearchExecutionPolicy;
   startRetryCount?: number;
@@ -188,18 +195,12 @@ export async function executeResearchWithLifecycle({
   startRequestTimeoutMs?: number | null;
   pollRequestTimeoutMs?: number | null;
   deferDeadlineUntilStarted?: boolean;
-  start: (
-    input: string,
-    options: JsonObject | undefined,
-    context: ProviderContext,
-  ) => Promise<ProviderResearchJob>;
+  start: (context: ProviderContext) => Promise<ProviderResearchJob>;
   poll: (
     id: string,
-    options: JsonObject | undefined,
     context: ProviderContext,
   ) => Promise<ProviderResearchPollResult>;
 }): Promise<ProviderToolOutput> {
-  const providerOptions = stripLocalExecutionOptions(options);
   const effectiveStartRequestTimeoutMs =
     startRequestTimeoutMs === undefined
       ? policy.requestTimeoutMs
@@ -255,7 +256,7 @@ export async function executeResearchWithLifecycle({
       const job = await runWithExecutionPolicy(
         `${providerLabel} research start`,
         (attemptContext) =>
-          start(input, providerOptions, {
+          start({
             ...attemptContext,
             idempotencyKey: startIdempotencyKey,
           }),
@@ -291,7 +292,7 @@ export async function executeResearchWithLifecycle({
       try {
         const result = await runWithExecutionPolicy(
           `${providerLabel} research poll`,
-          (attemptContext) => poll(jobId!, providerOptions, attemptContext),
+          (attemptContext) => poll(jobId!, attemptContext),
           {
             ...policy,
             requestTimeoutMs: effectivePollRequestTimeoutMs,
@@ -609,17 +610,6 @@ function buildResumeError(error: string | unknown, jobId: string): Error {
   return new Error(
     `${message} Resume the background job with options.resumeId=${JSON.stringify(jobId)}.`,
   );
-}
-
-function getGeminiDefaults(
-  providerId: ProviderId,
-  providerConfig: unknown,
-): GeminiProviderConfig["defaults"] | undefined {
-  if (providerId !== "gemini") {
-    return undefined;
-  }
-
-  return (providerConfig as GeminiProviderConfig | undefined)?.defaults;
 }
 
 function readPositiveInteger(value: unknown): number | undefined {

--- a/src/execution-policy.ts
+++ b/src/execution-policy.ts
@@ -15,6 +15,7 @@ export interface RequestExecutionPolicy {
   requestTimeoutMs?: number;
   retryCount: number;
   retryDelayMs: number;
+  retryOnTimeout?: boolean;
 }
 
 export interface ResearchExecutionPolicy extends RequestExecutionPolicy {
@@ -140,7 +141,7 @@ export async function runWithExecutionPolicy<T>(
           : undefined,
       );
     } catch (error) {
-      if (!isRetryableError(error) || attempt >= maxAttempts) {
+      if (!shouldRetryError(error, policy) || attempt >= maxAttempts) {
         throw error;
       }
 
@@ -170,6 +171,8 @@ export async function executeResearchWithLifecycle({
   startRetryCount = 0,
   startRetryNotice,
   startIdempotencyKey,
+  startRetryOnTimeout = false,
+  pollRequestTimeoutMs,
   start,
   poll,
 }: {
@@ -182,6 +185,8 @@ export async function executeResearchWithLifecycle({
   startRetryCount?: number;
   startRetryNotice?: string;
   startIdempotencyKey?: string;
+  startRetryOnTimeout?: boolean;
+  pollRequestTimeoutMs?: number | null;
   start: (
     input: string,
     options: JsonObject | undefined,
@@ -196,6 +201,10 @@ export async function executeResearchWithLifecycle({
   const startedAt = Date.now();
   let lastStatus: ProviderResearchPollResult["status"] | undefined;
   const providerOptions = stripLocalExecutionOptions(options);
+  const effectivePollRequestTimeoutMs =
+    pollRequestTimeoutMs === undefined
+      ? policy.requestTimeoutMs
+      : (pollRequestTimeoutMs ?? undefined);
   const timeoutMessage =
     policy.timeoutMs === undefined
       ? undefined
@@ -229,6 +238,7 @@ export async function executeResearchWithLifecycle({
         {
           ...policy,
           retryCount: startRetryCount,
+          retryOnTimeout: startRetryOnTimeout,
         },
         lifecycleContext,
       );
@@ -254,7 +264,10 @@ export async function executeResearchWithLifecycle({
         const result = await runWithExecutionPolicy(
           `${providerLabel} research poll`,
           (attemptContext) => poll(jobId!, providerOptions, attemptContext),
-          policy,
+          {
+            ...policy,
+            requestTimeoutMs: effectivePollRequestTimeoutMs,
+          },
           lifecycleContext,
         );
         consecutivePollErrors = 0;
@@ -318,6 +331,17 @@ export async function executeResearchWithLifecycle({
   } finally {
     cleanupLifecycle();
   }
+}
+
+function shouldRetryError(
+  error: unknown,
+  policy: Pick<RequestExecutionPolicy, "retryOnTimeout">,
+): boolean {
+  if (error instanceof RequestTimeoutError) {
+    return policy.retryOnTimeout === true;
+  }
+
+  return isRetryableError(error);
 }
 
 export function isRetryableError(error: unknown): boolean {

--- a/src/execution-policy.ts
+++ b/src/execution-policy.ts
@@ -126,16 +126,18 @@ export async function runWithExecutionPolicy<T>(
 
     try {
       const result = operation(attemptContext);
-      if (policy.requestTimeoutMs === undefined) {
-        return await result;
-      }
-      const timeoutMessage = `${label} timed out after ${formatDuration(policy.requestTimeoutMs)}.`;
-      return await withTimeout(
+      const timeoutMessage =
+        policy.requestTimeoutMs === undefined
+          ? undefined
+          : `${label} timed out after ${formatDuration(policy.requestTimeoutMs)}.`;
+      return await withAbortAndOptionalTimeout(
         result,
         policy.requestTimeoutMs,
         context.signal,
         timeoutMessage,
-        () => abort(new RequestTimeoutError(timeoutMessage)),
+        timeoutMessage
+          ? () => abort(new RequestTimeoutError(timeoutMessage))
+          : undefined,
       );
     } catch (error) {
       if (!isRetryableError(error) || attempt >= maxAttempts) {
@@ -165,6 +167,9 @@ export async function executeResearchWithLifecycle({
   options,
   context,
   policy,
+  startRetryCount = 0,
+  startRetryNotice,
+  startIdempotencyKey,
   start,
   poll,
 }: {
@@ -174,6 +179,9 @@ export async function executeResearchWithLifecycle({
   options: JsonObject | undefined;
   context: ProviderContext;
   policy: ResearchExecutionPolicy;
+  startRetryCount?: number;
+  startRetryNotice?: string;
+  startIdempotencyKey?: string;
   start: (
     input: string,
     options: JsonObject | undefined,
@@ -208,12 +216,19 @@ export async function executeResearchWithLifecycle({
       );
     } else {
       lifecycleContext.onProgress?.(`Starting ${providerLabel} research`);
+      if (startRetryNotice) {
+        lifecycleContext.onProgress?.(startRetryNotice);
+      }
       const job = await runWithExecutionPolicy(
         `${providerLabel} research start`,
-        (attemptContext) => start(input, providerOptions, attemptContext),
+        (attemptContext) =>
+          start(input, providerOptions, {
+            ...attemptContext,
+            idempotencyKey: startIdempotencyKey,
+          }),
         {
           ...policy,
-          retryCount: 0,
+          retryCount: startRetryCount,
         },
         lifecycleContext,
       );
@@ -417,21 +432,33 @@ function createAttemptContext(context: ProviderContext): {
   };
 }
 
-async function withTimeout<T>(
+async function withAbortAndOptionalTimeout<T>(
   promise: Promise<T>,
-  timeoutMs: number,
+  timeoutMs: number | undefined,
   signal: AbortSignal | undefined,
-  message: string,
+  message: string | undefined,
   onTimeout?: () => void,
 ): Promise<T> {
+  if (timeoutMs === undefined && !signal) {
+    return await promise;
+  }
+
   throwIfAborted(signal);
 
   return await new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => {
-      onTimeout?.();
-      cleanup();
-      reject(new RequestTimeoutError(message));
-    }, timeoutMs);
+    const timer =
+      timeoutMs === undefined
+        ? undefined
+        : setTimeout(() => {
+            onTimeout?.();
+            cleanup();
+            reject(
+              new RequestTimeoutError(
+                message ??
+                  `Operation timed out after ${formatDuration(timeoutMs)}.`,
+              ),
+            );
+          }, timeoutMs);
 
     const onAbort = () => {
       cleanup();
@@ -439,7 +466,9 @@ async function withTimeout<T>(
     };
 
     const cleanup = () => {
-      clearTimeout(timer);
+      if (timer) {
+        clearTimeout(timer);
+      }
       signal?.removeEventListener("abort", onAbort);
     };
 

--- a/src/execution-policy.ts
+++ b/src/execution-policy.ts
@@ -206,7 +206,6 @@ export async function executeResearchWithLifecycle({
   startRetryOnTimeout = false,
   startRequestTimeoutMs,
   pollRequestTimeoutMs,
-  deferDeadlineUntilStarted = false,
   start,
   poll,
 }: {
@@ -220,7 +219,6 @@ export async function executeResearchWithLifecycle({
   startRetryOnTimeout?: boolean;
   startRequestTimeoutMs?: number | null;
   pollRequestTimeoutMs?: number | null;
-  deferDeadlineUntilStarted?: boolean;
   start: (context: ProviderContext) => Promise<ProviderResearchJob>;
   poll: (
     id: string,
@@ -265,9 +263,7 @@ export async function executeResearchWithLifecycle({
   };
 
   let jobId = policy.resumeId;
-  if (jobId || !deferDeadlineUntilStarted) {
-    activateLifecycleDeadline();
-  }
+  activateLifecycleDeadline();
 
   try {
     if (jobId) {
@@ -295,9 +291,6 @@ export async function executeResearchWithLifecycle({
         lifecycleContext,
       );
       jobId = job.id;
-      if (deferDeadlineUntilStarted) {
-        activateLifecycleDeadline();
-      }
       lifecycleContext.onProgress?.(
         `${providerLabel} research started: ${jobId}`,
       );
@@ -379,8 +372,13 @@ export async function executeResearchWithLifecycle({
       await sleep(policy.pollIntervalMs, lifecycleContext.signal);
     }
   } catch (error) {
-    if (jobId && isAbortErrorFromSignal(lifecycleContext.signal, error)) {
-      throw buildResumeError(error, jobId);
+    if (isAbortErrorFromSignal(lifecycleContext.signal, error)) {
+      if (jobId) {
+        throw buildResumeError(error, jobId);
+      }
+      if (error instanceof RequestTimeoutError) {
+        throw buildUnknownResearchStartError(error);
+      }
     }
     throw error;
   } finally {
@@ -635,6 +633,13 @@ function buildResumeError(error: string | unknown, jobId: string): Error {
   const message = typeof error === "string" ? error : formatErrorMessage(error);
   return new Error(
     `${message} Resume the background job with options.resumeId=${JSON.stringify(jobId)}.`,
+  );
+}
+
+function buildUnknownResearchStartError(error: string | unknown): Error {
+  const message = typeof error === "string" ? error : formatErrorMessage(error);
+  return new Error(
+    `${message} The provider may still create a background job, but no job id was returned so this run cannot be resumed automatically.`,
   );
 }
 

--- a/src/execution-policy.ts
+++ b/src/execution-policy.ts
@@ -171,6 +171,7 @@ export async function executeResearchWithLifecycle({
   startRetryOnTimeout = false,
   startRequestTimeoutMs,
   pollRequestTimeoutMs,
+  deferDeadlineUntilStarted = false,
   start,
   poll,
 }: {
@@ -186,6 +187,7 @@ export async function executeResearchWithLifecycle({
   startRetryOnTimeout?: boolean;
   startRequestTimeoutMs?: number | null;
   pollRequestTimeoutMs?: number | null;
+  deferDeadlineUntilStarted?: boolean;
   start: (
     input: string,
     options: JsonObject | undefined,
@@ -197,8 +199,6 @@ export async function executeResearchWithLifecycle({
     context: ProviderContext,
   ) => Promise<ProviderResearchPollResult>;
 }): Promise<ProviderToolOutput> {
-  const startedAt = Date.now();
-  let lastStatus: ProviderResearchPollResult["status"] | undefined;
   const providerOptions = stripLocalExecutionOptions(options);
   const effectiveStartRequestTimeoutMs =
     startRequestTimeoutMs === undefined
@@ -212,14 +212,35 @@ export async function executeResearchWithLifecycle({
     policy.timeoutMs === undefined
       ? undefined
       : `${providerLabel} research exceeded ${formatDuration(policy.timeoutMs)}.`;
-  const { signal: lifecycleSignal, cleanup: cleanupLifecycle } =
-    createDeadlineSignal(context.signal, policy.timeoutMs, timeoutMessage);
-  const lifecycleContext: ProviderContext = {
+
+  let lastStatus: ProviderResearchPollResult["status"] | undefined;
+  let lifecycleStartedAt = Date.now();
+  let lifecycleSignal = context.signal;
+  let cleanupLifecycle = () => {};
+  let lifecycleContext: ProviderContext = {
     ...context,
     signal: lifecycleSignal,
   };
 
+  const activateLifecycleDeadline = () => {
+    const deadline = createDeadlineSignal(
+      context.signal,
+      policy.timeoutMs,
+      timeoutMessage,
+    );
+    lifecycleSignal = deadline.signal;
+    cleanupLifecycle = deadline.cleanup;
+    lifecycleStartedAt = Date.now();
+    lifecycleContext = {
+      ...context,
+      signal: lifecycleSignal,
+    };
+  };
+
   let jobId = policy.resumeId;
+  if (jobId || !deferDeadlineUntilStarted) {
+    activateLifecycleDeadline();
+  }
 
   try {
     if (jobId) {
@@ -247,6 +268,9 @@ export async function executeResearchWithLifecycle({
         lifecycleContext,
       );
       jobId = job.id;
+      if (deferDeadlineUntilStarted) {
+        activateLifecycleDeadline();
+      }
       lifecycleContext.onProgress?.(
         `${providerLabel} research started: ${jobId}`,
       );
@@ -278,7 +302,7 @@ export async function executeResearchWithLifecycle({
 
         if (result.status !== lastStatus) {
           lifecycleContext.onProgress?.(
-            `${providerLabel} research status: ${result.status} (${formatElapsed(Date.now() - startedAt)} elapsed)`,
+            `${providerLabel} research status: ${result.status} (${formatElapsed(Date.now() - lifecycleStartedAt)} elapsed)`,
           );
           lastStatus = result.status;
         }

--- a/src/execution-policy.ts
+++ b/src/execution-policy.ts
@@ -188,93 +188,120 @@ export async function executeResearchWithLifecycle({
   const startedAt = Date.now();
   let lastStatus: ProviderResearchPollResult["status"] | undefined;
   const providerOptions = stripLocalExecutionOptions(options);
+  const timeoutMessage =
+    policy.timeoutMs === undefined
+      ? undefined
+      : `${providerLabel} research exceeded ${formatDuration(policy.timeoutMs)}.`;
+  const { signal: lifecycleSignal, cleanup: cleanupLifecycle } =
+    createDeadlineSignal(context.signal, policy.timeoutMs, timeoutMessage);
+  const lifecycleContext: ProviderContext = {
+    ...context,
+    signal: lifecycleSignal,
+  };
 
   let jobId = policy.resumeId;
-  if (jobId) {
-    context.onProgress?.(`Resuming ${providerLabel} research: ${jobId}`);
-  } else {
-    context.onProgress?.(`Starting ${providerLabel} research`);
-    const job = await runWithExecutionPolicy(
-      `${providerLabel} research start`,
-      (attemptContext) => start(input, providerOptions, attemptContext),
-      {
-        ...policy,
-        retryCount: 0,
-      },
-      context,
-    );
-    jobId = job.id;
-    context.onProgress?.(`${providerLabel} research started: ${jobId}`);
-  }
 
-  let consecutivePollErrors = 0;
-
-  while (true) {
-    throwIfAborted(context.signal, `${providerLabel} research aborted.`);
-
-    if (
-      policy.timeoutMs !== undefined &&
-      Date.now() - startedAt > policy.timeoutMs
-    ) {
-      throw buildResumeError(
-        `${providerLabel} research exceeded ${formatDuration(policy.timeoutMs)}.`,
-        jobId,
+  try {
+    if (jobId) {
+      lifecycleContext.onProgress?.(
+        `Resuming ${providerLabel} research: ${jobId}`,
+      );
+    } else {
+      lifecycleContext.onProgress?.(`Starting ${providerLabel} research`);
+      const job = await runWithExecutionPolicy(
+        `${providerLabel} research start`,
+        (attemptContext) => start(input, providerOptions, attemptContext),
+        {
+          ...policy,
+          retryCount: 0,
+        },
+        lifecycleContext,
+      );
+      jobId = job.id;
+      lifecycleContext.onProgress?.(
+        `${providerLabel} research started: ${jobId}`,
       );
     }
 
-    try {
-      const result = await runWithExecutionPolicy(
-        `${providerLabel} research poll`,
-        (attemptContext) => poll(jobId, providerOptions, attemptContext),
-        policy,
-        context,
-      );
-      consecutivePollErrors = 0;
-
-      if (result.status !== lastStatus) {
-        context.onProgress?.(
-          `${providerLabel} research status: ${result.status} (${formatElapsed(Date.now() - startedAt)} elapsed)`,
-        );
-        lastStatus = result.status;
-      }
-
-      if (result.status === "completed") {
-        return (
-          result.output ?? {
-            provider: providerId,
-            text: `${providerLabel} research completed without textual output.`,
-            summary: `Research via ${providerLabel}`,
-          }
-        );
-      }
-
-      if (result.status === "failed" || result.status === "cancelled") {
-        throw new NonResumableResearchError(
-          result.error || `${providerLabel} research ${result.status}.`,
-        );
-      }
-    } catch (error) {
-      if (error instanceof NonResumableResearchError) {
-        throw error;
-      }
-      if (!isRetryableError(error)) {
-        throw buildResumeError(error, jobId);
-      }
-
-      consecutivePollErrors += 1;
-      if (consecutivePollErrors >= policy.maxConsecutivePollErrors) {
-        throw buildResumeError(
-          `${providerLabel} research polling failed too many times in a row: ${formatErrorMessage(error)}`,
-          jobId,
-        );
-      }
-
-      context.onProgress?.(
-        `${providerLabel} research poll is still retrying after transient errors (${consecutivePollErrors}/${policy.maxConsecutivePollErrors} consecutive poll failures). Background job id: ${jobId}`,
-      );
+    if (!jobId) {
+      throw new Error(`${providerLabel} research did not return a job id.`);
     }
 
-    await sleep(policy.pollIntervalMs, context.signal);
+    let consecutivePollErrors = 0;
+
+    while (true) {
+      throwIfAborted(
+        lifecycleContext.signal,
+        `${providerLabel} research aborted.`,
+      );
+
+      try {
+        const result = await runWithExecutionPolicy(
+          `${providerLabel} research poll`,
+          (attemptContext) => poll(jobId!, providerOptions, attemptContext),
+          policy,
+          lifecycleContext,
+        );
+        consecutivePollErrors = 0;
+
+        if (result.status !== lastStatus) {
+          lifecycleContext.onProgress?.(
+            `${providerLabel} research status: ${result.status} (${formatElapsed(Date.now() - startedAt)} elapsed)`,
+          );
+          lastStatus = result.status;
+        }
+
+        if (result.status === "completed") {
+          return (
+            result.output ?? {
+              provider: providerId,
+              text: `${providerLabel} research completed without textual output.`,
+              summary: `Research via ${providerLabel}`,
+            }
+          );
+        }
+
+        if (result.status === "failed" || result.status === "cancelled") {
+          throw new NonResumableResearchError(
+            result.error || `${providerLabel} research ${result.status}.`,
+          );
+        }
+      } catch (error) {
+        if (error instanceof NonResumableResearchError) {
+          throw error;
+        }
+        if (isAbortErrorFromSignal(lifecycleContext.signal, error)) {
+          throw error;
+        }
+        if (
+          !(error instanceof RequestTimeoutError) &&
+          !isRetryableError(error)
+        ) {
+          throw buildResumeError(error, jobId);
+        }
+
+        consecutivePollErrors += 1;
+        if (consecutivePollErrors >= policy.maxConsecutivePollErrors) {
+          throw buildResumeError(
+            `${providerLabel} research polling failed too many times in a row: ${formatErrorMessage(error)}`,
+            jobId,
+          );
+        }
+
+        lifecycleContext.onProgress?.(
+          `${providerLabel} research poll is still retrying after transient errors (${consecutivePollErrors}/${policy.maxConsecutivePollErrors} consecutive poll failures). Background job id: ${jobId}`,
+        );
+      }
+
+      await sleep(policy.pollIntervalMs, lifecycleContext.signal);
+    }
+  } catch (error) {
+    if (jobId && isAbortErrorFromSignal(lifecycleContext.signal, error)) {
+      throw buildResumeError(error, jobId);
+    }
+    throw error;
+  } finally {
+    cleanupLifecycle();
   }
 }
 
@@ -347,7 +374,7 @@ export async function sleep(
     const onAbort = () => {
       clearTimeout(timer);
       signal?.removeEventListener("abort", onAbort);
-      reject(new Error("Operation aborted."));
+      reject(getAbortError(signal));
     };
 
     signal?.addEventListener("abort", onAbort, { once: true });
@@ -359,7 +386,7 @@ export function throwIfAborted(
   message = "Operation aborted.",
 ): void {
   if (signal?.aborted) {
-    throw new Error(message);
+    throw getAbortError(signal, message);
   }
 }
 
@@ -371,11 +398,11 @@ function createAttemptContext(context: ProviderContext): {
   const controller = new AbortController();
 
   if (context.signal?.aborted) {
-    controller.abort(context.signal.reason);
+    controller.abort(getAbortError(context.signal));
   }
 
   const onAbort = () => {
-    controller.abort(context.signal?.reason);
+    controller.abort(getAbortError(context.signal));
   };
 
   context.signal?.addEventListener("abort", onAbort, { once: true });
@@ -408,7 +435,7 @@ async function withTimeout<T>(
 
     const onAbort = () => {
       cleanup();
-      reject(new Error("Operation aborted."));
+      reject(getAbortError(signal));
     };
 
     const cleanup = () => {
@@ -428,6 +455,72 @@ async function withTimeout<T>(
       },
     );
   });
+}
+
+function getAbortError(
+  signal: AbortSignal | undefined,
+  message = "Operation aborted.",
+): Error {
+  const reason = signal?.reason;
+  if (reason instanceof Error) {
+    return reason;
+  }
+  if (typeof reason === "string" && reason.length > 0) {
+    return new Error(reason);
+  }
+  return new Error(message);
+}
+
+function isAbortErrorFromSignal(
+  signal: AbortSignal | undefined,
+  error: unknown,
+): boolean {
+  return signal?.aborted === true && signal.reason === error;
+}
+
+function createDeadlineSignal(
+  signal: AbortSignal | undefined,
+  timeoutMs: number | undefined,
+  timeoutMessage: string | undefined,
+): {
+  signal: AbortSignal | undefined;
+  cleanup: () => void;
+} {
+  if (timeoutMs === undefined) {
+    return {
+      signal,
+      cleanup: () => {},
+    };
+  }
+
+  const controller = new AbortController();
+
+  if (signal?.aborted) {
+    controller.abort(getAbortError(signal));
+  }
+
+  const onAbort = () => {
+    controller.abort(getAbortError(signal));
+  };
+
+  signal?.addEventListener("abort", onAbort, { once: true });
+
+  const timer = setTimeout(() => {
+    controller.abort(
+      new RequestTimeoutError(
+        timeoutMessage ??
+          `Operation timed out after ${formatDuration(timeoutMs)}.`,
+      ),
+    );
+  }, timeoutMs);
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    },
+  };
 }
 
 function buildResumeError(error: string | unknown, jobId: string): Error {

--- a/src/execution-policy.ts
+++ b/src/execution-policy.ts
@@ -1,0 +1,419 @@
+import type {
+  GeminiProviderConfig,
+  JsonObject,
+  ProviderContext,
+  ProviderId,
+  ProviderResearchJob,
+  ProviderResearchPollResult,
+  ProviderToolOutput,
+} from "./types.js";
+
+const DEFAULT_RESEARCH_POLL_INTERVAL_MS = 3000;
+const MAX_RETRY_DELAY_MS = 30000;
+
+export interface RequestExecutionPolicy {
+  requestTimeoutMs?: number;
+  retryCount: number;
+  retryDelayMs: number;
+}
+
+export interface ResearchExecutionPolicy extends RequestExecutionPolicy {
+  pollIntervalMs: number;
+  timeoutMs?: number;
+  maxConsecutivePollErrors: number;
+  resumeId?: string;
+}
+
+class RequestTimeoutError extends Error {
+  override name = "RequestTimeoutError";
+}
+
+export function stripLocalExecutionOptions(
+  options: JsonObject | undefined,
+): JsonObject | undefined {
+  if (!options) {
+    return undefined;
+  }
+
+  const {
+    requestTimeoutMs: _requestTimeoutMs,
+    retryCount: _retryCount,
+    retryDelayMs: _retryDelayMs,
+    pollIntervalMs: _pollIntervalMs,
+    timeoutMs: _timeoutMs,
+    maxConsecutivePollErrors: _maxConsecutivePollErrors,
+    resumeInteractionId: _resumeInteractionId,
+    resumeId: _resumeId,
+    ...rest
+  } = options;
+
+  return Object.keys(rest).length > 0 ? rest : undefined;
+}
+
+export function resolveRequestExecutionPolicy(
+  providerId: ProviderId,
+  providerConfig: unknown,
+  options: JsonObject | undefined,
+): RequestExecutionPolicy {
+  const geminiDefaults = getGeminiDefaults(providerId, providerConfig);
+
+  return {
+    requestTimeoutMs:
+      readPositiveInteger(options?.requestTimeoutMs) ??
+      geminiDefaults?.requestTimeoutMs,
+    retryCount:
+      readNonNegativeInteger(options?.retryCount) ??
+      geminiDefaults?.retryCount ??
+      0,
+    retryDelayMs:
+      readPositiveInteger(options?.retryDelayMs) ??
+      geminiDefaults?.retryDelayMs ??
+      2000,
+  };
+}
+
+export function resolveResearchExecutionPolicy(
+  providerId: ProviderId,
+  providerConfig: unknown,
+  options: JsonObject | undefined,
+): ResearchExecutionPolicy {
+  const request = resolveRequestExecutionPolicy(
+    providerId,
+    providerConfig,
+    options,
+  );
+  const geminiDefaults = getGeminiDefaults(providerId, providerConfig);
+
+  return {
+    ...request,
+    pollIntervalMs:
+      readPositiveInteger(options?.pollIntervalMs) ??
+      geminiDefaults?.researchPollIntervalMs ??
+      DEFAULT_RESEARCH_POLL_INTERVAL_MS,
+    timeoutMs:
+      readPositiveInteger(options?.timeoutMs) ??
+      geminiDefaults?.researchTimeoutMs,
+    maxConsecutivePollErrors:
+      readPositiveInteger(options?.maxConsecutivePollErrors) ??
+      geminiDefaults?.researchMaxConsecutivePollErrors ??
+      3,
+    resumeId:
+      readNonEmptyString(options?.resumeId) ??
+      readNonEmptyString(options?.resumeInteractionId),
+  };
+}
+
+export async function runWithExecutionPolicy<T>(
+  label: string,
+  operation: () => Promise<T>,
+  policy: RequestExecutionPolicy,
+  context: ProviderContext,
+): Promise<T> {
+  const maxAttempts = Math.max(1, policy.retryCount + 1);
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    throwIfAborted(context.signal);
+
+    try {
+      const result = operation();
+      if (policy.requestTimeoutMs === undefined) {
+        return await result;
+      }
+      return await withTimeout(
+        result,
+        policy.requestTimeoutMs,
+        context.signal,
+        `${label} timed out after ${formatDuration(policy.requestTimeoutMs)}.`,
+      );
+    } catch (error) {
+      if (!isRetryableError(error) || attempt >= maxAttempts) {
+        throw error;
+      }
+
+      const delayMs = Math.min(
+        policy.retryDelayMs * 2 ** (attempt - 1),
+        MAX_RETRY_DELAY_MS,
+      );
+      context.onProgress?.(
+        `${label} failed (${formatErrorMessage(error)}). Retrying in ${formatDuration(delayMs)} (attempt ${attempt + 1}/${maxAttempts}).`,
+      );
+      await sleep(delayMs, context.signal);
+    }
+  }
+
+  throw new Error(`${label} failed.`);
+}
+
+export async function executeResearchWithLifecycle({
+  providerLabel,
+  providerId,
+  input,
+  options,
+  context,
+  policy,
+  start,
+  poll,
+}: {
+  providerLabel: string;
+  providerId: ProviderId;
+  input: string;
+  options: JsonObject | undefined;
+  context: ProviderContext;
+  policy: ResearchExecutionPolicy;
+  start: (
+    input: string,
+    options: JsonObject | undefined,
+    context: ProviderContext,
+  ) => Promise<ProviderResearchJob>;
+  poll: (
+    id: string,
+    options: JsonObject | undefined,
+    context: ProviderContext,
+  ) => Promise<ProviderResearchPollResult>;
+}): Promise<ProviderToolOutput> {
+  const startedAt = Date.now();
+  let lastStatus: ProviderResearchPollResult["status"] | undefined;
+  const providerOptions = stripLocalExecutionOptions(options);
+
+  let jobId = policy.resumeId;
+  if (jobId) {
+    context.onProgress?.(`Resuming ${providerLabel} research: ${jobId}`);
+  } else {
+    context.onProgress?.(`Starting ${providerLabel} research`);
+    const job = await runWithExecutionPolicy(
+      `${providerLabel} research start`,
+      () => start(input, providerOptions, context),
+      policy,
+      context,
+    );
+    jobId = job.id;
+    context.onProgress?.(`${providerLabel} research started: ${jobId}`);
+  }
+
+  let consecutivePollErrors = 0;
+
+  while (true) {
+    throwIfAborted(context.signal, `${providerLabel} research aborted.`);
+
+    if (
+      policy.timeoutMs !== undefined &&
+      Date.now() - startedAt > policy.timeoutMs
+    ) {
+      throw buildResumeError(
+        `${providerLabel} research exceeded ${formatDuration(policy.timeoutMs)}.`,
+        jobId,
+      );
+    }
+
+    try {
+      const result = await runWithExecutionPolicy(
+        `${providerLabel} research poll`,
+        () => poll(jobId, providerOptions, context),
+        policy,
+        context,
+      );
+      consecutivePollErrors = 0;
+
+      if (result.status !== lastStatus) {
+        context.onProgress?.(
+          `${providerLabel} research status: ${result.status} (${formatElapsed(Date.now() - startedAt)} elapsed)`,
+        );
+        lastStatus = result.status;
+      }
+
+      if (result.status === "completed") {
+        return (
+          result.output ?? {
+            provider: providerId,
+            text: `${providerLabel} research completed without textual output.`,
+            summary: `Research via ${providerLabel}`,
+          }
+        );
+      }
+
+      if (result.status === "failed" || result.status === "cancelled") {
+        throw buildResumeError(
+          result.error || `${providerLabel} research ${result.status}.`,
+          jobId,
+        );
+      }
+    } catch (error) {
+      if (!isRetryableError(error)) {
+        throw buildResumeError(error, jobId);
+      }
+
+      consecutivePollErrors += 1;
+      if (consecutivePollErrors >= policy.maxConsecutivePollErrors) {
+        throw buildResumeError(
+          `${providerLabel} research polling failed too many times in a row: ${formatErrorMessage(error)}`,
+          jobId,
+        );
+      }
+
+      context.onProgress?.(
+        `${providerLabel} research poll is still retrying after transient errors (${consecutivePollErrors}/${policy.maxConsecutivePollErrors} consecutive poll failures). Background job id: ${jobId}`,
+      );
+    }
+
+    await sleep(policy.pollIntervalMs, context.signal);
+  }
+}
+
+export function isRetryableError(error: unknown): boolean {
+  if (error instanceof RequestTimeoutError) {
+    return true;
+  }
+
+  const message = formatErrorMessage(error).toLowerCase();
+  if (!message || message === "operation aborted.") {
+    return false;
+  }
+
+  return /429|500|502|503|504|deadline exceeded|econnreset|ecanceled|ehostunreach|eai_again|enotfound|etimedout|fetch failed|gateway timeout|internal error|network|overloaded|rate limit|resource exhausted|socket hang up|temporarily unavailable|timeout|unavailable/.test(
+    message,
+  );
+}
+
+export function formatErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof error.message === "string"
+  ) {
+    return error.message;
+  }
+  return String(error);
+}
+
+export function formatElapsed(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+
+  return `${totalSeconds}s`;
+}
+
+export function formatDuration(ms: number): string {
+  if (ms >= 60000) {
+    return formatElapsed(ms);
+  }
+
+  if (ms >= 1000) {
+    return `${Math.floor(ms / 1000)}s`;
+  }
+
+  return `${ms}ms`;
+}
+
+export async function sleep(
+  ms: number,
+  signal: AbortSignal | undefined,
+): Promise<void> {
+  throwIfAborted(signal);
+
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      reject(new Error("Operation aborted."));
+    };
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+export function throwIfAborted(
+  signal: AbortSignal | undefined,
+  message = "Operation aborted.",
+): void {
+  if (signal?.aborted) {
+    throw new Error(message);
+  }
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  signal: AbortSignal | undefined,
+  message: string,
+): Promise<T> {
+  throwIfAborted(signal);
+
+  return await new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new RequestTimeoutError(message));
+    }, timeoutMs);
+
+    const onAbort = () => {
+      cleanup();
+      reject(new Error("Operation aborted."));
+    };
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    };
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (error) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}
+
+function buildResumeError(error: string | unknown, jobId: string): Error {
+  const message = typeof error === "string" ? error : formatErrorMessage(error);
+  return new Error(
+    `${message} Resume the background job with options.resumeId=${JSON.stringify(jobId)}.`,
+  );
+}
+
+function getGeminiDefaults(
+  providerId: ProviderId,
+  providerConfig: unknown,
+): GeminiProviderConfig["defaults"] | undefined {
+  if (providerId !== "gemini") {
+    return undefined;
+  }
+
+  return (providerConfig as GeminiProviderConfig | undefined)?.defaults;
+}
+
+function readPositiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 1
+    ? Math.trunc(value)
+    : undefined;
+}
+
+function readNonNegativeInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? Math.trunc(value)
+    : undefined;
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
+}

--- a/src/execution-policy.ts
+++ b/src/execution-policy.ts
@@ -172,6 +172,7 @@ export async function executeResearchWithLifecycle({
   startRetryNotice,
   startIdempotencyKey,
   startRetryOnTimeout = false,
+  startRequestTimeoutMs,
   pollRequestTimeoutMs,
   start,
   poll,
@@ -186,6 +187,7 @@ export async function executeResearchWithLifecycle({
   startRetryNotice?: string;
   startIdempotencyKey?: string;
   startRetryOnTimeout?: boolean;
+  startRequestTimeoutMs?: number | null;
   pollRequestTimeoutMs?: number | null;
   start: (
     input: string,
@@ -201,6 +203,10 @@ export async function executeResearchWithLifecycle({
   const startedAt = Date.now();
   let lastStatus: ProviderResearchPollResult["status"] | undefined;
   const providerOptions = stripLocalExecutionOptions(options);
+  const effectiveStartRequestTimeoutMs =
+    startRequestTimeoutMs === undefined
+      ? policy.requestTimeoutMs
+      : (startRequestTimeoutMs ?? undefined);
   const effectivePollRequestTimeoutMs =
     pollRequestTimeoutMs === undefined
       ? policy.requestTimeoutMs
@@ -237,6 +243,7 @@ export async function executeResearchWithLifecycle({
           }),
         {
           ...policy,
+          requestTimeoutMs: effectiveStartRequestTimeoutMs,
           retryCount: startRetryCount,
           retryOnTimeout: startRetryOnTimeout,
         },

--- a/src/execution-policy.ts
+++ b/src/execution-policy.ts
@@ -353,7 +353,7 @@ export async function executeResearchWithLifecycle({
           !(error instanceof RequestTimeoutError) &&
           !isRetryableError(error)
         ) {
-          throw buildResumeError(error, jobId);
+          throw normalizeError(error);
         }
 
         consecutivePollErrors += 1;
@@ -641,6 +641,10 @@ function buildUnknownResearchStartError(error: string | unknown): Error {
   return new Error(
     `${message} The provider may still create a background job, but no job id was returned so this run cannot be resumed automatically.`,
   );
+}
+
+function normalizeError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(formatErrorMessage(error));
 }
 
 function parseOptionalPositiveIntegerOption(

--- a/src/execution-policy.ts
+++ b/src/execution-policy.ts
@@ -33,6 +33,16 @@ class NonResumableResearchError extends Error {
   override name = "NonResumableResearchError";
 }
 
+export interface LocalExecutionOptions {
+  requestTimeoutMs?: number;
+  retryCount?: number;
+  retryDelayMs?: number;
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+  maxConsecutivePollErrors?: number;
+  resumeId?: string;
+}
+
 export function stripLocalExecutionOptions(
   options: Record<string, unknown> | JsonObject | undefined,
 ): JsonObject | undefined {
@@ -48,28 +58,47 @@ export function stripLocalExecutionOptions(
     timeoutMs: _timeoutMs,
     maxConsecutivePollErrors: _maxConsecutivePollErrors,
     resumeId: _resumeId,
+    resumeInteractionId: _resumeInteractionId,
     ...rest
   } = options;
 
   return Object.keys(rest).length > 0 ? (rest as JsonObject) : undefined;
 }
 
+export function parseLocalExecutionOptions(
+  options: Record<string, unknown> | JsonObject | undefined,
+): LocalExecutionOptions {
+  return {
+    requestTimeoutMs: parseOptionalPositiveIntegerOption(
+      options,
+      "requestTimeoutMs",
+    ),
+    retryCount: parseOptionalNonNegativeIntegerOption(options, "retryCount"),
+    retryDelayMs: parseOptionalPositiveIntegerOption(options, "retryDelayMs"),
+    pollIntervalMs: parseOptionalPositiveIntegerOption(
+      options,
+      "pollIntervalMs",
+    ),
+    timeoutMs: parseOptionalPositiveIntegerOption(options, "timeoutMs"),
+    maxConsecutivePollErrors: parseOptionalPositiveIntegerOption(
+      options,
+      "maxConsecutivePollErrors",
+    ),
+    resumeId: parseOptionalNonEmptyStringOption(options, "resumeId"),
+  };
+}
+
 export function extractExecutionPolicyDefaults(
   options: Record<string, unknown> | JsonObject | undefined,
 ): ExecutionPolicyDefaults | undefined {
-  if (!options) {
-    return undefined;
-  }
-
+  const localOptions = parseLocalExecutionOptions(options);
   const defaults: ExecutionPolicyDefaults = {
-    requestTimeoutMs: readPositiveInteger(options.requestTimeoutMs),
-    retryCount: readNonNegativeInteger(options.retryCount),
-    retryDelayMs: readPositiveInteger(options.retryDelayMs),
-    researchPollIntervalMs: readPositiveInteger(options.pollIntervalMs),
-    researchTimeoutMs: readPositiveInteger(options.timeoutMs),
-    researchMaxConsecutivePollErrors: readPositiveInteger(
-      options.maxConsecutivePollErrors,
-    ),
+    requestTimeoutMs: localOptions.requestTimeoutMs,
+    retryCount: localOptions.retryCount,
+    retryDelayMs: localOptions.retryDelayMs,
+    researchPollIntervalMs: localOptions.pollIntervalMs,
+    researchTimeoutMs: localOptions.timeoutMs,
+    researchMaxConsecutivePollErrors: localOptions.maxConsecutivePollErrors,
   };
 
   return Object.values(defaults).some((value) => value !== undefined)
@@ -81,16 +110,13 @@ export function resolveRequestExecutionPolicy(
   options: JsonObject | undefined,
   defaults: ExecutionPolicyDefaults | undefined,
 ): RequestExecutionPolicy {
+  const localOptions = parseLocalExecutionOptions(options);
+
   return {
     requestTimeoutMs:
-      readPositiveInteger(options?.requestTimeoutMs) ??
-      defaults?.requestTimeoutMs,
-    retryCount:
-      readNonNegativeInteger(options?.retryCount) ?? defaults?.retryCount ?? 0,
-    retryDelayMs:
-      readPositiveInteger(options?.retryDelayMs) ??
-      defaults?.retryDelayMs ??
-      2000,
+      localOptions.requestTimeoutMs ?? defaults?.requestTimeoutMs,
+    retryCount: localOptions.retryCount ?? defaults?.retryCount ?? 0,
+    retryDelayMs: localOptions.retryDelayMs ?? defaults?.retryDelayMs ?? 2000,
   };
 }
 
@@ -98,21 +124,21 @@ export function resolveResearchExecutionPolicy(
   options: JsonObject | undefined,
   defaults: ExecutionPolicyDefaults | undefined,
 ): ResearchExecutionPolicy {
+  const localOptions = parseLocalExecutionOptions(options);
   const request = resolveRequestExecutionPolicy(options, defaults);
 
   return {
     ...request,
     pollIntervalMs:
-      readPositiveInteger(options?.pollIntervalMs) ??
+      localOptions.pollIntervalMs ??
       defaults?.researchPollIntervalMs ??
       DEFAULT_RESEARCH_POLL_INTERVAL_MS,
-    timeoutMs:
-      readPositiveInteger(options?.timeoutMs) ?? defaults?.researchTimeoutMs,
+    timeoutMs: localOptions.timeoutMs ?? defaults?.researchTimeoutMs,
     maxConsecutivePollErrors:
-      readPositiveInteger(options?.maxConsecutivePollErrors) ??
+      localOptions.maxConsecutivePollErrors ??
       defaults?.researchMaxConsecutivePollErrors ??
       3,
-    resumeId: readNonEmptyString(options?.resumeId),
+    resumeId: localOptions.resumeId,
   };
 }
 
@@ -612,20 +638,57 @@ function buildResumeError(error: string | unknown, jobId: string): Error {
   );
 }
 
-function readPositiveInteger(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) && value >= 1
-    ? Math.trunc(value)
-    : undefined;
+function parseOptionalPositiveIntegerOption(
+  options: Record<string, unknown> | JsonObject | undefined,
+  key: keyof Pick<
+    LocalExecutionOptions,
+    | "requestTimeoutMs"
+    | "retryDelayMs"
+    | "pollIntervalMs"
+    | "timeoutMs"
+    | "maxConsecutivePollErrors"
+  >,
+): number | undefined {
+  const value = options?.[key];
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+    throw new Error(`options.${key} must be a positive integer.`);
+  }
+
+  return value;
 }
 
-function readNonNegativeInteger(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) && value >= 0
-    ? Math.trunc(value)
-    : undefined;
+function parseOptionalNonNegativeIntegerOption(
+  options: Record<string, unknown> | JsonObject | undefined,
+  key: "retryCount",
+): number | undefined {
+  const value = options?.[key];
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw new Error(`options.${key} must be a non-negative integer.`);
+  }
+
+  return value;
 }
 
-function readNonEmptyString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim().length > 0
-    ? value
-    : undefined;
+function parseOptionalNonEmptyStringOption(
+  options: Record<string, unknown> | JsonObject | undefined,
+  key: "resumeId",
+): string | undefined {
+  const value = options?.[key];
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`options.${key} must be a non-empty string.`);
+  }
+
+  return value;
 }

--- a/src/execution-policy.ts
+++ b/src/execution-policy.ts
@@ -47,7 +47,6 @@ export function stripLocalExecutionOptions(
     pollIntervalMs: _pollIntervalMs,
     timeoutMs: _timeoutMs,
     maxConsecutivePollErrors: _maxConsecutivePollErrors,
-    resumeInteractionId: _resumeInteractionId,
     resumeId: _resumeId,
     ...rest
   } = options;
@@ -102,9 +101,7 @@ export function resolveResearchExecutionPolicy(
       readPositiveInteger(options?.maxConsecutivePollErrors) ??
       geminiDefaults?.researchMaxConsecutivePollErrors ??
       3,
-    resumeId:
-      readNonEmptyString(options?.resumeId) ??
-      readNonEmptyString(options?.resumeInteractionId),
+    resumeId: readNonEmptyString(options?.resumeId),
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,9 +27,18 @@ import {
 import { Type } from "@sinclair/typebox";
 import { loadConfig, writeConfigFile } from "./config.js";
 import {
+  executeResearchWithLifecycle,
+  formatElapsed,
+  resolveRequestExecutionPolicy,
+  resolveResearchExecutionPolicy,
+  runWithExecutionPolicy,
+  stripLocalExecutionOptions,
+} from "./execution-policy.js";
+import {
   getEffectiveProviderConfig,
   resolveProviderChoice,
   resolveProviderForCapability,
+  supportsProviderCapability,
 } from "./provider-resolution.js";
 import {
   isProviderToolEnabled,
@@ -157,21 +166,45 @@ function registerWebSearchTool(
         throw new Error(`Provider '${provider.id}' is not configured.`);
       }
 
-      const response = await provider.search!(
-        params.query,
-        maxResults,
-        normalizeOptions(params.options),
-        providerConfig as never,
-        {
-          cwd: ctx.cwd,
-          signal: signal ?? undefined,
-          onProgress: (message) =>
-            onUpdate?.({
-              content: [{ type: "text", text: message }],
-              details: {},
-            }),
-        },
+      const progress = createToolProgressReporter(
+        "search",
+        provider.id,
+        onUpdate,
       );
+      const options = normalizeOptions(params.options);
+      const providerOptions = stripLocalExecutionOptions(options);
+      const policy = resolveRequestExecutionPolicy(
+        provider.id,
+        providerConfig,
+        options,
+      );
+
+      let response: SearchResponse;
+      try {
+        response = await runWithExecutionPolicy(
+          `${provider.label} search request`,
+          () =>
+            provider.search!(
+              params.query,
+              maxResults,
+              providerOptions,
+              providerConfig as never,
+              {
+                cwd: ctx.cwd,
+                signal: signal ?? undefined,
+                onProgress: progress.report,
+              },
+            ),
+          policy,
+          {
+            cwd: ctx.cwd,
+            signal: signal ?? undefined,
+            onProgress: progress.report,
+          },
+        );
+      } finally {
+        progress.stop();
+      }
 
       const rendered = await truncateAndSave(
         formatSearchResponse(response),
@@ -251,10 +284,11 @@ function registerWebContentsTool(
         ctx,
         signal,
         onUpdate,
-        invoke: (provider, providerConfig, context) =>
+        options: normalizeOptions(params.options),
+        invoke: (provider, providerConfig, providerOptions, context) =>
           provider.contents!(
             params.urls,
-            normalizeOptions(params.options),
+            providerOptions,
             providerConfig as never,
             context,
           ),
@@ -337,10 +371,11 @@ function registerWebAnswerTool(
         ctx,
         signal,
         onUpdate,
-        invoke: (provider, providerConfig, context) =>
+        options: normalizeOptions(params.options),
+        invoke: (provider, providerConfig, providerOptions, context) =>
           provider.answer!(
             params.query,
-            normalizeOptions(params.options),
+            providerOptions,
             providerConfig as never,
             context,
           ),
@@ -396,10 +431,12 @@ function registerWebResearchTool(
         ctx,
         signal,
         onUpdate,
-        invoke: (provider, providerConfig, context) =>
+        options: normalizeOptions(params.options),
+        input: params.input,
+        invoke: (provider, providerConfig, providerOptions, context) =>
           provider.research!(
             params.input,
-            normalizeOptions(params.options),
+            providerOptions,
             providerConfig as never,
             context,
           ),
@@ -544,8 +581,8 @@ async function syncManagedToolAvailability(
 function getProviderIdsForCapability(
   capability: ProviderCapability,
 ): ProviderId[] {
-  return PROVIDERS.filter(
-    (provider) => typeof provider[capability] === "function",
+  return PROVIDERS.filter((provider) =>
+    supportsProviderCapability(provider, capability),
   ).map((provider) => provider.id);
 }
 
@@ -580,6 +617,9 @@ async function executeProviderTool({
   ctx,
   signal,
   onUpdate,
+  options,
+  input,
+  useProviderLifecycle = true,
   invoke,
 }: {
   capability: Exclude<ProviderCapability, "search">;
@@ -593,9 +633,13 @@ async function executeProviderTool({
         details: {};
       }) => void)
     | undefined;
+  options: JsonObject | undefined;
+  input?: string;
+  useProviderLifecycle?: boolean;
   invoke: (
     provider: (typeof PROVIDERS)[number],
     providerConfig: ProviderConfigUnion,
+    providerOptions: JsonObject | undefined,
     context: {
       cwd: string;
       signal?: AbortSignal;
@@ -619,14 +663,61 @@ async function executeProviderTool({
     provider.id,
     onUpdate,
   );
+  const providerOptions = stripLocalExecutionOptions(options);
+  const providerContext = {
+    cwd: ctx.cwd,
+    signal: signal ?? undefined,
+    onProgress: progress.report,
+  };
 
   let response: ProviderToolOutput;
   try {
-    response = await invoke(provider, providerConfig as ProviderConfigUnion, {
-      cwd: ctx.cwd,
-      signal: signal ?? undefined,
-      onProgress: progress.report,
-    });
+    if (
+      useProviderLifecycle &&
+      capability === "research" &&
+      typeof provider.startResearch === "function" &&
+      typeof provider.pollResearch === "function"
+    ) {
+      response = await executeResearchWithLifecycle({
+        providerLabel: provider.label,
+        providerId: provider.id,
+        input: input ?? "",
+        options,
+        context: providerContext,
+        policy: resolveResearchExecutionPolicy(
+          provider.id,
+          providerConfig,
+          options,
+        ),
+        start: (input, researchOptions, context) =>
+          provider.startResearch!(
+            input,
+            researchOptions,
+            providerConfig as never,
+            context,
+          ),
+        poll: (id, researchOptions, context) =>
+          provider.pollResearch!(
+            id,
+            researchOptions,
+            providerConfig as never,
+            context,
+          ),
+      });
+    } else {
+      response = await runWithExecutionPolicy(
+        `${provider.label} ${capability} request`,
+        () =>
+          invoke(
+            provider,
+            providerConfig as ProviderConfigUnion,
+            providerOptions,
+            providerContext,
+          ),
+        resolveRequestExecutionPolicy(provider.id, providerConfig, options),
+        providerContext,
+      );
+    }
   } finally {
     progress.stop();
   }
@@ -792,6 +883,12 @@ interface ProviderMenuOption {
     | "geminiContentsModel"
     | "geminiAnswerModel"
     | "geminiResearchAgent"
+    | "geminiRequestTimeoutMs"
+    | "geminiRetryCount"
+    | "geminiRetryDelayMs"
+    | "geminiResearchPollIntervalMs"
+    | "geminiResearchTimeoutMs"
+    | "geminiResearchMaxPollErrors"
     | "parallelSearchMode"
     | "parallelExtractExcerpts"
     | "parallelExtractFullContent"
@@ -844,7 +941,13 @@ function buildProviderMenuOptions(
       | "geminiSearchModel"
       | "geminiContentsModel"
       | "geminiAnswerModel"
-      | "geminiResearchAgent",
+      | "geminiResearchAgent"
+      | "geminiRequestTimeoutMs"
+      | "geminiRetryCount"
+      | "geminiRetryDelayMs"
+      | "geminiResearchPollIntervalMs"
+      | "geminiResearchTimeoutMs"
+      | "geminiResearchMaxPollErrors",
     label: string,
     help: string,
   ) => {
@@ -1009,6 +1112,36 @@ function buildProviderMenuOptions(
       "geminiResearchAgent",
       "Research agent",
       "Agent used for Gemini deep research runs.",
+    );
+    pushText(
+      "geminiRequestTimeoutMs",
+      "Request timeout (ms)",
+      "Maximum time to wait for a single Gemini API request before retrying.",
+    );
+    pushText(
+      "geminiRetryCount",
+      "Retry count",
+      "How many times Gemini requests should be retried after transient failures.",
+    );
+    pushText(
+      "geminiRetryDelayMs",
+      "Retry delay (ms)",
+      "Initial delay before retrying failed Gemini requests. Later retries back off automatically.",
+    );
+    pushText(
+      "geminiResearchPollIntervalMs",
+      "Research poll interval (ms)",
+      "How often to poll Gemini background research jobs for updates.",
+    );
+    pushText(
+      "geminiResearchTimeoutMs",
+      "Research timeout (ms)",
+      "Maximum total time to wait for Gemini research before returning a resumable timeout error.",
+    );
+    pushText(
+      "geminiResearchMaxPollErrors",
+      "Max poll errors",
+      "How many consecutive polling failures to tolerate before the Gemini research run stops locally.",
     );
     return options;
   }
@@ -1249,7 +1382,13 @@ class WebProvidersSettingsView implements Component {
             : key === "geminiSearchModel" ||
                 key === "geminiContentsModel" ||
                 key === "geminiAnswerModel" ||
-                key === "geminiResearchAgent"
+                key === "geminiResearchAgent" ||
+                key === "geminiRequestTimeoutMs" ||
+                key === "geminiRetryCount" ||
+                key === "geminiRetryDelayMs" ||
+                key === "geminiResearchPollIntervalMs" ||
+                key === "geminiResearchTimeoutMs" ||
+                key === "geminiResearchMaxPollErrors"
               ? getGeminiTextSettingValue(
                   providerConfig as GeminiProviderConfig | undefined,
                   key,
@@ -1440,7 +1579,13 @@ class WebProvidersSettingsView implements Component {
       id === "geminiSearchModel" ||
       id === "geminiContentsModel" ||
       id === "geminiAnswerModel" ||
-      id === "geminiResearchAgent"
+      id === "geminiResearchAgent" ||
+      id === "geminiRequestTimeoutMs" ||
+      id === "geminiRetryCount" ||
+      id === "geminiRetryDelayMs" ||
+      id === "geminiResearchPollIntervalMs" ||
+      id === "geminiResearchTimeoutMs" ||
+      id === "geminiResearchMaxPollErrors"
     ) {
       return getGeminiTextSettingValue(
         providerConfig as GeminiProviderConfig | undefined,
@@ -1832,14 +1977,48 @@ function getGeminiTextSettingValue(
     | "geminiSearchModel"
     | "geminiContentsModel"
     | "geminiAnswerModel"
-    | "geminiResearchAgent",
+    | "geminiResearchAgent"
+    | "geminiRequestTimeoutMs"
+    | "geminiRetryCount"
+    | "geminiRetryDelayMs"
+    | "geminiResearchPollIntervalMs"
+    | "geminiResearchTimeoutMs"
+    | "geminiResearchMaxPollErrors",
 ): string | undefined {
   const defaults = config?.defaults;
   if (!defaults) return undefined;
   if (key === "geminiSearchModel") return defaults.searchModel;
   if (key === "geminiContentsModel") return defaults.contentsModel;
   if (key === "geminiAnswerModel") return defaults.answerModel;
-  return defaults.researchAgent;
+  if (key === "geminiResearchAgent") return defaults.researchAgent;
+  if (key === "geminiRequestTimeoutMs") {
+    return typeof defaults.requestTimeoutMs === "number"
+      ? String(defaults.requestTimeoutMs)
+      : undefined;
+  }
+  if (key === "geminiRetryCount") {
+    return typeof defaults.retryCount === "number"
+      ? String(defaults.retryCount)
+      : undefined;
+  }
+  if (key === "geminiRetryDelayMs") {
+    return typeof defaults.retryDelayMs === "number"
+      ? String(defaults.retryDelayMs)
+      : undefined;
+  }
+  if (key === "geminiResearchPollIntervalMs") {
+    return typeof defaults.researchPollIntervalMs === "number"
+      ? String(defaults.researchPollIntervalMs)
+      : undefined;
+  }
+  if (key === "geminiResearchTimeoutMs") {
+    return typeof defaults.researchTimeoutMs === "number"
+      ? String(defaults.researchTimeoutMs)
+      : undefined;
+  }
+  return typeof defaults.researchMaxConsecutivePollErrors === "number"
+    ? String(defaults.researchMaxConsecutivePollErrors)
+    : undefined;
 }
 
 function assignOptionalString(
@@ -1853,6 +2032,28 @@ function assignOptionalString(
   } else {
     target[key] = trimmed;
   }
+}
+
+function assignOptionalInteger(
+  target: Record<string, JsonObject | string | number | boolean | undefined>,
+  key: string,
+  value: string,
+  errorMessage: string,
+  options?: { allowZero?: boolean },
+): void {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    delete target[key];
+    return;
+  }
+
+  const parsed = Number(trimmed);
+  const minimum = options?.allowZero ? 0 : 1;
+  if (!Number.isInteger(parsed) || parsed < minimum) {
+    throw new Error(errorMessage);
+  }
+
+  target[key] = parsed;
 }
 
 function applyClaudeSettingChange(
@@ -2091,6 +2292,79 @@ function applyGeminiSettingChange(
       );
       cleanupGeminiDefaults(target);
       return true;
+    case "geminiRequestTimeoutMs":
+      assignOptionalInteger(
+        target.defaults as Record<
+          string,
+          JsonObject | string | number | boolean | undefined
+        >,
+        "requestTimeoutMs",
+        value,
+        "Gemini request timeout must be a positive integer.",
+      );
+      cleanupGeminiDefaults(target);
+      return true;
+    case "geminiRetryCount":
+      assignOptionalInteger(
+        target.defaults as Record<
+          string,
+          JsonObject | string | number | boolean | undefined
+        >,
+        "retryCount",
+        value,
+        "Gemini retry count must be a non-negative integer.",
+        { allowZero: true },
+      );
+      cleanupGeminiDefaults(target);
+      return true;
+    case "geminiRetryDelayMs":
+      assignOptionalInteger(
+        target.defaults as Record<
+          string,
+          JsonObject | string | number | boolean | undefined
+        >,
+        "retryDelayMs",
+        value,
+        "Gemini retry delay must be a positive integer.",
+      );
+      cleanupGeminiDefaults(target);
+      return true;
+    case "geminiResearchPollIntervalMs":
+      assignOptionalInteger(
+        target.defaults as Record<
+          string,
+          JsonObject | string | number | boolean | undefined
+        >,
+        "researchPollIntervalMs",
+        value,
+        "Gemini research poll interval must be a positive integer.",
+      );
+      cleanupGeminiDefaults(target);
+      return true;
+    case "geminiResearchTimeoutMs":
+      assignOptionalInteger(
+        target.defaults as Record<
+          string,
+          JsonObject | string | number | boolean | undefined
+        >,
+        "researchTimeoutMs",
+        value,
+        "Gemini research timeout must be a positive integer.",
+      );
+      cleanupGeminiDefaults(target);
+      return true;
+    case "geminiResearchMaxPollErrors":
+      assignOptionalInteger(
+        target.defaults as Record<
+          string,
+          JsonObject | string | number | boolean | undefined
+        >,
+        "researchMaxConsecutivePollErrors",
+        value,
+        "Gemini max poll errors must be a positive integer.",
+      );
+      cleanupGeminiDefaults(target);
+      return true;
     default:
       return false;
   }
@@ -2298,18 +2572,6 @@ function cleanSingleLine(text: string): string {
 
 function formatQuotedPreview(text: string, maxLength = 80): string {
   return `"${truncateInline(cleanSingleLine(text), maxLength)}"`;
-}
-
-function formatElapsed(ms: number): string {
-  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-
-  if (minutes > 0) {
-    return `${minutes}m ${seconds}s`;
-  }
-
-  return `${totalSeconds}s`;
 }
 
 function formatSearchResponse(response: SearchResponse): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -737,6 +737,7 @@ async function executeProviderTool({
           pollRequestTimeoutMs: supportsPollCancellation
             ? researchPolicy.requestTimeoutMs
             : null,
+          deferDeadlineUntilStarted: !supportsSafeStartRetries,
           start: (input, researchOptions, context) =>
             provider.startResearch!(
               input,
@@ -1228,7 +1229,7 @@ function buildProviderMenuOptions(
     pushText(
       "geminiRequestTimeoutMs",
       "Request timeout (ms)",
-      "Maximum time to wait for a single Gemini API request before failing that attempt. Timed-out requests are not retried.",
+      "Maximum time to wait for a single Gemini API request before failing that attempt. Timed-out requests are generally not retried, except for idempotent research-start operations.",
     );
     pushText(
       "geminiRetryCount",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -28,19 +27,20 @@ import {
 import { Type } from "@sinclair/typebox";
 import { loadConfig, writeConfigFile } from "./config.js";
 import {
-  executeResearchWithLifecycle,
   formatElapsed,
-  resolveRequestExecutionPolicy,
-  resolveResearchExecutionPolicy,
-  runWithExecutionPolicy,
   stripLocalExecutionOptions,
 } from "./execution-policy.js";
+import {
+  getProviderConfigManifest,
+  type ProviderSettingDescriptor,
+} from "./provider-config-manifests.js";
 import {
   getEffectiveProviderConfig,
   resolveProviderChoice,
   resolveProviderForCapability,
   supportsProviderCapability,
 } from "./provider-resolution.js";
+import { executeOperationPlan } from "./provider-runtime.js";
 import {
   isProviderToolEnabled,
   PROVIDER_TOOL_META,
@@ -56,13 +56,13 @@ import type {
   GeminiProviderConfig,
   JsonObject,
   ParallelProviderConfig,
-  PerplexityProviderConfig,
   ProviderId,
+  ProviderOperationPlan,
+  ProviderOperationRequest,
   ProviderToolDetails,
   ProviderToolOutput,
   SearchResponse,
   ValyuProviderConfig,
-  WebProvider,
   WebProvidersConfig,
   WebSearchDetails,
 } from "./types.js";
@@ -72,19 +72,6 @@ const DEFAULT_MAX_RESULTS = 5;
 const MAX_ALLOWED_RESULTS = 20;
 const RESEARCH_HEARTBEAT_MS = 15000;
 type ProviderCapability = ProviderToolId;
-type BlockingResearchProvider = WebProvider<PerplexityProviderConfig> & {
-  id: "perplexity";
-  research: (
-    input: string,
-    options: JsonObject | undefined,
-    config: PerplexityProviderConfig,
-    context: {
-      cwd: string;
-      signal?: AbortSignal;
-      onProgress?: (message: string) => void;
-    },
-  ) => Promise<ProviderToolOutput>;
-};
 const CAPABILITY_TOOL_NAMES: Record<ProviderCapability, string> = {
   search: "web_search",
   contents: "web_contents",
@@ -187,32 +174,30 @@ function registerWebSearchTool(
         onUpdate,
       );
       const options = normalizeOptions(params.options);
-      const providerOptions = stripLocalExecutionOptions(options);
-      const policy = resolveRequestExecutionPolicy(
-        provider.id,
-        providerConfig,
-        options,
+      const plan = buildProviderPlan(
+        provider,
+        providerConfig as ProviderConfigUnion,
+        {
+          capability: "search",
+          query: params.query,
+          maxResults,
+          options: stripLocalExecutionOptions(options),
+        },
       );
 
       let response: SearchResponse;
       try {
-        response = await runWithExecutionPolicy(
-          `${provider.label} search request`,
-          (attemptContext) =>
-            provider.search!(
-              params.query,
-              maxResults,
-              providerOptions,
-              providerConfig as never,
-              attemptContext,
-            ),
-          policy,
-          {
-            cwd: ctx.cwd,
-            signal: signal ?? undefined,
-            onProgress: progress.report,
-          },
-        );
+        const result = await executeOperationPlan(plan, options, {
+          cwd: ctx.cwd,
+          signal: signal ?? undefined,
+          onProgress: progress.report,
+        });
+        if (!isSearchResponse(result)) {
+          throw new Error(
+            `${provider.label} search returned an invalid result.`,
+          );
+        }
+        response = result;
       } finally {
         progress.stop();
       }
@@ -296,13 +281,7 @@ function registerWebContentsTool(
         signal,
         onUpdate,
         options: normalizeOptions(params.options),
-        invoke: (provider, providerConfig, providerOptions, context) =>
-          provider.contents!(
-            params.urls,
-            providerOptions,
-            providerConfig as never,
-            context,
-          ),
+        urls: params.urls,
       });
     },
     renderCall(args, theme) {
@@ -383,13 +362,7 @@ function registerWebAnswerTool(
         signal,
         onUpdate,
         options: normalizeOptions(params.options),
-        invoke: (provider, providerConfig, providerOptions, context) =>
-          provider.answer!(
-            params.query,
-            providerOptions,
-            providerConfig as never,
-            context,
-          ),
+        query: params.query,
       });
     },
     renderCall(args, theme) {
@@ -444,14 +417,6 @@ function registerWebResearchTool(
         onUpdate,
         options: normalizeOptions(params.options),
         input: params.input,
-        invoke: (provider, providerConfig, providerOptions, context) =>
-          invokePerplexityResearchBypass(
-            provider,
-            params.input,
-            providerOptions,
-            providerConfig,
-            context,
-          ),
       });
     },
     renderCall(args, theme) {
@@ -630,8 +595,10 @@ async function executeProviderTool({
   signal,
   onUpdate,
   options,
+  urls,
+  query,
   input,
-  invoke,
+  planOverride,
 }: {
   capability: Exclude<ProviderCapability, "search">;
   config: WebProvidersConfig;
@@ -645,17 +612,10 @@ async function executeProviderTool({
       }) => void)
     | undefined;
   options: JsonObject | undefined;
+  urls?: string[];
+  query?: string;
   input?: string;
-  invoke: (
-    provider: (typeof PROVIDERS)[number],
-    providerConfig: ProviderConfigUnion,
-    providerOptions: JsonObject | undefined,
-    context: {
-      cwd: string;
-      signal?: AbortSignal;
-      onProgress?: (message: string) => void;
-    },
-  ) => Promise<ProviderToolOutput>;
+  planOverride?: ProviderOperationPlan<ProviderToolOutput>;
 }) {
   const provider = resolveProviderForCapability(
     config,
@@ -673,101 +633,33 @@ async function executeProviderTool({
     provider.id,
     onUpdate,
   );
-  const providerOptions = stripLocalExecutionOptions(options);
   const providerContext = {
     cwd: ctx.cwd,
     signal: signal ?? undefined,
     onProgress: progress.report,
   };
+  const plan =
+    planOverride ??
+    buildProviderPlan(
+      provider,
+      providerConfig as ProviderConfigUnion,
+      buildOperationRequest(capability, {
+        urls,
+        query,
+        input,
+        options: stripLocalExecutionOptions(options),
+      }),
+    );
 
   let response: ProviderToolOutput;
   try {
-    if (capability === "research") {
-      assertResearchOptionsSupported(options);
-
-      if (isBlockingResearchProvider(provider)) {
-        // Perplexity deep research is synchronous today, so it intentionally
-        // bypasses the lifecycle path instead of introducing a second generic
-        // research abstraction.
-        assertBlockingResearchOptionsSupported(provider.label, options);
-        response = await runWithExecutionPolicy(
-          `${provider.label} research request`,
-          (attemptContext) =>
-            invoke(
-              provider,
-              providerConfig as ProviderConfigUnion,
-              providerOptions,
-              attemptContext,
-            ),
-          resolveRequestExecutionPolicy(provider.id, providerConfig, options),
-          providerContext,
-        );
-      } else {
-        const researchPolicy = resolveResearchExecutionPolicy(
-          provider.id,
-          providerConfig,
-          options,
-        );
-        const supportsSafeStartRetries =
-          provider.supportsIdempotentResearchStartRetries === true;
-        const supportsSafeStartTimeouts = supportsSafeStartRetries;
-        const supportsPollCancellation =
-          provider.supportsResearchPollingCancellation === true;
-        response = await executeResearchWithLifecycle({
-          providerLabel: provider.label,
-          providerId: provider.id,
-          input: input ?? "",
-          options,
-          context: providerContext,
-          policy: researchPolicy,
-          startRetryCount: supportsSafeStartRetries
-            ? researchPolicy.retryCount
-            : 0,
-          startRetryNotice:
-            !supportsSafeStartRetries && researchPolicy.retryCount > 0
-              ? `${provider.label} research start retries are disabled to avoid duplicate background jobs; configured retries apply after the job starts.`
-              : undefined,
-          startIdempotencyKey: supportsSafeStartRetries
-            ? `pi-web-providers:${provider.id}:${randomUUID()}`
-            : undefined,
-          startRetryOnTimeout: supportsSafeStartRetries,
-          startRequestTimeoutMs: supportsSafeStartTimeouts
-            ? researchPolicy.requestTimeoutMs
-            : null,
-          pollRequestTimeoutMs: supportsPollCancellation
-            ? researchPolicy.requestTimeoutMs
-            : null,
-          deferDeadlineUntilStarted: !supportsSafeStartRetries,
-          start: (input, researchOptions, context) =>
-            provider.startResearch!(
-              input,
-              researchOptions,
-              providerConfig as never,
-              context,
-            ),
-          poll: (id, researchOptions, context) =>
-            provider.pollResearch!(
-              id,
-              researchOptions,
-              providerConfig as never,
-              context,
-            ),
-        });
-      }
-    } else {
-      response = await runWithExecutionPolicy(
-        `${provider.label} ${capability} request`,
-        (attemptContext) =>
-          invoke(
-            provider,
-            providerConfig as ProviderConfigUnion,
-            providerOptions,
-            attemptContext,
-          ),
-        resolveRequestExecutionPolicy(provider.id, providerConfig, options),
-        providerContext,
+    const result = await executeOperationPlan(plan, options, providerContext);
+    if (isSearchResponse(result)) {
+      throw new Error(
+        `${provider.label} ${capability} returned an invalid result.`,
       );
     }
+    response = result;
   } finally {
     progress.stop();
   }
@@ -786,67 +678,56 @@ async function executeProviderTool({
   };
 }
 
-function invokePerplexityResearchBypass(
-  provider: (typeof PROVIDERS)[number],
-  input: string,
-  options: JsonObject | undefined,
-  providerConfig: ProviderConfigUnion,
-  context: {
-    cwd: string;
-    signal?: AbortSignal;
-    onProgress?: (message: string) => void;
+function buildOperationRequest(
+  capability: Exclude<ProviderCapability, "search">,
+  args: {
+    options: JsonObject | undefined;
+    urls?: string[];
+    query?: string;
+    input?: string;
   },
-): Promise<ProviderToolOutput> {
-  if (isBlockingResearchProvider(provider)) {
-    return provider.research(
-      input,
-      options,
-      providerConfig as PerplexityProviderConfig,
-      context,
-    );
+): ProviderOperationRequest {
+  if (capability === "contents") {
+    return {
+      capability,
+      urls: args.urls ?? [],
+      options: args.options,
+    };
   }
 
-  throw new Error(
-    `Provider '${provider.id}' does not use the Perplexity research bypass.`,
-  );
+  if (capability === "answer") {
+    return {
+      capability,
+      query: args.query ?? "",
+      options: args.options,
+    };
+  }
+
+  return {
+    capability,
+    input: args.input ?? "",
+    options: args.options,
+  };
 }
 
-function isBlockingResearchProvider(
+function buildProviderPlan(
   provider: (typeof PROVIDERS)[number],
-): provider is BlockingResearchProvider {
-  return (
-    provider.id === "perplexity" &&
-    "research" in provider &&
-    typeof provider.research === "function"
-  );
-}
-
-function assertResearchOptionsSupported(options: JsonObject | undefined): void {
-  if (options?.resumeInteractionId !== undefined) {
+  providerConfig: ProviderConfigUnion,
+  request: ProviderOperationRequest,
+) {
+  const plan = provider.buildPlan(request, providerConfig as never);
+  if (!plan) {
     throw new Error(
-      "resumeInteractionId is not supported. Use resumeId instead.",
+      `Provider '${provider.id}' could not build a plan for '${request.capability}'.`,
     );
   }
+  return plan;
 }
 
-function assertBlockingResearchOptionsSupported(
-  providerLabel: string,
-  options: JsonObject | undefined,
-): void {
-  const unsupported = [
-    ["pollIntervalMs", options?.pollIntervalMs],
-    ["timeoutMs", options?.timeoutMs],
-    ["maxConsecutivePollErrors", options?.maxConsecutivePollErrors],
-    ["resumeId", options?.resumeId],
-  ].flatMap(([key, value]) => (value === undefined ? [] : [key]));
-
-  if (unsupported.length === 0) {
-    return;
-  }
-
-  throw new Error(
-    `${providerLabel} research runs synchronously and does not support ${unsupported.join(", ")}. Use requestTimeoutMs/retryCount/retryDelayMs instead.`,
-  );
+function isSearchResponse(
+  value: SearchResponse | ProviderToolOutput,
+): value is SearchResponse {
+  return "results" in value;
 }
 
 function normalizeOptions(value: unknown): JsonObject | undefined {
@@ -976,43 +857,6 @@ function renderProviderToolResult(
   return new Text(summaryText, 0, 0);
 }
 
-interface ProviderMenuOption {
-  key:
-    | "apiKey"
-    | "baseUrl"
-    | "model"
-    | "claudePathToExecutable"
-    | "claudeEffort"
-    | "claudeMaxTurns"
-    | "modelReasoningEffort"
-    | "webSearchMode"
-    | "networkAccessEnabled"
-    | "webSearchEnabled"
-    | "additionalDirectories"
-    | "exaSearchType"
-    | "exaTextContents"
-    | "geminiApiVersion"
-    | "geminiSearchModel"
-    | "geminiContentsModel"
-    | "geminiAnswerModel"
-    | "geminiResearchAgent"
-    | "geminiRequestTimeoutMs"
-    | "geminiRetryCount"
-    | "geminiRetryDelayMs"
-    | "geminiResearchPollIntervalMs"
-    | "geminiResearchTimeoutMs"
-    | "geminiResearchMaxPollErrors"
-    | "parallelSearchMode"
-    | "parallelExtractExcerpts"
-    | "parallelExtractFullContent"
-    | "valyuSearchType"
-    | "valyuResponseLength";
-  label: string;
-  help: string;
-  kind: "text" | "values";
-  values?: string[];
-}
-
 interface ProviderToolMenuOption {
   key: ProviderToolId;
   label: string;
@@ -1038,267 +882,11 @@ function buildProviderToolMenuOptions(
   }));
 }
 
-function buildProviderMenuOptions(
+function getProviderSettings(
   providerId: ProviderId,
-): ProviderMenuOption[] {
-  const options: ProviderMenuOption[] = [];
-
-  const pushText = (
-    key:
-      | "apiKey"
-      | "baseUrl"
-      | "model"
-      | "claudePathToExecutable"
-      | "claudeMaxTurns"
-      | "additionalDirectories"
-      | "geminiSearchModel"
-      | "geminiContentsModel"
-      | "geminiAnswerModel"
-      | "geminiResearchAgent"
-      | "geminiRequestTimeoutMs"
-      | "geminiRetryCount"
-      | "geminiRetryDelayMs"
-      | "geminiResearchPollIntervalMs"
-      | "geminiResearchTimeoutMs"
-      | "geminiResearchMaxPollErrors",
-    label: string,
-    help: string,
-  ) => {
-    options.push({
-      key,
-      label,
-      help,
-      kind: "text",
-    });
-  };
-
-  const pushValues = (
-    key:
-      | "claudeEffort"
-      | "modelReasoningEffort"
-      | "webSearchMode"
-      | "networkAccessEnabled"
-      | "webSearchEnabled"
-      | "exaSearchType"
-      | "exaTextContents"
-      | "geminiApiVersion"
-      | "parallelSearchMode"
-      | "parallelExtractExcerpts"
-      | "parallelExtractFullContent"
-      | "valyuSearchType"
-      | "valyuResponseLength",
-    label: string,
-    help: string,
-    values: string[],
-  ) => {
-    options.push({
-      key,
-      label,
-      help,
-      kind: "values",
-      values,
-    });
-  };
-
-  if (providerId === "claude") {
-    pushText(
-      "model",
-      "Model",
-      "Optional Claude model override. Leave empty to use the local default.",
-    );
-    pushValues(
-      "claudeEffort",
-      "Effort",
-      "How much effort Claude should use. 'default' uses the SDK default.",
-      ["default", "low", "medium", "high", "max"],
-    );
-    pushText(
-      "claudeMaxTurns",
-      "Max turns",
-      "Optional maximum number of Claude turns. Leave empty to use the SDK default.",
-    );
-    pushText(
-      "claudePathToExecutable",
-      "Executable path",
-      "Optional path to the Claude Code executable. Leave empty to use the bundled/default executable.",
-    );
-    return options;
-  }
-
-  if (providerId === "codex") {
-    pushText(
-      "model",
-      "Model",
-      "Optional Codex model override. Leave empty to use the local default.",
-    );
-    pushValues(
-      "modelReasoningEffort",
-      "Reasoning effort",
-      "Reasoning depth for Codex. 'default' uses the SDK default.",
-      ["default", "minimal", "low", "medium", "high", "xhigh"],
-    );
-    pushValues(
-      "webSearchMode",
-      "Web search mode",
-      "How Codex should source web results. 'default' currently behaves like 'live'.",
-      ["default", "disabled", "cached", "live"],
-    );
-    pushValues(
-      "networkAccessEnabled",
-      "Network access",
-      "Allow Codex network access during search runs. 'default' currently behaves like 'true'.",
-      ["default", "true", "false"],
-    );
-    pushValues(
-      "webSearchEnabled",
-      "Web search",
-      "Enable Codex web search. 'default' currently behaves like 'true'.",
-      ["default", "true", "false"],
-    );
-    pushText(
-      "additionalDirectories",
-      "Additional dirs",
-      "Optional comma-separated directories that Codex may read in addition to the current working directory.",
-    );
-    return options;
-  }
-
-  pushText(
-    "apiKey",
-    "API key",
-    "Provider API key. You can use a literal value, an env var name like EXA_API_KEY, or !command.",
-  );
-  if (providerId !== "gemini") {
-    pushText("baseUrl", "Base URL", "Optional API base URL override.");
-  }
-
-  if (providerId === "exa") {
-    pushValues(
-      "exaSearchType",
-      "Search type",
-      "Exa search mode. 'default' uses the SDK default.",
-      [
-        "default",
-        "keyword",
-        "neural",
-        "auto",
-        "hybrid",
-        "fast",
-        "instant",
-        "deep",
-        "deep-reasoning",
-        "deep-max",
-      ],
-    );
-    pushValues(
-      "exaTextContents",
-      "Text contents",
-      "Whether Exa should include text contents in search results. 'default' uses the SDK default.",
-      ["default", "true", "false"],
-    );
-    return options;
-  }
-
-  if (providerId === "gemini") {
-    pushValues(
-      "geminiApiVersion",
-      "API version",
-      "Gemini API version. 'default' uses the SDK default beta endpoints.",
-      ["default", "v1alpha", "v1beta", "v1"],
-    );
-    pushText(
-      "geminiSearchModel",
-      "Search model",
-      "Model used for Gemini search interactions.",
-    );
-    pushText(
-      "geminiContentsModel",
-      "Contents model",
-      "Model used for Gemini URL content extraction via URL Context.",
-    );
-    pushText(
-      "geminiAnswerModel",
-      "Answer model",
-      "Model used for grounded Gemini answers.",
-    );
-    pushText(
-      "geminiResearchAgent",
-      "Research agent",
-      "Agent used for Gemini deep research runs.",
-    );
-    pushText(
-      "geminiRequestTimeoutMs",
-      "Request timeout (ms)",
-      "Maximum time to wait for a single Gemini API request before failing that attempt. Timed-out requests are generally not retried, except for idempotent research-start operations.",
-    );
-    pushText(
-      "geminiRetryCount",
-      "Retry count",
-      "How many times Gemini requests should be retried after transient failures.",
-    );
-    pushText(
-      "geminiRetryDelayMs",
-      "Retry delay (ms)",
-      "Initial delay before retrying failed Gemini requests. Later retries back off automatically.",
-    );
-    pushText(
-      "geminiResearchPollIntervalMs",
-      "Research poll interval (ms)",
-      "How often to poll Gemini background research jobs for updates.",
-    );
-    pushText(
-      "geminiResearchTimeoutMs",
-      "Research timeout (ms)",
-      "Maximum total time to wait for Gemini research before returning a resumable timeout error.",
-    );
-    pushText(
-      "geminiResearchMaxPollErrors",
-      "Max poll errors",
-      "How many consecutive polling failures to tolerate before the Gemini research run stops locally.",
-    );
-    return options;
-  }
-
-  if (providerId === "perplexity") {
-    return options;
-  }
-
-  if (providerId === "parallel") {
-    pushValues(
-      "parallelSearchMode",
-      "Search mode",
-      "Parallel search mode. 'default' uses the SDK default.",
-      ["default", "agentic", "one-shot"],
-    );
-    pushValues(
-      "parallelExtractExcerpts",
-      "Extract excerpts",
-      "Include excerpts in Parallel extraction results. 'default' uses the SDK default.",
-      ["default", "on", "off"],
-    );
-    pushValues(
-      "parallelExtractFullContent",
-      "Extract full content",
-      "Include full page content in Parallel extraction results. 'default' uses the SDK default.",
-      ["default", "on", "off"],
-    );
-    return options;
-  }
-
-  pushValues(
-    "valyuSearchType",
-    "Search type",
-    "Valyu search type. 'default' uses the SDK default.",
-    ["default", "all", "web", "proprietary", "news"],
-  );
-  pushValues(
-    "valyuResponseLength",
-    "Response length",
-    "Valyu response length. 'default' uses the SDK default.",
-    ["default", "short", "medium", "large", "max"],
-  );
-
-  return options;
+): readonly ProviderSettingDescriptor<ProviderConfigUnion>[] {
+  return getProviderConfigManifest(providerId)
+    .settings as readonly ProviderSettingDescriptor<ProviderConfigUnion>[];
 }
 
 class WebProvidersSettingsView implements Component {
@@ -1342,7 +930,12 @@ class WebProvidersSettingsView implements Component {
 
     const configItems = this.buildConfigSectionItems();
     lines.push(
-      ...this.renderSection(width, "Provider config", "config", configItems),
+      ...this.renderSection(
+        width,
+        "Provider config & policy",
+        "config",
+        configItems,
+      ),
     );
 
     const selected = this.getSelectedEntry();
@@ -1439,88 +1032,34 @@ class WebProvidersSettingsView implements Component {
 
   private buildConfigSectionItems(): SettingsEntry[] {
     const providerConfig = this.currentProviderConfig();
-    return buildProviderMenuOptions(this.activeProvider).map((option) =>
-      this.buildProviderItem(option, providerConfig),
+    return getProviderSettings(this.activeProvider).map((setting) =>
+      this.buildProviderItem(setting, providerConfig),
     );
   }
 
   private buildProviderItem(
-    option: ProviderMenuOption,
+    setting: ProviderSettingDescriptor<ProviderConfigUnion>,
     providerConfig: ProviderConfigUnion | undefined,
   ): SettingsEntry {
-    if (option.kind === "values") {
+    if (setting.kind === "values") {
       return {
-        id: option.key,
-        label: option.label,
-        currentValue: getProviderChoiceValue(
-          this.activeProvider,
-          providerConfig,
-          option.key as
-            | "claudeEffort"
-            | "modelReasoningEffort"
-            | "webSearchMode"
-            | "networkAccessEnabled"
-            | "webSearchEnabled"
-            | "exaSearchType"
-            | "exaTextContents"
-            | "geminiApiVersion"
-            | "parallelSearchMode"
-            | "parallelExtractExcerpts"
-            | "parallelExtractFullContent"
-            | "valyuSearchType"
-            | "valyuResponseLength",
-        ),
-        values: option.values,
-        description: option.help,
+        id: setting.id,
+        label: setting.label,
+        currentValue: setting.getValue(providerConfig),
+        values: setting.values,
+        description: setting.help,
         kind: "cycle",
       };
     }
 
-    if (option.kind === "text") {
-      const key = option.key as ProviderMenuOption["key"];
-      const currentValue =
-        this.activeProvider === "claude" &&
-        (key === "model" ||
-          key === "claudePathToExecutable" ||
-          key === "claudeMaxTurns")
-          ? getClaudeTextSettingValue(
-              providerConfig as ClaudeProviderConfig | undefined,
-              key,
-            )
-          : key === "model" || key === "additionalDirectories"
-            ? getCodexTextSettingValue(
-                providerConfig as CodexProviderConfig | undefined,
-                key,
-              )
-            : key === "geminiSearchModel" ||
-                key === "geminiContentsModel" ||
-                key === "geminiAnswerModel" ||
-                key === "geminiResearchAgent" ||
-                key === "geminiRequestTimeoutMs" ||
-                key === "geminiRetryCount" ||
-                key === "geminiRetryDelayMs" ||
-                key === "geminiResearchPollIntervalMs" ||
-                key === "geminiResearchTimeoutMs" ||
-                key === "geminiResearchMaxPollErrors"
-              ? getGeminiTextSettingValue(
-                  providerConfig as GeminiProviderConfig | undefined,
-                  key,
-                )
-              : getProviderStringValue(
-                  providerConfig,
-                  key as "apiKey" | "baseUrl",
-                );
-      const secret = key === "apiKey";
-      return {
-        id: key,
-        label: option.label,
-        currentValue: summarizeStringValue(currentValue, secret),
-        description: option.help,
-        kind: "text",
-      };
-    }
-
-    throw new Error(`Unsupported provider menu option: ${option.key}`);
+    const currentValue = setting.getValue(providerConfig);
+    return {
+      id: setting.id,
+      label: setting.label,
+      currentValue: summarizeStringValue(currentValue, setting.secret === true),
+      description: setting.help,
+      kind: "text",
+    };
   }
 
   private currentProviderConfig(): ProviderConfigUnion | undefined {
@@ -1668,44 +1207,13 @@ class WebProvidersSettingsView implements Component {
 
   private getEntryRawValue(id: string): string | undefined {
     const providerConfig = this.currentProviderConfig();
-    if (id === "apiKey" || id === "baseUrl") {
-      return getProviderStringValue(providerConfig, id);
+    const setting = getProviderSettings(this.activeProvider).find(
+      (candidate) => candidate.id === id,
+    );
+    if (!setting || setting.kind !== "text") {
+      return undefined;
     }
-    if (
-      this.activeProvider === "claude" &&
-      (id === "model" ||
-        id === "claudePathToExecutable" ||
-        id === "claudeMaxTurns")
-    ) {
-      return getClaudeTextSettingValue(
-        providerConfig as ClaudeProviderConfig | undefined,
-        id,
-      );
-    }
-    if (id === "model" || id === "additionalDirectories") {
-      return getCodexTextSettingValue(
-        providerConfig as CodexProviderConfig | undefined,
-        id,
-      );
-    }
-    if (
-      id === "geminiSearchModel" ||
-      id === "geminiContentsModel" ||
-      id === "geminiAnswerModel" ||
-      id === "geminiResearchAgent" ||
-      id === "geminiRequestTimeoutMs" ||
-      id === "geminiRetryCount" ||
-      id === "geminiRetryDelayMs" ||
-      id === "geminiResearchPollIntervalMs" ||
-      id === "geminiResearchTimeoutMs" ||
-      id === "geminiResearchMaxPollErrors"
-    ) {
-      return getGeminiTextSettingValue(
-        providerConfig as GeminiProviderConfig | undefined,
-        id,
-      );
-    }
-    return undefined;
+    return setting.getValue(providerConfig);
   }
 
   private async handleChange(id: string, value: string): Promise<void> {
@@ -1732,80 +1240,26 @@ class WebProvidersSettingsView implements Component {
         config.providers?.[this.activeProvider] as
           | ProviderConfigUnion
           | undefined,
-      ) as Record<string, JsonObject | string | boolean | undefined>;
+      );
 
       if (id.startsWith("tool:")) {
         const toolId = id.slice("tool:".length) as ProviderToolId;
-        const typedProviderConfig =
-          providerConfig as unknown as ProviderConfigUnion;
-        const tools = (typedProviderConfig.tools ?? {}) as Partial<
+        const tools = (providerConfig.tools ?? {}) as Partial<
           Record<ProviderToolId, boolean>
         >;
         tools[toolId] = value === "on";
-        typedProviderConfig.tools = tools as typeof typedProviderConfig.tools;
-        config.providers[this.activeProvider] = typedProviderConfig as never;
+        providerConfig.tools = tools as typeof providerConfig.tools;
+        config.providers[this.activeProvider] = providerConfig as never;
         return;
       }
 
-      if (id === "apiKey" || id === "baseUrl") {
-        assignOptionalString(providerConfig, id, value);
-      } else if (
-        this.activeProvider === "claude" &&
-        applyClaudeSettingChange(
-          providerConfig as unknown as ClaudeProviderConfig,
-          id,
-          value,
-        )
-      ) {
-        // handled above
-      } else if (
-        this.activeProvider === "codex" &&
-        applyCodexSettingChange(
-          providerConfig as unknown as CodexProviderConfig,
-          id,
-          value,
-        )
-      ) {
-        // handled above
-      } else if (
-        this.activeProvider === "exa" &&
-        applyExaSettingChange(
-          providerConfig as unknown as ExaProviderConfig,
-          id,
-          value,
-        )
-      ) {
-        // handled above
-      } else if (
-        this.activeProvider === "gemini" &&
-        applyGeminiSettingChange(
-          providerConfig as unknown as GeminiProviderConfig,
-          id,
-          value,
-        )
-      ) {
-        // handled above
-      } else if (
-        this.activeProvider === "parallel" &&
-        applyParallelSettingChange(
-          providerConfig as unknown as ParallelProviderConfig,
-          id,
-          value,
-        )
-      ) {
-        // handled above
-      } else if (
-        this.activeProvider === "valyu" &&
-        applyValyuSettingChange(
-          providerConfig as unknown as ValyuProviderConfig,
-          id,
-          value,
-        )
-      ) {
-        // handled above
-      } else {
+      const setting = getProviderSettings(this.activeProvider).find(
+        (candidate) => candidate.id === id,
+      );
+      if (!setting) {
         throw new Error(`Unknown setting '${id}'.`);
       }
+      setting.setValue(providerConfig, value);
       config.providers[this.activeProvider] = providerConfig as never;
     });
   }
@@ -1942,632 +1396,6 @@ function summarizeStringValue(
     return "literal";
   }
   return truncateInline(value, 40);
-}
-
-function getProviderStringValue(
-  config: ProviderConfigUnion | undefined,
-  key: "apiKey" | "baseUrl",
-): string | undefined {
-  if (!config) return undefined;
-  const value = (config as Record<string, unknown>)[key];
-  return typeof value === "string" ? value : undefined;
-}
-
-function getProviderChoiceValue(
-  providerId: ProviderId,
-  config: ProviderConfigUnion | undefined,
-  key:
-    | "claudeEffort"
-    | "modelReasoningEffort"
-    | "webSearchMode"
-    | "networkAccessEnabled"
-    | "webSearchEnabled"
-    | "exaSearchType"
-    | "exaTextContents"
-    | "geminiApiVersion"
-    | "parallelSearchMode"
-    | "parallelExtractExcerpts"
-    | "parallelExtractFullContent"
-    | "valyuSearchType"
-    | "valyuResponseLength",
-): string {
-  if (providerId === "claude") {
-    const defaults = (config as ClaudeProviderConfig | undefined)?.defaults;
-    if (key === "claudeEffort") {
-      return typeof defaults?.effort === "string" ? defaults.effort : "default";
-    }
-  }
-
-  if (providerId === "codex") {
-    const defaults = (config as CodexProviderConfig | undefined)?.defaults;
-    if (key === "networkAccessEnabled" || key === "webSearchEnabled") {
-      const value = defaults?.[key];
-      return typeof value === "boolean" ? String(value) : "default";
-    }
-    if (key === "modelReasoningEffort" || key === "webSearchMode") {
-      const value = defaults?.[key];
-      return typeof value === "string" ? value : "default";
-    }
-  }
-
-  if (providerId === "exa") {
-    const defaults = (config as ExaProviderConfig | undefined)?.defaults as
-      | Record<string, unknown>
-      | undefined;
-    if (key === "exaSearchType") {
-      return typeof defaults?.type === "string" ? defaults.type : "default";
-    }
-    if (key === "exaTextContents") {
-      const contents = isJsonObject(defaults?.contents)
-        ? defaults.contents
-        : undefined;
-      return typeof contents?.text === "boolean"
-        ? String(contents.text)
-        : "default";
-    }
-  }
-
-  if (providerId === "valyu") {
-    const defaults = (config as ValyuProviderConfig | undefined)?.defaults as
-      | Record<string, unknown>
-      | undefined;
-    if (key === "valyuSearchType") {
-      return typeof defaults?.searchType === "string"
-        ? defaults.searchType
-        : "default";
-    }
-    if (key === "valyuResponseLength") {
-      return typeof defaults?.responseLength === "string"
-        ? defaults.responseLength
-        : "default";
-    }
-  }
-
-  if (providerId === "gemini") {
-    const defaults = (config as GeminiProviderConfig | undefined)?.defaults;
-    if (key === "geminiApiVersion") {
-      return typeof defaults?.apiVersion === "string"
-        ? defaults.apiVersion
-        : "default";
-    }
-  }
-
-  if (providerId === "parallel") {
-    const defaults = (config as ParallelProviderConfig | undefined)?.defaults;
-    const search = isJsonObject(defaults?.search) ? defaults.search : undefined;
-    const extract = isJsonObject(defaults?.extract)
-      ? defaults.extract
-      : undefined;
-    if (key === "parallelSearchMode") {
-      return typeof search?.mode === "string" ? search.mode : "default";
-    }
-    if (key === "parallelExtractExcerpts") {
-      if (extract?.excerpts === undefined) return "default";
-      return extract.excerpts ? "on" : "off";
-    }
-    if (key === "parallelExtractFullContent") {
-      if (extract?.full_content === undefined) return "default";
-      return extract.full_content ? "on" : "off";
-    }
-  }
-
-  throw new Error(`Unsupported choice setting '${key}' for '${providerId}'.`);
-}
-
-function getClaudeTextSettingValue(
-  config: ClaudeProviderConfig | undefined,
-  key: "model" | "claudePathToExecutable" | "claudeMaxTurns",
-): string | undefined {
-  if (key === "claudePathToExecutable") {
-    return config?.pathToClaudeCodeExecutable;
-  }
-
-  const defaults = config?.defaults;
-  if (!defaults) return undefined;
-  if (key === "claudeMaxTurns") {
-    return typeof defaults.maxTurns === "number"
-      ? String(defaults.maxTurns)
-      : undefined;
-  }
-  return defaults.model;
-}
-
-function getCodexTextSettingValue(
-  config: CodexProviderConfig | undefined,
-  key: "model" | "additionalDirectories",
-): string | undefined {
-  const defaults = config?.defaults;
-  if (!defaults) return undefined;
-  if (key === "additionalDirectories") {
-    return defaults.additionalDirectories?.join(", ");
-  }
-  return defaults.model;
-}
-
-function getGeminiTextSettingValue(
-  config: GeminiProviderConfig | undefined,
-  key:
-    | "geminiSearchModel"
-    | "geminiContentsModel"
-    | "geminiAnswerModel"
-    | "geminiResearchAgent"
-    | "geminiRequestTimeoutMs"
-    | "geminiRetryCount"
-    | "geminiRetryDelayMs"
-    | "geminiResearchPollIntervalMs"
-    | "geminiResearchTimeoutMs"
-    | "geminiResearchMaxPollErrors",
-): string | undefined {
-  const defaults = config?.defaults;
-  if (!defaults) return undefined;
-  if (key === "geminiSearchModel") return defaults.searchModel;
-  if (key === "geminiContentsModel") return defaults.contentsModel;
-  if (key === "geminiAnswerModel") return defaults.answerModel;
-  if (key === "geminiResearchAgent") return defaults.researchAgent;
-  if (key === "geminiRequestTimeoutMs") {
-    return typeof defaults.requestTimeoutMs === "number"
-      ? String(defaults.requestTimeoutMs)
-      : undefined;
-  }
-  if (key === "geminiRetryCount") {
-    return typeof defaults.retryCount === "number"
-      ? String(defaults.retryCount)
-      : undefined;
-  }
-  if (key === "geminiRetryDelayMs") {
-    return typeof defaults.retryDelayMs === "number"
-      ? String(defaults.retryDelayMs)
-      : undefined;
-  }
-  if (key === "geminiResearchPollIntervalMs") {
-    return typeof defaults.researchPollIntervalMs === "number"
-      ? String(defaults.researchPollIntervalMs)
-      : undefined;
-  }
-  if (key === "geminiResearchTimeoutMs") {
-    return typeof defaults.researchTimeoutMs === "number"
-      ? String(defaults.researchTimeoutMs)
-      : undefined;
-  }
-  return typeof defaults.researchMaxConsecutivePollErrors === "number"
-    ? String(defaults.researchMaxConsecutivePollErrors)
-    : undefined;
-}
-
-function assignOptionalString(
-  target: Record<string, JsonObject | string | boolean | undefined>,
-  key: string,
-  value: string,
-): void {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    delete target[key];
-  } else {
-    target[key] = trimmed;
-  }
-}
-
-function assignOptionalInteger(
-  target: Record<string, JsonObject | string | number | boolean | undefined>,
-  key: string,
-  value: string,
-  errorMessage: string,
-  options?: { allowZero?: boolean },
-): void {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    delete target[key];
-    return;
-  }
-
-  const parsed = Number(trimmed);
-  const minimum = options?.allowZero ? 0 : 1;
-  if (!Number.isInteger(parsed) || parsed < minimum) {
-    throw new Error(errorMessage);
-  }
-
-  target[key] = parsed;
-}
-
-function applyClaudeSettingChange(
-  target: ClaudeProviderConfig,
-  key: string,
-  value: string,
-): boolean {
-  target.defaults ??= {};
-
-  switch (key) {
-    case "model":
-      assignOptionalString(
-        target.defaults as Record<
-          string,
-          JsonObject | string | boolean | undefined
-        >,
-        "model",
-        value,
-      );
-      cleanupClaudeDefaults(target);
-      return true;
-    case "claudePathToExecutable":
-      assignOptionalString(
-        target as Record<string, JsonObject | string | boolean | undefined>,
-        "pathToClaudeCodeExecutable",
-        value,
-      );
-      cleanupClaudeDefaults(target);
-      return true;
-    case "claudeMaxTurns": {
-      const trimmed = value.trim();
-      if (!trimmed) {
-        delete target.defaults.maxTurns;
-      } else {
-        const parsed = Number(trimmed);
-        if (!Number.isInteger(parsed) || parsed < 1) {
-          throw new Error("Claude max turns must be a positive integer.");
-        }
-        target.defaults.maxTurns = parsed;
-      }
-      cleanupClaudeDefaults(target);
-      return true;
-    }
-    case "claudeEffort":
-      if (value === "default") {
-        delete target.defaults.effort;
-      } else {
-        target.defaults.effort = value as never;
-      }
-      cleanupClaudeDefaults(target);
-      return true;
-    default:
-      return false;
-  }
-}
-
-function applyCodexSettingChange(
-  target: CodexProviderConfig,
-  key: string,
-  value: string,
-): boolean {
-  target.defaults ??= {};
-
-  switch (key) {
-    case "model":
-      assignOptionalString(
-        target.defaults as Record<
-          string,
-          JsonObject | string | boolean | undefined
-        >,
-        "model",
-        value,
-      );
-      cleanupCodexDefaults(target);
-      return true;
-    case "additionalDirectories": {
-      const trimmed = value.trim();
-      if (!trimmed) {
-        delete target.defaults.additionalDirectories;
-      } else {
-        target.defaults.additionalDirectories = trimmed
-          .split(",")
-          .map((entry) => entry.trim())
-          .filter((entry) => entry.length > 0);
-      }
-      cleanupCodexDefaults(target);
-      return true;
-    }
-    case "modelReasoningEffort":
-    case "webSearchMode":
-      if (value === "default") {
-        delete target.defaults[key];
-      } else {
-        target.defaults[key] = value as never;
-      }
-      cleanupCodexDefaults(target);
-      return true;
-    case "networkAccessEnabled":
-    case "webSearchEnabled":
-      if (value === "default") {
-        delete target.defaults[key];
-      } else {
-        target.defaults[key] = value === "true";
-      }
-      cleanupCodexDefaults(target);
-      return true;
-    default:
-      return false;
-  }
-}
-
-function applyExaSettingChange(
-  target: ExaProviderConfig,
-  key: string,
-  value: string,
-): boolean {
-  target.defaults = isJsonObject(target.defaults) ? { ...target.defaults } : {};
-
-  switch (key) {
-    case "exaSearchType":
-      if (value === "default") {
-        delete target.defaults.type;
-      } else {
-        target.defaults.type = value;
-      }
-      cleanupGenericDefaults(target);
-      return true;
-    case "exaTextContents": {
-      const contents = isJsonObject(target.defaults.contents)
-        ? { ...target.defaults.contents }
-        : {};
-      if (value === "default") {
-        delete contents.text;
-      } else {
-        contents.text = value === "true";
-      }
-      if (Object.keys(contents).length === 0) {
-        delete target.defaults.contents;
-      } else {
-        target.defaults.contents = contents;
-      }
-      cleanupGenericDefaults(target);
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-
-function applyValyuSettingChange(
-  target: ValyuProviderConfig,
-  key: string,
-  value: string,
-): boolean {
-  target.defaults = isJsonObject(target.defaults) ? { ...target.defaults } : {};
-
-  switch (key) {
-    case "valyuSearchType":
-      if (value === "default") {
-        delete target.defaults.searchType;
-      } else {
-        target.defaults.searchType = value;
-      }
-      cleanupGenericDefaults(target);
-      return true;
-    case "valyuResponseLength":
-      if (value === "default") {
-        delete target.defaults.responseLength;
-      } else {
-        target.defaults.responseLength = value;
-      }
-      cleanupGenericDefaults(target);
-      return true;
-    default:
-      return false;
-  }
-}
-
-function applyGeminiSettingChange(
-  target: GeminiProviderConfig,
-  key: string,
-  value: string,
-): boolean {
-  target.defaults ??= {};
-
-  switch (key) {
-    case "geminiApiVersion":
-      if (value === "default") {
-        delete target.defaults.apiVersion;
-      } else {
-        target.defaults.apiVersion = value;
-      }
-      cleanupGeminiDefaults(target);
-      return true;
-    case "geminiSearchModel":
-      assignOptionalString(
-        target.defaults as Record<
-          string,
-          JsonObject | string | boolean | undefined
-        >,
-        "searchModel",
-        value,
-      );
-      cleanupGeminiDefaults(target);
-      return true;
-    case "geminiContentsModel":
-      assignOptionalString(
-        target.defaults as Record<
-          string,
-          JsonObject | string | boolean | undefined
-        >,
-        "contentsModel",
-        value,
-      );
-      cleanupGeminiDefaults(target);
-      return true;
-    case "geminiAnswerModel":
-      assignOptionalString(
-        target.defaults as Record<
-          string,
-          JsonObject | string | boolean | undefined
-        >,
-        "answerModel",
-        value,
-      );
-      cleanupGeminiDefaults(target);
-      return true;
-    case "geminiResearchAgent":
-      assignOptionalString(
-        target.defaults as Record<
-          string,
-          JsonObject | string | boolean | undefined
-        >,
-        "researchAgent",
-        value,
-      );
-      cleanupGeminiDefaults(target);
-      return true;
-    case "geminiRequestTimeoutMs":
-      assignOptionalInteger(
-        target.defaults as Record<
-          string,
-          JsonObject | string | number | boolean | undefined
-        >,
-        "requestTimeoutMs",
-        value,
-        "Gemini request timeout must be a positive integer.",
-      );
-      cleanupGeminiDefaults(target);
-      return true;
-    case "geminiRetryCount":
-      assignOptionalInteger(
-        target.defaults as Record<
-          string,
-          JsonObject | string | number | boolean | undefined
-        >,
-        "retryCount",
-        value,
-        "Gemini retry count must be a non-negative integer.",
-        { allowZero: true },
-      );
-      cleanupGeminiDefaults(target);
-      return true;
-    case "geminiRetryDelayMs":
-      assignOptionalInteger(
-        target.defaults as Record<
-          string,
-          JsonObject | string | number | boolean | undefined
-        >,
-        "retryDelayMs",
-        value,
-        "Gemini retry delay must be a positive integer.",
-      );
-      cleanupGeminiDefaults(target);
-      return true;
-    case "geminiResearchPollIntervalMs":
-      assignOptionalInteger(
-        target.defaults as Record<
-          string,
-          JsonObject | string | number | boolean | undefined
-        >,
-        "researchPollIntervalMs",
-        value,
-        "Gemini research poll interval must be a positive integer.",
-      );
-      cleanupGeminiDefaults(target);
-      return true;
-    case "geminiResearchTimeoutMs":
-      assignOptionalInteger(
-        target.defaults as Record<
-          string,
-          JsonObject | string | number | boolean | undefined
-        >,
-        "researchTimeoutMs",
-        value,
-        "Gemini research timeout must be a positive integer.",
-      );
-      cleanupGeminiDefaults(target);
-      return true;
-    case "geminiResearchMaxPollErrors":
-      assignOptionalInteger(
-        target.defaults as Record<
-          string,
-          JsonObject | string | number | boolean | undefined
-        >,
-        "researchMaxConsecutivePollErrors",
-        value,
-        "Gemini max poll errors must be a positive integer.",
-      );
-      cleanupGeminiDefaults(target);
-      return true;
-    default:
-      return false;
-  }
-}
-
-function applyParallelSettingChange(
-  target: ParallelProviderConfig,
-  key: string,
-  value: string,
-): boolean {
-  target.defaults ??= {};
-  target.defaults.search = isJsonObject(target.defaults.search)
-    ? { ...target.defaults.search }
-    : {};
-  target.defaults.extract = isJsonObject(target.defaults.extract)
-    ? { ...target.defaults.extract }
-    : {};
-
-  switch (key) {
-    case "parallelSearchMode":
-      if (value === "default") {
-        delete target.defaults.search.mode;
-      } else {
-        target.defaults.search.mode = value;
-      }
-      cleanupParallelDefaults(target);
-      return true;
-    case "parallelExtractExcerpts":
-      if (value === "default") {
-        delete target.defaults.extract.excerpts;
-      } else {
-        target.defaults.extract.excerpts = value === "on";
-      }
-      cleanupParallelDefaults(target);
-      return true;
-    case "parallelExtractFullContent":
-      if (value === "default") {
-        delete target.defaults.extract.full_content;
-      } else {
-        target.defaults.extract.full_content = value === "on";
-      }
-      cleanupParallelDefaults(target);
-      return true;
-    default:
-      return false;
-  }
-}
-
-function cleanupClaudeDefaults(target: ClaudeProviderConfig): void {
-  if (target.defaults && Object.keys(target.defaults).length === 0) {
-    delete target.defaults;
-  }
-}
-
-function cleanupCodexDefaults(target: CodexProviderConfig): void {
-  if (target.defaults && Object.keys(target.defaults).length === 0) {
-    delete target.defaults;
-  }
-}
-
-function cleanupGenericDefaults(
-  target: ExaProviderConfig | ValyuProviderConfig,
-): void {
-  if (target.defaults && Object.keys(target.defaults).length === 0) {
-    delete target.defaults;
-  }
-}
-
-function cleanupGeminiDefaults(target: GeminiProviderConfig): void {
-  if (target.defaults && Object.keys(target.defaults).length === 0) {
-    delete target.defaults;
-  }
-}
-
-function cleanupParallelDefaults(target: ParallelProviderConfig): void {
-  if (
-    target.defaults?.search &&
-    Object.keys(target.defaults.search).length === 0
-  ) {
-    delete target.defaults.search;
-  }
-  if (
-    target.defaults?.extract &&
-    Object.keys(target.defaults.extract).length === 0
-  ) {
-    delete target.defaults.extract;
-  }
-  if (target.defaults && Object.keys(target.defaults).length === 0) {
-    delete target.defaults;
-  }
 }
 
 function isJsonObject(value: unknown): value is JsonObject {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1112,7 +1112,7 @@ function buildProviderMenuOptions(
     pushText(
       "geminiRequestTimeoutMs",
       "Request timeout (ms)",
-      "Maximum time to wait for a single Gemini API request before retrying.",
+      "Maximum time to wait for a single Gemini API request before failing that attempt. Timed-out requests are not retried.",
     );
     pushText(
       "geminiRetryCount",

--- a/src/index.ts
+++ b/src/index.ts
@@ -183,17 +183,13 @@ function registerWebSearchTool(
       try {
         response = await runWithExecutionPolicy(
           `${provider.label} search request`,
-          () =>
+          (attemptContext) =>
             provider.search!(
               params.query,
               maxResults,
               providerOptions,
               providerConfig as never,
-              {
-                cwd: ctx.cwd,
-                signal: signal ?? undefined,
-                onProgress: progress.report,
-              },
+              attemptContext,
             ),
           policy,
           {
@@ -707,12 +703,12 @@ async function executeProviderTool({
     } else {
       response = await runWithExecutionPolicy(
         `${provider.label} ${capability} request`,
-        () =>
+        (attemptContext) =>
           invoke(
             provider,
             providerConfig as ProviderConfigUnion,
             providerOptions,
-            providerContext,
+            attemptContext,
           ),
         resolveRequestExecutionPolicy(provider.id, providerConfig, options),
         providerContext,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -674,17 +675,29 @@ async function executeProviderTool({
       typeof provider.startResearch === "function" &&
       typeof provider.pollResearch === "function"
     ) {
+      const researchPolicy = resolveResearchExecutionPolicy(
+        provider.id,
+        providerConfig,
+        options,
+      );
+      const supportsSafeStartRetries = provider.id === "gemini";
       response = await executeResearchWithLifecycle({
         providerLabel: provider.label,
         providerId: provider.id,
         input: input ?? "",
         options,
         context: providerContext,
-        policy: resolveResearchExecutionPolicy(
-          provider.id,
-          providerConfig,
-          options,
-        ),
+        policy: researchPolicy,
+        startRetryCount: supportsSafeStartRetries
+          ? researchPolicy.retryCount
+          : 0,
+        startRetryNotice:
+          !supportsSafeStartRetries && researchPolicy.retryCount > 0
+            ? `${provider.label} research start retries are disabled to avoid duplicate background jobs; configured retries apply after the job starts.`
+            : undefined,
+        startIdempotencyKey: supportsSafeStartRetries
+          ? `pi-web-providers:${provider.id}:${randomUUID()}`
+          : undefined,
         start: (input, researchOptions, context) =>
           provider.startResearch!(
             input,

--- a/src/index.ts
+++ b/src/index.ts
@@ -682,6 +682,7 @@ async function executeProviderTool({
       );
       const supportsSafeStartRetries =
         provider.supportsIdempotentResearchStartRetries === true;
+      const supportsSafeStartTimeouts = supportsSafeStartRetries;
       const supportsPollCancellation =
         provider.supportsResearchPollingCancellation === true;
       response = await executeResearchWithLifecycle({
@@ -702,6 +703,9 @@ async function executeProviderTool({
           ? `pi-web-providers:${provider.id}:${randomUUID()}`
           : undefined,
         startRetryOnTimeout: supportsSafeStartRetries,
+        startRequestTimeoutMs: supportsSafeStartTimeouts
+          ? researchPolicy.requestTimeoutMs
+          : null,
         pollRequestTimeoutMs: supportsPollCancellation
           ? researchPolicy.requestTimeoutMs
           : null,

--- a/src/index.ts
+++ b/src/index.ts
@@ -680,7 +680,10 @@ async function executeProviderTool({
         providerConfig,
         options,
       );
-      const supportsSafeStartRetries = provider.id === "gemini";
+      const supportsSafeStartRetries =
+        provider.supportsIdempotentResearchStartRetries === true;
+      const supportsPollCancellation =
+        provider.supportsResearchPollingCancellation === true;
       response = await executeResearchWithLifecycle({
         providerLabel: provider.label,
         providerId: provider.id,
@@ -698,6 +701,10 @@ async function executeProviderTool({
         startIdempotencyKey: supportsSafeStartRetries
           ? `pi-web-providers:${provider.id}:${randomUUID()}`
           : undefined,
+        startRetryOnTimeout: supportsSafeStartRetries,
+        pollRequestTimeoutMs: supportsPollCancellation
+          ? researchPolicy.requestTimeoutMs
+          : null,
         start: (input, researchOptions, context) =>
           provider.startResearch!(
             input,

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,10 @@ import {
   resolveProviderForCapability,
   supportsProviderCapability,
 } from "./provider-resolution.js";
-import { executeOperationPlan } from "./provider-runtime.js";
+import {
+  executeOperationPlan,
+  resolvePlanExecutionSupport,
+} from "./provider-runtime.js";
 import {
   isProviderToolEnabled,
   PROVIDER_TOOL_META,
@@ -66,7 +69,7 @@ import type {
   WebProvidersConfig,
   WebSearchDetails,
 } from "./types.js";
-import { PROVIDER_IDS } from "./types.js";
+import { EXECUTION_CONTROL_KEYS, PROVIDER_IDS } from "./types.js";
 
 const DEFAULT_MAX_RESULTS = 5;
 const MAX_ALLOWED_RESULTS = 20;
@@ -151,7 +154,9 @@ function registerWebSearchTool(
           description: `Maximum number of results to return (default: ${DEFAULT_MAX_RESULTS})`,
         }),
       ),
-      options: jsonOptionsSchema("Provider-specific search options."),
+      options: jsonOptionsSchema(
+        describeOptionsField("search", visibleProviderIds),
+      ),
       provider: providerEnum(
         visibleProviderIds,
         "Provider override. If omitted, uses the active configured provider or falls back to Codex for search when it is not explicitly disabled.",
@@ -265,7 +270,7 @@ function registerWebContentsTool(
         minItems: 1,
         description: "One or more URLs to extract",
       }),
-      options: jsonOptionsSchema("Provider-specific extraction options."),
+      options: jsonOptionsSchema(describeOptionsField("contents", providerIds)),
       provider: providerEnum(
         providerIds,
         "Provider override. If omitted, uses the active configured provider that supports web contents.",
@@ -346,7 +351,7 @@ function registerWebAnswerTool(
     description: "Answer a question using web-grounded evidence.",
     parameters: Type.Object({
       query: Type.String({ description: "Question to answer" }),
-      options: jsonOptionsSchema("Provider-specific answer options."),
+      options: jsonOptionsSchema(describeOptionsField("answer", providerIds)),
       provider: providerEnum(
         providerIds,
         "Provider override. If omitted, uses the active configured provider that supports web answers.",
@@ -400,7 +405,7 @@ function registerWebResearchTool(
       "Investigate a topic across web sources and produce a longer report.",
     parameters: Type.Object({
       input: Type.String({ description: "Research brief or question" }),
-      options: jsonOptionsSchema("Provider-specific research options."),
+      options: jsonOptionsSchema(describeOptionsField("research", providerIds)),
       provider: providerEnum(
         providerIds,
         "Provider override. If omitted, uses the active configured provider that supports research.",
@@ -585,6 +590,88 @@ function jsonOptionsSchema(description: string) {
       },
     ),
   );
+}
+
+function describeOptionsField(
+  capability: ProviderCapability,
+  providerIds: readonly ProviderId[],
+): string {
+  const labels: Record<ProviderCapability, string> = {
+    search: "Provider-specific search options.",
+    contents: "Provider-specific extraction options.",
+    answer: "Provider-specific answer options.",
+    research: "Provider-specific research options.",
+  };
+  const supportedControls = getSupportedExecutionControlsForCapability(
+    capability,
+    providerIds,
+  );
+
+  if (supportedControls.length === 0) {
+    return labels[capability];
+  }
+
+  const qualifier =
+    capability === "research"
+      ? " Depending on provider, local execution controls may include: "
+      : " Local execution controls: ";
+
+  return `${labels[capability]}${qualifier}${supportedControls.join(", ")}.`;
+}
+
+function getSupportedExecutionControlsForCapability(
+  capability: ProviderCapability,
+  providerIds: readonly ProviderId[],
+): string[] {
+  const supportedControls = new Set<string>();
+
+  for (const providerId of providerIds) {
+    const provider = PROVIDER_MAP[providerId];
+    const plan = provider.buildPlan(
+      createExecutionSupportProbeRequest(capability),
+      provider.createTemplate() as never,
+    );
+    if (!plan) {
+      continue;
+    }
+
+    const executionSupport = resolvePlanExecutionSupport(plan);
+    for (const key of EXECUTION_CONTROL_KEYS) {
+      if (executionSupport[key] === true) {
+        supportedControls.add(key);
+      }
+    }
+  }
+
+  return EXECUTION_CONTROL_KEYS.filter((key) => supportedControls.has(key));
+}
+
+function createExecutionSupportProbeRequest(
+  capability: ProviderCapability,
+): ProviderOperationRequest {
+  switch (capability) {
+    case "search":
+      return {
+        capability,
+        query: "Describe execution controls",
+        maxResults: 1,
+      };
+    case "contents":
+      return {
+        capability,
+        urls: ["https://example.com"],
+      };
+    case "answer":
+      return {
+        capability,
+        query: "Describe execution controls",
+      };
+    case "research":
+      return {
+        capability,
+        input: "Describe execution controls",
+      };
+  }
 }
 
 async function executeProviderTool({
@@ -1578,6 +1665,7 @@ export const __test__ = {
   executeProviderTool,
   extractTextContent,
   getAvailableManagedToolNames,
+  describeOptionsField,
   getAvailableProviderIdsForCapability,
   getSyncedActiveTools,
   renderCallHeader,

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ import type {
   ProviderToolOutput,
   SearchResponse,
   ValyuProviderConfig,
+  WebProvider,
   WebProvidersConfig,
   WebSearchDetails,
 } from "./types.js";
@@ -71,6 +72,19 @@ const DEFAULT_MAX_RESULTS = 5;
 const MAX_ALLOWED_RESULTS = 20;
 const RESEARCH_HEARTBEAT_MS = 15000;
 type ProviderCapability = ProviderToolId;
+type BlockingResearchProvider = WebProvider<PerplexityProviderConfig> & {
+  id: "perplexity";
+  research: (
+    input: string,
+    options: JsonObject | undefined,
+    config: PerplexityProviderConfig,
+    context: {
+      cwd: string;
+      signal?: AbortSignal;
+      onProgress?: (message: string) => void;
+    },
+  ) => Promise<ProviderToolOutput>;
+};
 const CAPABILITY_TOOL_NAMES: Record<ProviderCapability, string> = {
   search: "web_search",
   contents: "web_contents",
@@ -431,10 +445,11 @@ function registerWebResearchTool(
         options: normalizeOptions(params.options),
         input: params.input,
         invoke: (provider, providerConfig, providerOptions, context) =>
-          provider.research!(
+          invokePerplexityResearchBypass(
+            provider,
             params.input,
             providerOptions,
-            providerConfig as never,
+            providerConfig,
             context,
           ),
       });
@@ -616,7 +631,6 @@ async function executeProviderTool({
   onUpdate,
   options,
   input,
-  useProviderLifecycle = true,
   invoke,
 }: {
   capability: Exclude<ProviderCapability, "search">;
@@ -632,7 +646,6 @@ async function executeProviderTool({
     | undefined;
   options: JsonObject | undefined;
   input?: string;
-  useProviderLifecycle?: boolean;
   invoke: (
     provider: (typeof PROVIDERS)[number],
     providerConfig: ProviderConfigUnion,
@@ -669,61 +682,77 @@ async function executeProviderTool({
 
   let response: ProviderToolOutput;
   try {
-    if (
-      useProviderLifecycle &&
-      capability === "research" &&
-      typeof provider.startResearch === "function" &&
-      typeof provider.pollResearch === "function"
-    ) {
-      const researchPolicy = resolveResearchExecutionPolicy(
-        provider.id,
-        providerConfig,
-        options,
-      );
-      const supportsSafeStartRetries =
-        provider.supportsIdempotentResearchStartRetries === true;
-      const supportsSafeStartTimeouts = supportsSafeStartRetries;
-      const supportsPollCancellation =
-        provider.supportsResearchPollingCancellation === true;
-      response = await executeResearchWithLifecycle({
-        providerLabel: provider.label,
-        providerId: provider.id,
-        input: input ?? "",
-        options,
-        context: providerContext,
-        policy: researchPolicy,
-        startRetryCount: supportsSafeStartRetries
-          ? researchPolicy.retryCount
-          : 0,
-        startRetryNotice:
-          !supportsSafeStartRetries && researchPolicy.retryCount > 0
-            ? `${provider.label} research start retries are disabled to avoid duplicate background jobs; configured retries apply after the job starts.`
+    if (capability === "research") {
+      assertResearchOptionsSupported(options);
+
+      if (isBlockingResearchProvider(provider)) {
+        // Perplexity deep research is synchronous today, so it intentionally
+        // bypasses the lifecycle path instead of introducing a second generic
+        // research abstraction.
+        assertBlockingResearchOptionsSupported(provider.label, options);
+        response = await runWithExecutionPolicy(
+          `${provider.label} research request`,
+          (attemptContext) =>
+            invoke(
+              provider,
+              providerConfig as ProviderConfigUnion,
+              providerOptions,
+              attemptContext,
+            ),
+          resolveRequestExecutionPolicy(provider.id, providerConfig, options),
+          providerContext,
+        );
+      } else {
+        const researchPolicy = resolveResearchExecutionPolicy(
+          provider.id,
+          providerConfig,
+          options,
+        );
+        const supportsSafeStartRetries =
+          provider.supportsIdempotentResearchStartRetries === true;
+        const supportsSafeStartTimeouts = supportsSafeStartRetries;
+        const supportsPollCancellation =
+          provider.supportsResearchPollingCancellation === true;
+        response = await executeResearchWithLifecycle({
+          providerLabel: provider.label,
+          providerId: provider.id,
+          input: input ?? "",
+          options,
+          context: providerContext,
+          policy: researchPolicy,
+          startRetryCount: supportsSafeStartRetries
+            ? researchPolicy.retryCount
+            : 0,
+          startRetryNotice:
+            !supportsSafeStartRetries && researchPolicy.retryCount > 0
+              ? `${provider.label} research start retries are disabled to avoid duplicate background jobs; configured retries apply after the job starts.`
+              : undefined,
+          startIdempotencyKey: supportsSafeStartRetries
+            ? `pi-web-providers:${provider.id}:${randomUUID()}`
             : undefined,
-        startIdempotencyKey: supportsSafeStartRetries
-          ? `pi-web-providers:${provider.id}:${randomUUID()}`
-          : undefined,
-        startRetryOnTimeout: supportsSafeStartRetries,
-        startRequestTimeoutMs: supportsSafeStartTimeouts
-          ? researchPolicy.requestTimeoutMs
-          : null,
-        pollRequestTimeoutMs: supportsPollCancellation
-          ? researchPolicy.requestTimeoutMs
-          : null,
-        start: (input, researchOptions, context) =>
-          provider.startResearch!(
-            input,
-            researchOptions,
-            providerConfig as never,
-            context,
-          ),
-        poll: (id, researchOptions, context) =>
-          provider.pollResearch!(
-            id,
-            researchOptions,
-            providerConfig as never,
-            context,
-          ),
-      });
+          startRetryOnTimeout: supportsSafeStartRetries,
+          startRequestTimeoutMs: supportsSafeStartTimeouts
+            ? researchPolicy.requestTimeoutMs
+            : null,
+          pollRequestTimeoutMs: supportsPollCancellation
+            ? researchPolicy.requestTimeoutMs
+            : null,
+          start: (input, researchOptions, context) =>
+            provider.startResearch!(
+              input,
+              researchOptions,
+              providerConfig as never,
+              context,
+            ),
+          poll: (id, researchOptions, context) =>
+            provider.pollResearch!(
+              id,
+              researchOptions,
+              providerConfig as never,
+              context,
+            ),
+        });
+      }
     } else {
       response = await runWithExecutionPolicy(
         `${provider.label} ${capability} request`,
@@ -754,6 +783,69 @@ async function executeProviderTool({
     content: [{ type: "text" as const, text }],
     details,
   };
+}
+
+function invokePerplexityResearchBypass(
+  provider: (typeof PROVIDERS)[number],
+  input: string,
+  options: JsonObject | undefined,
+  providerConfig: ProviderConfigUnion,
+  context: {
+    cwd: string;
+    signal?: AbortSignal;
+    onProgress?: (message: string) => void;
+  },
+): Promise<ProviderToolOutput> {
+  if (isBlockingResearchProvider(provider)) {
+    return provider.research(
+      input,
+      options,
+      providerConfig as PerplexityProviderConfig,
+      context,
+    );
+  }
+
+  throw new Error(
+    `Provider '${provider.id}' does not use the Perplexity research bypass.`,
+  );
+}
+
+function isBlockingResearchProvider(
+  provider: (typeof PROVIDERS)[number],
+): provider is BlockingResearchProvider {
+  return (
+    provider.id === "perplexity" &&
+    "research" in provider &&
+    typeof provider.research === "function"
+  );
+}
+
+function assertResearchOptionsSupported(options: JsonObject | undefined): void {
+  if (options?.resumeInteractionId !== undefined) {
+    throw new Error(
+      "resumeInteractionId is not supported. Use resumeId instead.",
+    );
+  }
+}
+
+function assertBlockingResearchOptionsSupported(
+  providerLabel: string,
+  options: JsonObject | undefined,
+): void {
+  const unsupported = [
+    ["pollIntervalMs", options?.pollIntervalMs],
+    ["timeoutMs", options?.timeoutMs],
+    ["maxConsecutivePollErrors", options?.maxConsecutivePollErrors],
+    ["resumeId", options?.resumeId],
+  ].flatMap(([key, value]) => (value === undefined ? [] : [key]));
+
+  if (unsupported.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    `${providerLabel} research runs synchronously and does not support ${unsupported.join(", ")}. Use requestTimeoutMs/retryCount/retryDelayMs instead.`,
+  );
 }
 
 function normalizeOptions(value: unknown): JsonObject | undefined {

--- a/src/provider-config-manifests.ts
+++ b/src/provider-config-manifests.ts
@@ -1,0 +1,861 @@
+import type {
+  ClaudeProviderConfig,
+  ClaudeProviderNativeConfig,
+  CodexProviderConfig,
+  CodexProviderNativeConfig,
+  ExaProviderConfig,
+  ExecutionPolicyDefaults,
+  GeminiProviderConfig,
+  GeminiProviderNativeConfig,
+  JsonObject,
+  ParallelProviderConfig,
+  ParallelProviderNativeConfig,
+  PerplexityProviderConfig,
+  ProviderId,
+  ValyuProviderConfig,
+} from "./types.js";
+
+export interface ProviderTextSettingDescriptor<TConfig> {
+  id: string;
+  kind: "text";
+  label: string;
+  help: string;
+  secret?: boolean;
+  getValue: (config: TConfig | undefined) => string | undefined;
+  setValue: (config: TConfig, value: string) => void;
+}
+
+export interface ProviderValuesSettingDescriptor<TConfig> {
+  id: string;
+  kind: "values";
+  label: string;
+  help: string;
+  values: string[];
+  getValue: (config: TConfig | undefined) => string;
+  setValue: (config: TConfig, value: string) => void;
+}
+
+export type ProviderSettingDescriptor<TConfig> =
+  | ProviderTextSettingDescriptor<TConfig>
+  | ProviderValuesSettingDescriptor<TConfig>;
+
+export const PROVIDER_CONFIG_MANIFESTS = {
+  claude: {
+    settings: [
+      stringSetting<ClaudeProviderConfig>({
+        id: "model",
+        label: "Model",
+        help: "Optional Claude model override. Leave empty to use the local default.",
+        getValue: (config) => getClaudeNative(config)?.model,
+        setValue: (config, value) => {
+          assignOptionalString(ensureClaudeNative(config), "model", value);
+          cleanupEmpty(config, "native");
+        },
+      }),
+      valuesSetting<ClaudeProviderConfig>({
+        id: "claudeEffort",
+        label: "Effort",
+        help: "How much effort Claude should use. 'default' uses the SDK default.",
+        values: ["default", "low", "medium", "high", "max"],
+        getValue: (config) => getClaudeNative(config)?.effort ?? "default",
+        setValue: (config, value) => {
+          const native = ensureClaudeNative(config);
+          if (value === "default") {
+            delete native.effort;
+          } else {
+            native.effort = value as ClaudeProviderNativeConfig["effort"];
+          }
+          cleanupEmpty(config, "native");
+        },
+      }),
+      integerSetting<ClaudeProviderConfig>({
+        id: "claudeMaxTurns",
+        label: "Max turns",
+        help: "Optional maximum number of Claude turns. Leave empty to use the SDK default.",
+        minimum: 1,
+        errorMessage: "Claude max turns must be a positive integer.",
+        getValue: (config) =>
+          getIntegerString(getClaudeNative(config)?.maxTurns),
+        setValue: (config, value) => {
+          assignOptionalInteger(
+            ensureClaudeNative(config) as Record<
+              string,
+              number | string | boolean | JsonObject | undefined
+            >,
+            "maxTurns",
+            value,
+            "Claude max turns must be a positive integer.",
+          );
+          cleanupEmpty(config, "native");
+        },
+      }),
+      stringSetting<ClaudeProviderConfig>({
+        id: "claudePathToExecutable",
+        label: "Executable path",
+        help: "Optional path to the Claude Code executable. Leave empty to use the bundled/default executable.",
+        getValue: (config) => config?.pathToClaudeCodeExecutable,
+        setValue: (config, value) => {
+          assignOptionalString(
+            config as Record<
+              string,
+              string | number | boolean | JsonObject | undefined
+            >,
+            "pathToClaudeCodeExecutable",
+            value,
+          );
+        },
+      }),
+      ...requestPolicySettings<ClaudeProviderConfig>(),
+    ],
+  },
+  codex: {
+    settings: [
+      stringSetting<CodexProviderConfig>({
+        id: "model",
+        label: "Model",
+        help: "Optional Codex model override. Leave empty to use the local default.",
+        getValue: (config) => getCodexNative(config)?.model,
+        setValue: (config, value) => {
+          assignOptionalString(
+            ensureCodexNative(config) as Record<
+              string,
+              string | number | boolean | JsonObject | undefined
+            >,
+            "model",
+            value,
+          );
+          cleanupEmpty(config, "native");
+        },
+      }),
+      valuesSetting<CodexProviderConfig>({
+        id: "modelReasoningEffort",
+        label: "Reasoning effort",
+        help: "Reasoning depth for Codex. 'default' uses the SDK default.",
+        values: ["default", "minimal", "low", "medium", "high", "xhigh"],
+        getValue: (config) =>
+          getCodexNative(config)?.modelReasoningEffort ?? "default",
+        setValue: (config, value) => {
+          const native = ensureCodexNative(config);
+          if (value === "default") {
+            delete native.modelReasoningEffort;
+          } else {
+            native.modelReasoningEffort =
+              value as CodexProviderNativeConfig["modelReasoningEffort"];
+          }
+          cleanupEmpty(config, "native");
+        },
+      }),
+      valuesSetting<CodexProviderConfig>({
+        id: "webSearchMode",
+        label: "Web search mode",
+        help: "How Codex should source web results. 'default' currently behaves like 'live'.",
+        values: ["default", "disabled", "cached", "live"],
+        getValue: (config) =>
+          getCodexNative(config)?.webSearchMode ?? "default",
+        setValue: (config, value) => {
+          const native = ensureCodexNative(config);
+          if (value === "default") {
+            delete native.webSearchMode;
+          } else {
+            native.webSearchMode =
+              value as CodexProviderNativeConfig["webSearchMode"];
+          }
+          cleanupEmpty(config, "native");
+        },
+      }),
+      valuesSetting<CodexProviderConfig>({
+        id: "networkAccessEnabled",
+        label: "Network access",
+        help: "Allow Codex network access during search runs. 'default' currently behaves like 'true'.",
+        values: ["default", "true", "false"],
+        getValue: (config) =>
+          getBooleanValue(getCodexNative(config)?.networkAccessEnabled),
+        setValue: (config, value) => {
+          assignOptionalBoolean(
+            ensureCodexNative(config) as Record<string, unknown>,
+            "networkAccessEnabled",
+            value,
+          );
+          cleanupEmpty(config, "native");
+        },
+      }),
+      valuesSetting<CodexProviderConfig>({
+        id: "webSearchEnabled",
+        label: "Web search",
+        help: "Enable Codex web search. 'default' currently behaves like 'true'.",
+        values: ["default", "true", "false"],
+        getValue: (config) =>
+          getBooleanValue(getCodexNative(config)?.webSearchEnabled),
+        setValue: (config, value) => {
+          assignOptionalBoolean(
+            ensureCodexNative(config) as Record<string, unknown>,
+            "webSearchEnabled",
+            value,
+          );
+          cleanupEmpty(config, "native");
+        },
+      }),
+      stringSetting<CodexProviderConfig>({
+        id: "additionalDirectories",
+        label: "Additional dirs",
+        help: "Optional comma-separated directories that Codex may read in addition to the current working directory.",
+        getValue: (config) =>
+          getCodexNative(config)?.additionalDirectories?.join(", "),
+        setValue: (config, value) => {
+          const native = ensureCodexNative(config);
+          const trimmed = value.trim();
+          if (!trimmed) {
+            delete native.additionalDirectories;
+          } else {
+            native.additionalDirectories = trimmed
+              .split(",")
+              .map((entry) => entry.trim())
+              .filter((entry) => entry.length > 0);
+          }
+          cleanupEmpty(config, "native");
+        },
+      }),
+      ...requestPolicySettings<CodexProviderConfig>(),
+    ],
+  },
+  exa: {
+    settings: [
+      apiKeySetting<ExaProviderConfig>(),
+      baseUrlSetting<ExaProviderConfig>(),
+      valuesSetting<ExaProviderConfig>({
+        id: "exaSearchType",
+        label: "Search type",
+        help: "Exa search mode. 'default' uses the SDK default.",
+        values: [
+          "default",
+          "keyword",
+          "neural",
+          "auto",
+          "hybrid",
+          "fast",
+          "instant",
+          "deep",
+          "deep-reasoning",
+          "deep-max",
+        ],
+        getValue: (config) =>
+          readString(getExaNative(config)?.type) ?? "default",
+        setValue: (config, value) => {
+          const native = ensureExaNative(config);
+          if (value === "default") {
+            delete native.type;
+          } else {
+            native.type = value;
+          }
+          cleanupEmpty(config, "native");
+        },
+      }),
+      valuesSetting<ExaProviderConfig>({
+        id: "exaTextContents",
+        label: "Text contents",
+        help: "Whether Exa should include text contents in search results. 'default' uses the SDK default.",
+        values: ["default", "true", "false"],
+        getValue: (config) => {
+          const contents = asJsonObject(getExaNative(config)?.contents);
+          return typeof contents?.text === "boolean"
+            ? String(contents.text)
+            : "default";
+        },
+        setValue: (config, value) => {
+          const native = ensureExaNative(config);
+          const contents = asJsonObject(native.contents) ?? {};
+          if (value === "default") {
+            delete contents.text;
+          } else {
+            contents.text = value === "true";
+          }
+          if (Object.keys(contents).length === 0) {
+            delete native.contents;
+          } else {
+            native.contents = contents;
+          }
+          cleanupEmpty(config, "native");
+        },
+      }),
+      ...requestPolicySettings<ExaProviderConfig>(),
+      ...lifecyclePolicySettings<ExaProviderConfig>(),
+    ],
+  },
+  gemini: {
+    settings: [
+      apiKeySetting<GeminiProviderConfig>(),
+      valuesSetting<GeminiProviderConfig>({
+        id: "geminiApiVersion",
+        label: "API version",
+        help: "Gemini API version. 'default' uses the SDK default beta endpoints.",
+        values: ["default", "v1alpha", "v1beta", "v1"],
+        getValue: (config) => getGeminiNative(config)?.apiVersion ?? "default",
+        setValue: (config, value) => {
+          const native = ensureGeminiNative(config);
+          if (value === "default") {
+            delete native.apiVersion;
+          } else {
+            native.apiVersion = value;
+          }
+          cleanupEmpty(config, "native");
+        },
+      }),
+      stringSetting<GeminiProviderConfig>({
+        id: "geminiSearchModel",
+        label: "Search model",
+        help: "Model used for Gemini search interactions.",
+        getValue: (config) => getGeminiNative(config)?.searchModel,
+        setValue: (config, value) => {
+          assignOptionalString(
+            ensureGeminiNative(config),
+            "searchModel",
+            value,
+          );
+          cleanupEmpty(config, "native");
+        },
+      }),
+      stringSetting<GeminiProviderConfig>({
+        id: "geminiContentsModel",
+        label: "Contents model",
+        help: "Model used for Gemini URL content extraction via URL Context.",
+        getValue: (config) => getGeminiNative(config)?.contentsModel,
+        setValue: (config, value) => {
+          assignOptionalString(
+            ensureGeminiNative(config),
+            "contentsModel",
+            value,
+          );
+          cleanupEmpty(config, "native");
+        },
+      }),
+      stringSetting<GeminiProviderConfig>({
+        id: "geminiAnswerModel",
+        label: "Answer model",
+        help: "Model used for grounded Gemini answers.",
+        getValue: (config) => getGeminiNative(config)?.answerModel,
+        setValue: (config, value) => {
+          assignOptionalString(
+            ensureGeminiNative(config),
+            "answerModel",
+            value,
+          );
+          cleanupEmpty(config, "native");
+        },
+      }),
+      stringSetting<GeminiProviderConfig>({
+        id: "geminiResearchAgent",
+        label: "Research agent",
+        help: "Agent used for Gemini deep research runs.",
+        getValue: (config) => getGeminiNative(config)?.researchAgent,
+        setValue: (config, value) => {
+          assignOptionalString(
+            ensureGeminiNative(config),
+            "researchAgent",
+            value,
+          );
+          cleanupEmpty(config, "native");
+        },
+      }),
+      ...requestPolicySettings<GeminiProviderConfig>(),
+      ...lifecyclePolicySettings<GeminiProviderConfig>(),
+    ],
+  },
+  perplexity: {
+    settings: [
+      apiKeySetting<PerplexityProviderConfig>(),
+      baseUrlSetting<PerplexityProviderConfig>(),
+      ...requestPolicySettings<PerplexityProviderConfig>(),
+    ],
+  },
+  parallel: {
+    settings: [
+      apiKeySetting<ParallelProviderConfig>(),
+      baseUrlSetting<ParallelProviderConfig>(),
+      valuesSetting<ParallelProviderConfig>({
+        id: "parallelSearchMode",
+        label: "Search mode",
+        help: "Parallel search mode. 'default' uses the SDK default.",
+        values: ["default", "agentic", "one-shot"],
+        getValue: (config) =>
+          readString(getParallelNative(config)?.search?.mode) ?? "default",
+        setValue: (config, value) => {
+          const native = ensureParallelNative(config);
+          native.search = asJsonObject(native.search) ?? {};
+          if (value === "default") {
+            delete native.search.mode;
+          } else {
+            native.search.mode = value;
+          }
+          cleanupNestedObjects(config);
+        },
+      }),
+      valuesSetting<ParallelProviderConfig>({
+        id: "parallelExtractExcerpts",
+        label: "Extract excerpts",
+        help: "Include excerpts in Parallel extraction results. 'default' uses the SDK default.",
+        values: ["default", "on", "off"],
+        getValue: (config) =>
+          getOnOffValue(
+            readBoolean(getParallelNative(config)?.extract?.excerpts),
+          ),
+        setValue: (config, value) => {
+          const native = ensureParallelNative(config);
+          native.extract = asJsonObject(native.extract) ?? {};
+          if (value === "default") {
+            delete native.extract.excerpts;
+          } else {
+            native.extract.excerpts = value === "on";
+          }
+          cleanupNestedObjects(config);
+        },
+      }),
+      valuesSetting<ParallelProviderConfig>({
+        id: "parallelExtractFullContent",
+        label: "Extract full content",
+        help: "Include full page content in Parallel extraction results. 'default' uses the SDK default.",
+        values: ["default", "on", "off"],
+        getValue: (config) =>
+          getOnOffValue(
+            readBoolean(getParallelNative(config)?.extract?.full_content),
+          ),
+        setValue: (config, value) => {
+          const native = ensureParallelNative(config);
+          native.extract = asJsonObject(native.extract) ?? {};
+          if (value === "default") {
+            delete native.extract.full_content;
+          } else {
+            native.extract.full_content = value === "on";
+          }
+          cleanupNestedObjects(config);
+        },
+      }),
+      ...requestPolicySettings<ParallelProviderConfig>(),
+    ],
+  },
+  valyu: {
+    settings: [
+      apiKeySetting<ValyuProviderConfig>(),
+      baseUrlSetting<ValyuProviderConfig>(),
+      valuesSetting<ValyuProviderConfig>({
+        id: "valyuSearchType",
+        label: "Search type",
+        help: "Valyu search type. 'default' uses the SDK default.",
+        values: ["default", "all", "web", "proprietary", "news"],
+        getValue: (config) =>
+          readString(getValyuNative(config)?.searchType) ?? "default",
+        setValue: (config, value) => {
+          const native = ensureValyuNative(config);
+          if (value === "default") {
+            delete native.searchType;
+          } else {
+            native.searchType = value;
+          }
+          cleanupEmpty(config, "native");
+        },
+      }),
+      valuesSetting<ValyuProviderConfig>({
+        id: "valyuResponseLength",
+        label: "Response length",
+        help: "Valyu response length. 'default' uses the SDK default.",
+        values: ["default", "short", "medium", "large", "max"],
+        getValue: (config) =>
+          readString(getValyuNative(config)?.responseLength) ?? "default",
+        setValue: (config, value) => {
+          const native = ensureValyuNative(config);
+          if (value === "default") {
+            delete native.responseLength;
+          } else {
+            native.responseLength = value;
+          }
+          cleanupEmpty(config, "native");
+        },
+      }),
+      ...requestPolicySettings<ValyuProviderConfig>(),
+      ...lifecyclePolicySettings<ValyuProviderConfig>(),
+    ],
+  },
+} as const;
+
+export function getProviderConfigManifest(providerId: ProviderId) {
+  return PROVIDER_CONFIG_MANIFESTS[providerId];
+}
+
+function stringSetting<TConfig>(
+  setting: Omit<ProviderTextSettingDescriptor<TConfig>, "kind">,
+): ProviderTextSettingDescriptor<TConfig> {
+  return {
+    kind: "text",
+    ...setting,
+  };
+}
+
+function valuesSetting<TConfig>(
+  setting: Omit<ProviderValuesSettingDescriptor<TConfig>, "kind">,
+): ProviderValuesSettingDescriptor<TConfig> {
+  return {
+    kind: "values",
+    ...setting,
+  };
+}
+
+function apiKeySetting<TConfig extends { apiKey?: string }>() {
+  return stringSetting<TConfig>({
+    id: "apiKey",
+    label: "API key",
+    help: "Provider API key. You can use a literal value, an env var name like EXA_API_KEY, or !command.",
+    secret: true,
+    getValue: (config) => config?.apiKey,
+    setValue: (config, value) => {
+      assignOptionalString(
+        config as Record<
+          string,
+          string | number | boolean | JsonObject | undefined
+        >,
+        "apiKey",
+        value,
+      );
+    },
+  });
+}
+
+function baseUrlSetting<TConfig extends { baseUrl?: string }>() {
+  return stringSetting<TConfig>({
+    id: "baseUrl",
+    label: "Base URL",
+    help: "Optional API base URL override.",
+    getValue: (config) => config?.baseUrl,
+    setValue: (config, value) => {
+      assignOptionalString(
+        config as Record<
+          string,
+          string | number | boolean | JsonObject | undefined
+        >,
+        "baseUrl",
+        value,
+      );
+    },
+  });
+}
+
+function requestPolicySettings<
+  TConfig extends { policy?: ExecutionPolicyDefaults },
+>() {
+  return [
+    integerSetting<TConfig>({
+      id: "requestTimeoutMs",
+      label: "Request timeout (ms)",
+      help: "Maximum time to wait for a single provider request before failing that attempt.",
+      minimum: 1,
+      errorMessage: "Request timeout must be a positive integer.",
+      getValue: (config) => getIntegerString(config?.policy?.requestTimeoutMs),
+      setValue: (config, value) => {
+        assignOptionalInteger(
+          ensurePolicy(config),
+          "requestTimeoutMs",
+          value,
+          "Request timeout must be a positive integer.",
+        );
+        cleanupEmpty(config, "policy");
+      },
+    }),
+    integerSetting<TConfig>({
+      id: "retryCount",
+      label: "Retry count",
+      help: "How many times transient provider failures should be retried.",
+      minimum: 0,
+      errorMessage: "Retry count must be a non-negative integer.",
+      getValue: (config) => getIntegerString(config?.policy?.retryCount),
+      setValue: (config, value) => {
+        assignOptionalInteger(
+          ensurePolicy(config),
+          "retryCount",
+          value,
+          "Retry count must be a non-negative integer.",
+          { allowZero: true },
+        );
+        cleanupEmpty(config, "policy");
+      },
+    }),
+    integerSetting<TConfig>({
+      id: "retryDelayMs",
+      label: "Retry delay (ms)",
+      help: "Initial delay before retrying failed requests. Later retries back off automatically.",
+      minimum: 1,
+      errorMessage: "Retry delay must be a positive integer.",
+      getValue: (config) => getIntegerString(config?.policy?.retryDelayMs),
+      setValue: (config, value) => {
+        assignOptionalInteger(
+          ensurePolicy(config),
+          "retryDelayMs",
+          value,
+          "Retry delay must be a positive integer.",
+        );
+        cleanupEmpty(config, "policy");
+      },
+    }),
+  ] as const;
+}
+
+function lifecyclePolicySettings<
+  TConfig extends { policy?: ExecutionPolicyDefaults },
+>() {
+  return [
+    integerSetting<TConfig>({
+      id: "researchPollIntervalMs",
+      label: "Research poll interval (ms)",
+      help: "How often to poll long-running research jobs for updates.",
+      minimum: 1,
+      errorMessage: "Research poll interval must be a positive integer.",
+      getValue: (config) =>
+        getIntegerString(config?.policy?.researchPollIntervalMs),
+      setValue: (config, value) => {
+        assignOptionalInteger(
+          ensurePolicy(config),
+          "researchPollIntervalMs",
+          value,
+          "Research poll interval must be a positive integer.",
+        );
+        cleanupEmpty(config, "policy");
+      },
+    }),
+    integerSetting<TConfig>({
+      id: "researchTimeoutMs",
+      label: "Research timeout (ms)",
+      help: "Maximum total time to wait for research before returning a resumable timeout error.",
+      minimum: 1,
+      errorMessage: "Research timeout must be a positive integer.",
+      getValue: (config) => getIntegerString(config?.policy?.researchTimeoutMs),
+      setValue: (config, value) => {
+        assignOptionalInteger(
+          ensurePolicy(config),
+          "researchTimeoutMs",
+          value,
+          "Research timeout must be a positive integer.",
+        );
+        cleanupEmpty(config, "policy");
+      },
+    }),
+    integerSetting<TConfig>({
+      id: "researchMaxConsecutivePollErrors",
+      label: "Max poll errors",
+      help: "How many consecutive poll failures to tolerate before stopping the local research run.",
+      minimum: 1,
+      errorMessage: "Max poll errors must be a positive integer.",
+      getValue: (config) =>
+        getIntegerString(config?.policy?.researchMaxConsecutivePollErrors),
+      setValue: (config, value) => {
+        assignOptionalInteger(
+          ensurePolicy(config),
+          "researchMaxConsecutivePollErrors",
+          value,
+          "Max poll errors must be a positive integer.",
+        );
+        cleanupEmpty(config, "policy");
+      },
+    }),
+  ] as const;
+}
+
+function integerSetting<TConfig>(
+  setting: Omit<ProviderTextSettingDescriptor<TConfig>, "kind"> & {
+    minimum: number;
+    errorMessage: string;
+  },
+): ProviderTextSettingDescriptor<TConfig> {
+  const { minimum: _minimum, errorMessage: _errorMessage, ...rest } = setting;
+  return {
+    kind: "text",
+    ...rest,
+  };
+}
+
+function assignOptionalString(
+  target: Record<string, string | number | boolean | JsonObject | undefined>,
+  key: string,
+  value: string,
+): void {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    delete target[key];
+  } else {
+    target[key] = trimmed;
+  }
+}
+
+function assignOptionalInteger(
+  target: Record<string, string | number | boolean | JsonObject | undefined>,
+  key: string,
+  value: string,
+  errorMessage: string,
+  options?: { allowZero?: boolean },
+): void {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    delete target[key];
+    return;
+  }
+
+  const parsed = Number(trimmed);
+  const minimum = options?.allowZero ? 0 : 1;
+  if (!Number.isInteger(parsed) || parsed < minimum) {
+    throw new Error(errorMessage);
+  }
+
+  target[key] = parsed;
+}
+
+function assignOptionalBoolean(
+  target: Record<string, unknown>,
+  key: string,
+  value: string,
+): void {
+  if (value === "default") {
+    delete target[key];
+  } else {
+    target[key] = value === "true";
+  }
+}
+
+function getIntegerString(value: number | undefined): string | undefined {
+  return typeof value === "number" ? String(value) : undefined;
+}
+
+function getBooleanValue(value: boolean | undefined): string {
+  return typeof value === "boolean" ? String(value) : "default";
+}
+
+function getOnOffValue(value: boolean | undefined): string {
+  if (value === undefined) {
+    return "default";
+  }
+  return value ? "on" : "off";
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function readBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function asJsonObject(value: unknown): JsonObject | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as JsonObject)
+    : undefined;
+}
+
+function ensurePolicy<TConfig extends { policy?: ExecutionPolicyDefaults }>(
+  config: TConfig,
+): Record<string, string | number | boolean | JsonObject | undefined> {
+  config.policy = { ...(config.policy ?? {}) };
+  return config.policy as Record<
+    string,
+    string | number | boolean | JsonObject | undefined
+  >;
+}
+
+function cleanupEmpty<TConfig extends object>(
+  config: TConfig,
+  key: "native" | "policy",
+): void {
+  const value = asJsonObject((config as Record<string, unknown>)[key]);
+  if (value && Object.keys(value).length === 0) {
+    delete (config as Record<string, unknown>)[key];
+  }
+}
+
+function cleanupNestedObjects(config: ParallelProviderConfig): void {
+  const native = config.native;
+  if (!native) {
+    return;
+  }
+  if (native.search && Object.keys(native.search).length === 0) {
+    delete native.search;
+  }
+  if (native.extract && Object.keys(native.extract).length === 0) {
+    delete native.extract;
+  }
+  cleanupEmpty(config, "native");
+}
+
+function getClaudeNative(config: ClaudeProviderConfig | undefined) {
+  return config?.native ?? config?.defaults;
+}
+
+function ensureClaudeNative(
+  config: ClaudeProviderConfig,
+): Record<string, string | number | boolean | JsonObject | undefined> {
+  config.native = { ...(config.native ?? config.defaults ?? {}) };
+  delete config.defaults;
+  return config.native as Record<
+    string,
+    string | number | boolean | JsonObject | undefined
+  >;
+}
+
+function getCodexNative(config: CodexProviderConfig | undefined) {
+  return config?.native ?? config?.defaults;
+}
+
+function ensureCodexNative(
+  config: CodexProviderConfig,
+): CodexProviderNativeConfig {
+  config.native = { ...(config.native ?? config.defaults ?? {}) };
+  delete config.defaults;
+  return config.native;
+}
+
+function getGeminiNative(config: GeminiProviderConfig | undefined) {
+  return config?.native ?? config?.defaults;
+}
+
+function ensureGeminiNative(
+  config: GeminiProviderConfig,
+): Record<string, string | number | boolean | JsonObject | undefined> {
+  config.native = { ...(config.native ?? config.defaults ?? {}) };
+  delete config.defaults;
+  return config.native as Record<
+    string,
+    string | number | boolean | JsonObject | undefined
+  >;
+}
+
+function getParallelNative(config: ParallelProviderConfig | undefined) {
+  return config?.native ?? config?.defaults;
+}
+
+function ensureParallelNative(
+  config: ParallelProviderConfig,
+): ParallelProviderNativeConfig {
+  const search = asJsonObject(config.native?.search ?? config.defaults?.search);
+  const extract = asJsonObject(
+    config.native?.extract ?? config.defaults?.extract,
+  );
+  config.native = {
+    ...(search ? { search } : {}),
+    ...(extract ? { extract } : {}),
+  };
+  delete config.defaults;
+  return config.native;
+}
+
+function getExaNative(config: ExaProviderConfig | undefined) {
+  return config?.native ?? config?.defaults;
+}
+
+function ensureExaNative(config: ExaProviderConfig): JsonObject {
+  config.native = { ...(config.native ?? config.defaults ?? {}) };
+  delete config.defaults;
+  return config.native;
+}
+
+function getValyuNative(config: ValyuProviderConfig | undefined) {
+  return config?.native ?? config?.defaults;
+}
+
+function ensureValyuNative(config: ValyuProviderConfig): JsonObject {
+  config.native = { ...(config.native ?? config.defaults ?? {}) };
+  delete config.defaults;
+  return config.native;
+}

--- a/src/provider-plans.ts
+++ b/src/provider-plans.ts
@@ -1,0 +1,56 @@
+import type {
+  ExecutionPolicyDefaults,
+  JobProviderOperationPlan,
+  ProviderPlanTraits,
+  SingleProviderOperationPlan,
+} from "./types.js";
+
+interface ConfigWithPolicy {
+  policy?: ExecutionPolicyDefaults;
+}
+
+export function createSingleOperationPlan<TResult>({
+  config,
+  traits,
+  ...plan
+}: Omit<SingleProviderOperationPlan<TResult>, "mode" | "traits"> & {
+  config: ConfigWithPolicy;
+  traits?: Omit<ProviderPlanTraits, "policyDefaults">;
+}): SingleProviderOperationPlan<TResult> {
+  const builtTraits = buildTraits(config.policy, traits);
+
+  return {
+    ...plan,
+    mode: "single",
+    ...(builtTraits ? { traits: builtTraits } : {}),
+  };
+}
+
+export function createResearchJobPlan({
+  config,
+  traits,
+  ...plan
+}: Omit<JobProviderOperationPlan, "mode" | "traits"> & {
+  config: ConfigWithPolicy;
+  traits?: Omit<ProviderPlanTraits, "policyDefaults">;
+}): JobProviderOperationPlan {
+  const builtTraits = buildTraits(config.policy, traits);
+
+  return {
+    ...plan,
+    mode: "job",
+    ...(builtTraits ? { traits: builtTraits } : {}),
+  };
+}
+
+function buildTraits(
+  policyDefaults: ExecutionPolicyDefaults | undefined,
+  traits: Omit<ProviderPlanTraits, "policyDefaults"> | undefined,
+): ProviderPlanTraits | undefined {
+  const builtTraits: ProviderPlanTraits = {
+    ...(policyDefaults ? { policyDefaults } : {}),
+    ...(traits ?? {}),
+  };
+
+  return Object.keys(builtTraits).length > 0 ? builtTraits : undefined;
+}

--- a/src/provider-plans.ts
+++ b/src/provider-plans.ts
@@ -1,6 +1,6 @@
 import type {
+  BackgroundResearchOperationPlan,
   ExecutionPolicyDefaults,
-  JobProviderOperationPlan,
   ProviderPlanTraits,
   SingleProviderOperationPlan,
 } from "./types.js";
@@ -9,36 +9,62 @@ interface ConfigWithPolicy {
   policy?: ExecutionPolicyDefaults;
 }
 
-export function createSingleOperationPlan<TResult>({
+// Silent foreground plans wait for a final result without surfacing partial
+// provider output while the request is still running.
+export function createSilentForegroundPlan<TResult>({
   config,
   traits,
   ...plan
-}: Omit<SingleProviderOperationPlan<TResult>, "mode" | "traits"> & {
+}: Omit<SingleProviderOperationPlan<TResult>, "deliveryMode" | "traits"> & {
   config: ConfigWithPolicy;
   traits?: Omit<ProviderPlanTraits, "policyDefaults">;
 }): SingleProviderOperationPlan<TResult> {
+  return buildSinglePlan("silent-foreground", config.policy, traits, plan);
+}
+
+// Streaming foreground plans can surface intermediate provider output, but the
+// tool result is still only consumed once the call finishes.
+export function createStreamingForegroundPlan<TResult>({
+  config,
+  traits,
+  ...plan
+}: Omit<SingleProviderOperationPlan<TResult>, "deliveryMode" | "traits"> & {
+  config: ConfigWithPolicy;
+  traits?: Omit<ProviderPlanTraits, "policyDefaults">;
+}): SingleProviderOperationPlan<TResult> {
+  return buildSinglePlan("streaming-foreground", config.policy, traits, plan);
+}
+
+// Background research plans model providers that return a durable research job
+// which pi can poll and later resume via `resumeId`.
+export function createBackgroundResearchPlan({
+  config,
+  traits,
+  ...plan
+}: Omit<BackgroundResearchOperationPlan, "deliveryMode" | "traits"> & {
+  config: ConfigWithPolicy;
+  traits?: Omit<ProviderPlanTraits, "policyDefaults">;
+}): BackgroundResearchOperationPlan {
   const builtTraits = buildTraits(config.policy, traits);
 
   return {
     ...plan,
-    mode: "single",
+    deliveryMode: "background-research",
     ...(builtTraits ? { traits: builtTraits } : {}),
   };
 }
 
-export function createResearchJobPlan({
-  config,
-  traits,
-  ...plan
-}: Omit<JobProviderOperationPlan, "mode" | "traits"> & {
-  config: ConfigWithPolicy;
-  traits?: Omit<ProviderPlanTraits, "policyDefaults">;
-}): JobProviderOperationPlan {
-  const builtTraits = buildTraits(config.policy, traits);
+function buildSinglePlan<TResult>(
+  deliveryMode: SingleProviderOperationPlan<TResult>["deliveryMode"],
+  policyDefaults: ExecutionPolicyDefaults | undefined,
+  traits: Omit<ProviderPlanTraits, "policyDefaults"> | undefined,
+  plan: Omit<SingleProviderOperationPlan<TResult>, "deliveryMode" | "traits">,
+): SingleProviderOperationPlan<TResult> {
+  const builtTraits = buildTraits(policyDefaults, traits);
 
   return {
     ...plan,
-    mode: "job",
+    deliveryMode,
     ...(builtTraits ? { traits: builtTraits } : {}),
   };
 }

--- a/src/provider-resolution.ts
+++ b/src/provider-resolution.ts
@@ -4,9 +4,24 @@ import {
   type ProviderToolId,
 } from "./provider-tools.js";
 import { PROVIDER_MAP, PROVIDERS } from "./providers/index.js";
-import type { ProviderId, WebProvidersConfig } from "./types.js";
+import type { ProviderId, WebProvider, WebProvidersConfig } from "./types.js";
 
 const IMPLICIT_PROVIDER_FALLBACKS: readonly ProviderId[] = ["codex"] as const;
+
+export function supportsProviderCapability(
+  provider: WebProvider<unknown>,
+  capability: ProviderToolId,
+): boolean {
+  if (capability === "research") {
+    return (
+      typeof provider.research === "function" ||
+      (typeof provider.startResearch === "function" &&
+        typeof provider.pollResearch === "function")
+    );
+  }
+
+  return typeof provider[capability] === "function";
+}
 
 export function resolveProviderChoice(
   config: WebProvidersConfig,
@@ -44,7 +59,7 @@ export function resolveProviderForCapability(
   if (explicit) {
     const provider = PROVIDER_MAP[explicit];
     const providerConfig = getEffectiveProviderConfig(config, explicit);
-    if (typeof provider[capability] !== "function") {
+    if (!supportsProviderCapability(provider, capability)) {
       throw new Error(
         `Provider '${explicit}' does not support '${capability}'.`,
       );
@@ -64,7 +79,7 @@ export function resolveProviderForCapability(
   }
 
   for (const provider of PROVIDERS) {
-    if (typeof provider[capability] !== "function") continue;
+    if (!supportsProviderCapability(provider, capability)) continue;
     const providerConfig = config.providers?.[provider.id];
     if (providerConfig?.enabled !== true) continue;
     if (
@@ -82,7 +97,7 @@ export function resolveProviderForCapability(
 
   for (const providerId of IMPLICIT_PROVIDER_FALLBACKS) {
     const provider = PROVIDER_MAP[providerId];
-    if (typeof provider[capability] !== "function") continue;
+    if (!supportsProviderCapability(provider, capability)) continue;
     const providerConfig = getEffectiveProviderConfig(config, provider.id);
     if (!isProviderToolEnabled(provider.id, providerConfig, capability)) {
       continue;

--- a/src/provider-resolution.ts
+++ b/src/provider-resolution.ts
@@ -13,8 +13,10 @@ export function supportsProviderCapability(
   capability: ProviderToolId,
 ): boolean {
   if (capability === "research") {
+    // Research is lifecycle-based everywhere except Perplexity, whose SDK only
+    // exposes a single blocking deep-research call today.
     return (
-      typeof provider.research === "function" ||
+      provider.id === "perplexity" ||
       (typeof provider.startResearch === "function" &&
         typeof provider.pollResearch === "function")
     );

--- a/src/provider-resolution.ts
+++ b/src/provider-resolution.ts
@@ -12,17 +12,7 @@ export function supportsProviderCapability(
   provider: WebProvider<unknown>,
   capability: ProviderToolId,
 ): boolean {
-  if (capability === "research") {
-    // Research is lifecycle-based everywhere except Perplexity, whose SDK only
-    // exposes a single blocking deep-research call today.
-    return (
-      provider.id === "perplexity" ||
-      (typeof provider.startResearch === "function" &&
-        typeof provider.pollResearch === "function")
-    );
-  }
-
-  return typeof provider[capability] === "function";
+  return provider.capabilities.includes(capability);
 }
 
 export function resolveProviderChoice(

--- a/src/provider-runtime.ts
+++ b/src/provider-runtime.ts
@@ -60,7 +60,6 @@ export async function executeOperationPlan<
     pollRequestTimeoutMs: supportsRequestTimeouts
       ? researchPolicy.requestTimeoutMs
       : undefined,
-    deferDeadlineUntilStarted: !supportsSafeStartRetries,
     start: plan.start,
     poll: plan.poll,
   })) as TResult;

--- a/src/provider-runtime.ts
+++ b/src/provider-runtime.ts
@@ -1,12 +1,14 @@
 import { randomUUID } from "node:crypto";
 import {
   executeResearchWithLifecycle,
+  parseLocalExecutionOptions,
   type ResearchExecutionPolicy,
   resolveRequestExecutionPolicy,
   resolveResearchExecutionPolicy,
   runWithExecutionPolicy,
 } from "./execution-policy.js";
 import type {
+  ExecutionPolicyDefaults,
   JsonObject,
   ProviderContext,
   ProviderOperationPlan,
@@ -21,22 +23,22 @@ export async function executeOperationPlan<
   options: JsonObject | undefined,
   context: ProviderContext,
 ): Promise<TResult> {
-  assertResearchOptionsSupported(plan, options);
-
   if (plan.mode === "single") {
+    const requestPolicy = resolveSingleExecutionPolicy(plan, options);
     return await runWithExecutionPolicy(
       `${plan.providerLabel} ${plan.capability} request`,
       plan.execute,
-      resolveRequestExecutionPolicy(options, plan.traits?.policyDefaults),
+      requestPolicy,
       context,
     );
   }
 
-  const researchPolicy = resolveResearchPolicy(plan, options);
+  const researchPolicy = resolveJobResearchExecutionPolicy(plan, options);
+  const lifecycleTraits = plan.traits?.researchLifecycle;
   const supportsSafeStartRetries =
-    plan.traits?.supportsIdempotentStartRetries === true;
-  const supportsPollCancellation =
-    plan.traits?.supportsPollCancellation === true;
+    lifecycleTraits?.supportsStartRetries === true;
+  const supportsRequestTimeouts =
+    lifecycleTraits?.supportsRequestTimeouts === true;
 
   return (await executeResearchWithLifecycle({
     providerLabel: plan.providerLabel,
@@ -52,33 +54,59 @@ export async function executeOperationPlan<
       ? `pi-web-providers:${plan.providerId}:${randomUUID()}`
       : undefined,
     startRetryOnTimeout: supportsSafeStartRetries,
-    startRequestTimeoutMs: supportsSafeStartRetries
+    startRequestTimeoutMs: supportsRequestTimeouts
       ? researchPolicy.requestTimeoutMs
-      : null,
-    pollRequestTimeoutMs: supportsPollCancellation
+      : undefined,
+    pollRequestTimeoutMs: supportsRequestTimeouts
       ? researchPolicy.requestTimeoutMs
-      : null,
+      : undefined,
     deferDeadlineUntilStarted: !supportsSafeStartRetries,
     start: plan.start,
     poll: plan.poll,
   })) as TResult;
 }
 
-function resolveResearchPolicy<
+function resolveSingleExecutionPolicy<
+  TResult extends SearchResponse | ProviderToolOutput,
+>(plan: ProviderOperationPlan<TResult>, options: JsonObject | undefined) {
+  const localOptions = parseLocalExecutionOptions(options);
+
+  const researchOnlyOptions = [
+    ["pollIntervalMs", localOptions.pollIntervalMs],
+    ["timeoutMs", localOptions.timeoutMs],
+    ["maxConsecutivePollErrors", localOptions.maxConsecutivePollErrors],
+    ["resumeId", localOptions.resumeId],
+    ["resumeInteractionId", options?.resumeInteractionId],
+  ].flatMap(([key, value]) => (value === undefined ? [] : [key]));
+
+  if (plan.capability === "research") {
+    if (options?.resumeInteractionId !== undefined) {
+      throw new Error(
+        "resumeInteractionId is not supported. Use resumeId instead.",
+      );
+    }
+
+    if (researchOnlyOptions.length > 0) {
+      throw new Error(
+        `${plan.providerLabel} research runs synchronously and does not support ${researchOnlyOptions.join(", ")}. Use requestTimeoutMs/retryCount/retryDelayMs instead.`,
+      );
+    }
+  } else if (researchOnlyOptions.length > 0) {
+    throw new Error(
+      `${plan.providerLabel} ${plan.capability} does not support ${researchOnlyOptions.join(", ")}. These controls only apply to web_research. Use requestTimeoutMs/retryCount/retryDelayMs instead.`,
+    );
+  }
+
+  return resolveRequestExecutionPolicy(options, plan.traits?.policyDefaults);
+}
+
+function resolveJobResearchExecutionPolicy<
   TResult extends SearchResponse | ProviderToolOutput,
 >(
   plan: ProviderOperationPlan<TResult>,
   options: JsonObject | undefined,
 ): ResearchExecutionPolicy {
-  return resolveResearchExecutionPolicy(options, plan.traits?.policyDefaults);
-}
-
-function assertResearchOptionsSupported<
-  TResult extends SearchResponse | ProviderToolOutput,
->(plan: ProviderOperationPlan<TResult>, options: JsonObject | undefined): void {
-  if (plan.capability !== "research") {
-    return;
-  }
+  const localOptions = parseLocalExecutionOptions(options);
 
   if (options?.resumeInteractionId !== undefined) {
     throw new Error(
@@ -86,22 +114,35 @@ function assertResearchOptionsSupported<
     );
   }
 
-  if (plan.mode === "job") {
-    return;
+  if (
+    localOptions.requestTimeoutMs !== undefined &&
+    plan.traits?.researchLifecycle?.supportsRequestTimeouts !== true
+  ) {
+    throw new Error(
+      `${plan.providerLabel} research does not support requestTimeoutMs. Use retryCount/retryDelayMs/pollIntervalMs/timeoutMs/maxConsecutivePollErrors/resumeId instead.`,
+    );
   }
 
-  const unsupported = [
-    ["pollIntervalMs", options?.pollIntervalMs],
-    ["timeoutMs", options?.timeoutMs],
-    ["maxConsecutivePollErrors", options?.maxConsecutivePollErrors],
-    ["resumeId", options?.resumeId],
-  ].flatMap(([key, value]) => (value === undefined ? [] : [key]));
-
-  if (unsupported.length === 0) {
-    return;
-  }
-
-  throw new Error(
-    `${plan.providerLabel} research runs synchronously and does not support ${unsupported.join(", ")}. Use requestTimeoutMs/retryCount/retryDelayMs instead.`,
+  return resolveResearchExecutionPolicy(
+    options,
+    getSupportedResearchPolicyDefaults(plan),
   );
+}
+
+function getSupportedResearchPolicyDefaults<
+  TResult extends SearchResponse | ProviderToolOutput,
+>(plan: ProviderOperationPlan<TResult>): ExecutionPolicyDefaults | undefined {
+  const defaults = plan.traits?.policyDefaults;
+  if (!defaults) {
+    return undefined;
+  }
+
+  if (plan.traits?.researchLifecycle?.supportsRequestTimeouts === true) {
+    return defaults;
+  }
+
+  const { requestTimeoutMs: _requestTimeoutMs, ...rest } = defaults;
+  return Object.values(rest).some((value) => value !== undefined)
+    ? rest
+    : undefined;
 }

--- a/src/provider-runtime.ts
+++ b/src/provider-runtime.ts
@@ -7,14 +7,17 @@ import {
   resolveResearchExecutionPolicy,
   runWithExecutionPolicy,
 } from "./execution-policy.js";
-import type {
-  ExecutionPolicyDefaults,
-  JsonObject,
-  ProviderContext,
-  ProviderOperationPlan,
-  ProviderToolOutput,
-  SearchResponse,
-  SingleProviderOperationPlan,
+import {
+  EXECUTION_CONTROL_KEYS,
+  type ExecutionControlKey,
+  type ExecutionPolicyDefaults,
+  type ExecutionSupport,
+  type JsonObject,
+  type ProviderContext,
+  type ProviderOperationPlan,
+  type ProviderToolOutput,
+  type SearchResponse,
+  type SingleProviderOperationPlan,
 } from "./types.js";
 
 export async function executeOperationPlan<
@@ -69,44 +72,60 @@ export async function executeOperationPlan<
   })) as TResult;
 }
 
+export function resolvePlanExecutionSupport<
+  TResult extends SearchResponse | ProviderToolOutput,
+>(plan: ProviderOperationPlan<TResult>): Required<ExecutionSupport> {
+  const explicit = plan.traits?.executionSupport ?? {};
+
+  return {
+    requestTimeoutMs:
+      explicit.requestTimeoutMs ??
+      inferExecutionSupport(plan, "requestTimeoutMs"),
+    retryCount:
+      explicit.retryCount ?? inferExecutionSupport(plan, "retryCount"),
+    retryDelayMs:
+      explicit.retryDelayMs ?? inferExecutionSupport(plan, "retryDelayMs"),
+    pollIntervalMs:
+      explicit.pollIntervalMs ?? inferExecutionSupport(plan, "pollIntervalMs"),
+    timeoutMs: explicit.timeoutMs ?? inferExecutionSupport(plan, "timeoutMs"),
+    maxConsecutivePollErrors:
+      explicit.maxConsecutivePollErrors ??
+      inferExecutionSupport(plan, "maxConsecutivePollErrors"),
+    resumeId: explicit.resumeId ?? inferExecutionSupport(plan, "resumeId"),
+  };
+}
+
 function resolveForegroundExecutionPolicy<
   TResult extends SearchResponse | ProviderToolOutput,
 >(plan: SingleProviderOperationPlan<TResult>, options: JsonObject | undefined) {
-  // Silent foreground plans inherit the full request policy. Streaming
-  // foreground plans intentionally drop the default request timeout so that a
-  // provider can keep streaming progress without being cut off by a short
-  // request/response timeout that was tuned for silent foreground tools.
   const localOptions = parseLocalExecutionOptions(options);
+  const executionSupport = resolvePlanExecutionSupport(plan);
+  const unsupportedControls = getUnsupportedExecutionControls(
+    localOptions,
+    executionSupport,
+  );
 
-  const researchOnlyOptions = [
-    ["pollIntervalMs", localOptions.pollIntervalMs],
-    ["timeoutMs", localOptions.timeoutMs],
-    ["maxConsecutivePollErrors", localOptions.maxConsecutivePollErrors],
-    ["resumeId", localOptions.resumeId],
-    ["resumeInteractionId", options?.resumeInteractionId],
-  ].flatMap(([key, value]) => (value === undefined ? [] : [key]));
-
-  if (plan.capability === "research") {
-    if (options?.resumeInteractionId !== undefined) {
-      throw new Error(
-        "resumeInteractionId is not supported. Use resumeId instead.",
-      );
-    }
-
-    if (researchOnlyOptions.length > 0) {
-      throw new Error(
-        `${plan.providerLabel} research runs in ${formatForegroundMode(plan.deliveryMode)} mode and does not support ${researchOnlyOptions.join(", ")}. Use requestTimeoutMs/retryCount/retryDelayMs instead.`,
-      );
-    }
-  } else if (researchOnlyOptions.length > 0) {
+  if (options?.resumeInteractionId !== undefined) {
     throw new Error(
-      `${plan.providerLabel} ${plan.capability} does not support ${researchOnlyOptions.join(", ")}. These controls only apply to web_research. Use requestTimeoutMs/retryCount/retryDelayMs instead.`,
+      "resumeInteractionId is not supported. Use resumeId instead.",
+    );
+  }
+
+  if (unsupportedControls.length > 0) {
+    if (plan.capability === "research") {
+      throw new Error(
+        `${plan.providerLabel} research runs in ${formatForegroundMode(plan.deliveryMode)} mode and does not support ${unsupportedControls.join(", ")}. Use ${formatSupportedControls(executionSupport, plan.capability)} instead.`,
+      );
+    }
+
+    throw new Error(
+      `${plan.providerLabel} ${plan.capability} does not support ${unsupportedControls.join(", ")}. These controls only apply to web_research. Use ${formatSupportedControls(executionSupport, plan.capability)} instead.`,
     );
   }
 
   return resolveRequestExecutionPolicy(
     options,
-    getSupportedForegroundPolicyDefaults(plan),
+    filterPolicyDefaults(plan.traits?.policyDefaults, executionSupport),
   );
 }
 
@@ -117,6 +136,7 @@ function resolveBackgroundResearchExecutionPolicy<
   options: JsonObject | undefined,
 ): ResearchExecutionPolicy {
   const localOptions = parseLocalExecutionOptions(options);
+  const executionSupport = resolvePlanExecutionSupport(plan);
 
   if (options?.resumeInteractionId !== undefined) {
     throw new Error(
@@ -124,19 +144,98 @@ function resolveBackgroundResearchExecutionPolicy<
     );
   }
 
-  if (
-    localOptions.requestTimeoutMs !== undefined &&
-    plan.traits?.researchLifecycle?.supportsRequestTimeouts !== true
-  ) {
+  const unsupportedControls = getUnsupportedExecutionControls(
+    localOptions,
+    executionSupport,
+  );
+  if (unsupportedControls.length > 0) {
     throw new Error(
-      `${plan.providerLabel} research does not support requestTimeoutMs. Use retryCount/retryDelayMs/pollIntervalMs/timeoutMs/maxConsecutivePollErrors/resumeId instead.`,
+      `${plan.providerLabel} research does not support ${unsupportedControls.join(", ")}. Use ${formatSupportedControls(executionSupport, plan.capability)} instead.`,
     );
   }
 
   return resolveResearchExecutionPolicy(
     options,
-    getSupportedBackgroundResearchPolicyDefaults(plan),
+    filterPolicyDefaults(plan.traits?.policyDefaults, executionSupport),
   );
+}
+
+function inferExecutionSupport<
+  TResult extends SearchResponse | ProviderToolOutput,
+>(plan: ProviderOperationPlan<TResult>, key: ExecutionControlKey): boolean {
+  switch (key) {
+    case "requestTimeoutMs":
+      if (plan.deliveryMode !== "background-research") {
+        return true;
+      }
+      return plan.traits?.researchLifecycle?.supportsRequestTimeouts === true;
+    case "retryCount":
+    case "retryDelayMs":
+      return true;
+    case "pollIntervalMs":
+    case "timeoutMs":
+    case "maxConsecutivePollErrors":
+    case "resumeId":
+      return (
+        plan.capability === "research" &&
+        plan.deliveryMode === "background-research"
+      );
+  }
+}
+
+function getUnsupportedExecutionControls(
+  localOptions: ReturnType<typeof parseLocalExecutionOptions>,
+  executionSupport: Required<ExecutionSupport>,
+): ExecutionControlKey[] {
+  return EXECUTION_CONTROL_KEYS.filter((key) => {
+    const value = localOptions[key];
+    return value !== undefined && executionSupport[key] !== true;
+  });
+}
+
+function filterPolicyDefaults(
+  defaults: ExecutionPolicyDefaults | undefined,
+  executionSupport: Required<ExecutionSupport>,
+): ExecutionPolicyDefaults | undefined {
+  if (!defaults) {
+    return undefined;
+  }
+
+  const filtered: ExecutionPolicyDefaults = {
+    requestTimeoutMs: executionSupport.requestTimeoutMs
+      ? defaults.requestTimeoutMs
+      : undefined,
+    retryCount: executionSupport.retryCount ? defaults.retryCount : undefined,
+    retryDelayMs: executionSupport.retryDelayMs
+      ? defaults.retryDelayMs
+      : undefined,
+    researchPollIntervalMs: executionSupport.pollIntervalMs
+      ? defaults.researchPollIntervalMs
+      : undefined,
+    researchTimeoutMs: executionSupport.timeoutMs
+      ? defaults.researchTimeoutMs
+      : undefined,
+    researchMaxConsecutivePollErrors: executionSupport.maxConsecutivePollErrors
+      ? defaults.researchMaxConsecutivePollErrors
+      : undefined,
+  };
+
+  return Object.values(filtered).some((value) => value !== undefined)
+    ? filtered
+    : undefined;
+}
+
+function formatSupportedControls(
+  executionSupport: Required<ExecutionSupport>,
+  capability: SingleProviderOperationPlan<unknown>["capability"],
+): string {
+  const supportedControls = EXECUTION_CONTROL_KEYS.filter(
+    (key) => executionSupport[key] === true,
+  ).filter((key) => capability === "research" || key !== "resumeId");
+
+  return supportedControls.length > 0
+    ? supportedControls.join("/")
+    : "no local execution controls";
 }
 
 function formatForegroundMode(
@@ -145,40 +244,4 @@ function formatForegroundMode(
   return deliveryMode === "streaming-foreground"
     ? "streaming foreground"
     : "silent foreground";
-}
-
-function getSupportedForegroundPolicyDefaults<TResult>(
-  plan: SingleProviderOperationPlan<TResult>,
-): ExecutionPolicyDefaults | undefined {
-  const defaults = plan.traits?.policyDefaults;
-  if (!defaults) {
-    return undefined;
-  }
-
-  if (plan.deliveryMode === "silent-foreground") {
-    return defaults;
-  }
-
-  const { requestTimeoutMs: _requestTimeoutMs, ...rest } = defaults;
-  return Object.values(rest).some((value) => value !== undefined)
-    ? rest
-    : undefined;
-}
-
-function getSupportedBackgroundResearchPolicyDefaults<
-  TResult extends SearchResponse | ProviderToolOutput,
->(plan: ProviderOperationPlan<TResult>): ExecutionPolicyDefaults | undefined {
-  const defaults = plan.traits?.policyDefaults;
-  if (!defaults) {
-    return undefined;
-  }
-
-  if (plan.traits?.researchLifecycle?.supportsRequestTimeouts === true) {
-    return defaults;
-  }
-
-  const { requestTimeoutMs: _requestTimeoutMs, ...rest } = defaults;
-  return Object.values(rest).some((value) => value !== undefined)
-    ? rest
-    : undefined;
 }

--- a/src/provider-runtime.ts
+++ b/src/provider-runtime.ts
@@ -1,0 +1,107 @@
+import { randomUUID } from "node:crypto";
+import {
+  executeResearchWithLifecycle,
+  type ResearchExecutionPolicy,
+  resolveRequestExecutionPolicy,
+  resolveResearchExecutionPolicy,
+  runWithExecutionPolicy,
+} from "./execution-policy.js";
+import type {
+  JsonObject,
+  ProviderContext,
+  ProviderOperationPlan,
+  ProviderToolOutput,
+  SearchResponse,
+} from "./types.js";
+
+export async function executeOperationPlan<
+  TResult extends SearchResponse | ProviderToolOutput,
+>(
+  plan: ProviderOperationPlan<TResult>,
+  options: JsonObject | undefined,
+  context: ProviderContext,
+): Promise<TResult> {
+  assertResearchOptionsSupported(plan, options);
+
+  if (plan.mode === "single") {
+    return await runWithExecutionPolicy(
+      `${plan.providerLabel} ${plan.capability} request`,
+      plan.execute,
+      resolveRequestExecutionPolicy(options, plan.traits?.policyDefaults),
+      context,
+    );
+  }
+
+  const researchPolicy = resolveResearchPolicy(plan, options);
+  const supportsSafeStartRetries =
+    plan.traits?.supportsIdempotentStartRetries === true;
+  const supportsPollCancellation =
+    plan.traits?.supportsPollCancellation === true;
+
+  return (await executeResearchWithLifecycle({
+    providerLabel: plan.providerLabel,
+    providerId: plan.providerId,
+    context,
+    policy: researchPolicy,
+    startRetryCount: supportsSafeStartRetries ? researchPolicy.retryCount : 0,
+    startRetryNotice:
+      !supportsSafeStartRetries && researchPolicy.retryCount > 0
+        ? `${plan.providerLabel} research start retries are disabled to avoid duplicate background jobs; configured retries apply after the job starts.`
+        : undefined,
+    startIdempotencyKey: supportsSafeStartRetries
+      ? `pi-web-providers:${plan.providerId}:${randomUUID()}`
+      : undefined,
+    startRetryOnTimeout: supportsSafeStartRetries,
+    startRequestTimeoutMs: supportsSafeStartRetries
+      ? researchPolicy.requestTimeoutMs
+      : null,
+    pollRequestTimeoutMs: supportsPollCancellation
+      ? researchPolicy.requestTimeoutMs
+      : null,
+    deferDeadlineUntilStarted: !supportsSafeStartRetries,
+    start: plan.start,
+    poll: plan.poll,
+  })) as TResult;
+}
+
+function resolveResearchPolicy<
+  TResult extends SearchResponse | ProviderToolOutput,
+>(
+  plan: ProviderOperationPlan<TResult>,
+  options: JsonObject | undefined,
+): ResearchExecutionPolicy {
+  return resolveResearchExecutionPolicy(options, plan.traits?.policyDefaults);
+}
+
+function assertResearchOptionsSupported<
+  TResult extends SearchResponse | ProviderToolOutput,
+>(plan: ProviderOperationPlan<TResult>, options: JsonObject | undefined): void {
+  if (plan.capability !== "research") {
+    return;
+  }
+
+  if (options?.resumeInteractionId !== undefined) {
+    throw new Error(
+      "resumeInteractionId is not supported. Use resumeId instead.",
+    );
+  }
+
+  if (plan.mode === "job") {
+    return;
+  }
+
+  const unsupported = [
+    ["pollIntervalMs", options?.pollIntervalMs],
+    ["timeoutMs", options?.timeoutMs],
+    ["maxConsecutivePollErrors", options?.maxConsecutivePollErrors],
+    ["resumeId", options?.resumeId],
+  ].flatMap(([key, value]) => (value === undefined ? [] : [key]));
+
+  if (unsupported.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    `${plan.providerLabel} research runs synchronously and does not support ${unsupported.join(", ")}. Use requestTimeoutMs/retryCount/retryDelayMs instead.`,
+  );
+}

--- a/src/provider-runtime.ts
+++ b/src/provider-runtime.ts
@@ -14,6 +14,7 @@ import type {
   ProviderOperationPlan,
   ProviderToolOutput,
   SearchResponse,
+  SingleProviderOperationPlan,
 } from "./types.js";
 
 export async function executeOperationPlan<
@@ -23,8 +24,8 @@ export async function executeOperationPlan<
   options: JsonObject | undefined,
   context: ProviderContext,
 ): Promise<TResult> {
-  if (plan.mode === "single") {
-    const requestPolicy = resolveSingleExecutionPolicy(plan, options);
+  if (plan.deliveryMode !== "background-research") {
+    const requestPolicy = resolveForegroundExecutionPolicy(plan, options);
     return await runWithExecutionPolicy(
       `${plan.providerLabel} ${plan.capability} request`,
       plan.execute,
@@ -33,7 +34,10 @@ export async function executeOperationPlan<
     );
   }
 
-  const researchPolicy = resolveJobResearchExecutionPolicy(plan, options);
+  const researchPolicy = resolveBackgroundResearchExecutionPolicy(
+    plan,
+    options,
+  );
   const lifecycleTraits = plan.traits?.researchLifecycle;
   const supportsSafeStartRetries =
     lifecycleTraits?.supportsStartRetries === true;
@@ -65,9 +69,13 @@ export async function executeOperationPlan<
   })) as TResult;
 }
 
-function resolveSingleExecutionPolicy<
+function resolveForegroundExecutionPolicy<
   TResult extends SearchResponse | ProviderToolOutput,
->(plan: ProviderOperationPlan<TResult>, options: JsonObject | undefined) {
+>(plan: SingleProviderOperationPlan<TResult>, options: JsonObject | undefined) {
+  // Silent foreground plans inherit the full request policy. Streaming
+  // foreground plans intentionally drop the default request timeout so that a
+  // provider can keep streaming progress without being cut off by a short
+  // request/response timeout that was tuned for silent foreground tools.
   const localOptions = parseLocalExecutionOptions(options);
 
   const researchOnlyOptions = [
@@ -87,7 +95,7 @@ function resolveSingleExecutionPolicy<
 
     if (researchOnlyOptions.length > 0) {
       throw new Error(
-        `${plan.providerLabel} research runs synchronously and does not support ${researchOnlyOptions.join(", ")}. Use requestTimeoutMs/retryCount/retryDelayMs instead.`,
+        `${plan.providerLabel} research runs in ${formatForegroundMode(plan.deliveryMode)} mode and does not support ${researchOnlyOptions.join(", ")}. Use requestTimeoutMs/retryCount/retryDelayMs instead.`,
       );
     }
   } else if (researchOnlyOptions.length > 0) {
@@ -96,10 +104,13 @@ function resolveSingleExecutionPolicy<
     );
   }
 
-  return resolveRequestExecutionPolicy(options, plan.traits?.policyDefaults);
+  return resolveRequestExecutionPolicy(
+    options,
+    getSupportedForegroundPolicyDefaults(plan),
+  );
 }
 
-function resolveJobResearchExecutionPolicy<
+function resolveBackgroundResearchExecutionPolicy<
   TResult extends SearchResponse | ProviderToolOutput,
 >(
   plan: ProviderOperationPlan<TResult>,
@@ -124,11 +135,37 @@ function resolveJobResearchExecutionPolicy<
 
   return resolveResearchExecutionPolicy(
     options,
-    getSupportedResearchPolicyDefaults(plan),
+    getSupportedBackgroundResearchPolicyDefaults(plan),
   );
 }
 
-function getSupportedResearchPolicyDefaults<
+function formatForegroundMode(
+  deliveryMode: SingleProviderOperationPlan<unknown>["deliveryMode"],
+): "silent foreground" | "streaming foreground" {
+  return deliveryMode === "streaming-foreground"
+    ? "streaming foreground"
+    : "silent foreground";
+}
+
+function getSupportedForegroundPolicyDefaults<TResult>(
+  plan: SingleProviderOperationPlan<TResult>,
+): ExecutionPolicyDefaults | undefined {
+  const defaults = plan.traits?.policyDefaults;
+  if (!defaults) {
+    return undefined;
+  }
+
+  if (plan.deliveryMode === "silent-foreground") {
+    return defaults;
+  }
+
+  const { requestTimeoutMs: _requestTimeoutMs, ...rest } = defaults;
+  return Object.values(rest).some((value) => value !== undefined)
+    ? rest
+    : undefined;
+}
+
+function getSupportedBackgroundResearchPolicyDefaults<
   TResult extends SearchResponse | ProviderToolOutput,
 >(plan: ProviderOperationPlan<TResult>): ExecutionPolicyDefaults | undefined {
   const defaults = plan.traits?.policyDefaults;

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -7,6 +7,7 @@ import {
   type SDKMessage,
   type SDKResultMessage,
 } from "@anthropic-ai/claude-agent-sdk";
+import { createSingleOperationPlan } from "../provider-plans.js";
 import type {
   ClaudeProviderConfig,
   ProviderContext,
@@ -119,11 +120,11 @@ export class ClaudeProvider implements WebProvider<ClaudeProviderConfig> {
   buildPlan(request: ProviderOperationRequest, config: ClaudeProviderConfig) {
     switch (request.capability) {
       case "search":
-        return {
+        return createSingleOperationPlan({
+          config,
           capability: request.capability,
           providerId: this.id,
           providerLabel: this.label,
-          mode: "single" as const,
           execute: (context: ProviderContext) =>
             this.search(
               request.query,
@@ -132,16 +133,16 @@ export class ClaudeProvider implements WebProvider<ClaudeProviderConfig> {
               config,
               context,
             ),
-        };
+        });
       case "answer":
-        return {
+        return createSingleOperationPlan({
+          config,
           capability: request.capability,
           providerId: this.id,
           providerLabel: this.label,
-          mode: "single" as const,
           execute: (context: ProviderContext) =>
             this.answer(request.query, request.options, config, context),
-        };
+        });
       default:
         return null;
     }

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -10,6 +10,7 @@ import {
 import type {
   ClaudeProviderConfig,
   ProviderContext,
+  ProviderOperationRequest,
   ProviderStatus,
   ProviderToolOutput,
   SearchResponse,
@@ -78,10 +79,11 @@ interface ClaudeAnswerOutput {
 }
 
 export class ClaudeProvider implements WebProvider<ClaudeProviderConfig> {
-  readonly id = "claude";
+  readonly id: "claude" = "claude";
   readonly label = "Claude";
   readonly docsUrl =
     "https://github.com/anthropics/claude-agent-sdk-typescript";
+  readonly capabilities = ["search", "answer"] as const;
 
   createTemplate(): ClaudeProviderConfig {
     return {
@@ -112,6 +114,37 @@ export class ClaudeProvider implements WebProvider<ClaudeProviderConfig> {
       return { available: false, summary: "missing Claude auth" };
     }
     return { available: true, summary: "enabled" };
+  }
+
+  buildPlan(request: ProviderOperationRequest, config: ClaudeProviderConfig) {
+    switch (request.capability) {
+      case "search":
+        return {
+          capability: request.capability,
+          providerId: this.id,
+          providerLabel: this.label,
+          mode: "single" as const,
+          execute: (context: ProviderContext) =>
+            this.search(
+              request.query,
+              request.maxResults,
+              request.options,
+              config,
+              context,
+            ),
+        };
+      case "answer":
+        return {
+          capability: request.capability,
+          providerId: this.id,
+          providerLabel: this.label,
+          mode: "single" as const,
+          execute: (context: ProviderContext) =>
+            this.answer(request.query, request.options, config, context),
+        };
+      default:
+        return null;
+    }
   }
 
   async search(
@@ -436,7 +469,8 @@ function getClaudeRuntimeOptions(
   config: ClaudeProviderConfig,
   options: Record<string, unknown> | undefined,
 ): Record<string, unknown> {
-  const model = readNonEmptyString(options?.model) ?? config.defaults?.model;
+  const native = config.native ?? config.defaults;
+  const model = readNonEmptyString(options?.model) ?? native?.model;
   const effort = readEnum(options?.effort, ["low", "medium", "high", "max"]);
   const maxTurns = readPositiveInteger(options?.maxTurns);
   const maxThinkingTokens = readNonNegativeInteger(options?.maxThinkingTokens);
@@ -447,11 +481,9 @@ function getClaudeRuntimeOptions(
 
   return {
     ...(model ? { model } : {}),
-    ...((effort ?? config.defaults?.effort)
-      ? { effort: effort ?? config.defaults?.effort }
-      : {}),
-    ...((maxTurns ?? config.defaults?.maxTurns)
-      ? { maxTurns: maxTurns ?? config.defaults?.maxTurns }
+    ...((effort ?? native?.effort) ? { effort: effort ?? native?.effort } : {}),
+    ...((maxTurns ?? native?.maxTurns)
+      ? { maxTurns: maxTurns ?? native?.maxTurns }
       : {}),
     ...(maxThinkingTokens !== undefined ? { maxThinkingTokens } : {}),
     ...(maxBudgetUsd !== undefined ? { maxBudgetUsd } : {}),

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -7,6 +7,7 @@ import {
   type SDKMessage,
   type SDKResultMessage,
 } from "@anthropic-ai/claude-agent-sdk";
+import { createDefaultRequestPolicy } from "../execution-policy-defaults.js";
 import { createSingleOperationPlan } from "../provider-plans.js";
 import type {
   ClaudeProviderConfig,
@@ -93,6 +94,7 @@ export class ClaudeProvider implements WebProvider<ClaudeProviderConfig> {
         search: true,
         answer: true,
       },
+      policy: createDefaultRequestPolicy(),
     };
   }
 

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -8,7 +8,7 @@ import {
   type SDKResultMessage,
 } from "@anthropic-ai/claude-agent-sdk";
 import { createDefaultRequestPolicy } from "../execution-policy-defaults.js";
-import { createSingleOperationPlan } from "../provider-plans.js";
+import { createSilentForegroundPlan } from "../provider-plans.js";
 import type {
   ClaudeProviderConfig,
   ProviderContext,
@@ -122,7 +122,7 @@ export class ClaudeProvider implements WebProvider<ClaudeProviderConfig> {
   buildPlan(request: ProviderOperationRequest, config: ClaudeProviderConfig) {
     switch (request.capability) {
       case "search":
-        return createSingleOperationPlan({
+        return createSilentForegroundPlan({
           config,
           capability: request.capability,
           providerId: this.id,
@@ -137,7 +137,7 @@ export class ClaudeProvider implements WebProvider<ClaudeProviderConfig> {
             ),
         });
       case "answer":
-        return createSingleOperationPlan({
+        return createSilentForegroundPlan({
           config,
           capability: request.capability,
           providerId: this.id,

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { Codex, type ThreadEvent } from "@openai/codex-sdk";
 import { resolveConfigValue, resolveEnvMap } from "../config.js";
 import { createDefaultRequestPolicy } from "../execution-policy-defaults.js";
-import { createSingleOperationPlan } from "../provider-plans.js";
+import { createSilentForegroundPlan } from "../provider-plans.js";
 import type {
   CodexProviderConfig,
   ProviderContext,
@@ -97,7 +97,7 @@ export class CodexProvider implements WebProvider<CodexProviderConfig> {
       return null;
     }
 
-    return createSingleOperationPlan({
+    return createSilentForegroundPlan({
       config,
       capability: request.capability,
       providerId: this.id,

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -3,6 +3,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { Codex, type ThreadEvent } from "@openai/codex-sdk";
 import { resolveConfigValue, resolveEnvMap } from "../config.js";
+import { createDefaultRequestPolicy } from "../execution-policy-defaults.js";
 import { createSingleOperationPlan } from "../provider-plans.js";
 import type {
   CodexProviderConfig,
@@ -60,6 +61,7 @@ export class CodexProvider implements WebProvider<CodexProviderConfig> {
         webSearchEnabled: true,
         webSearchMode: "live",
       },
+      policy: createDefaultRequestPolicy(),
     };
   }
 

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -3,6 +3,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { Codex, type ThreadEvent } from "@openai/codex-sdk";
 import { resolveConfigValue, resolveEnvMap } from "../config.js";
+import { createSingleOperationPlan } from "../provider-plans.js";
 import type {
   CodexProviderConfig,
   ProviderContext,
@@ -94,11 +95,11 @@ export class CodexProvider implements WebProvider<CodexProviderConfig> {
       return null;
     }
 
-    return {
+    return createSingleOperationPlan({
+      config,
       capability: request.capability,
       providerId: this.id,
       providerLabel: this.label,
-      mode: "single" as const,
       execute: (context: ProviderContext) =>
         this.search(
           request.query,
@@ -107,7 +108,7 @@ export class CodexProvider implements WebProvider<CodexProviderConfig> {
           config,
           context,
         ),
-    };
+    });
   }
 
   async search(

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -2,14 +2,15 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { Codex, type ThreadEvent } from "@openai/codex-sdk";
+import { resolveConfigValue, resolveEnvMap } from "../config.js";
 import type {
   CodexProviderConfig,
   ProviderContext,
+  ProviderOperationRequest,
   ProviderStatus,
   SearchResponse,
   WebProvider,
 } from "../types.js";
-import { resolveConfigValue, resolveEnvMap } from "../config.js";
 import { trimSnippet } from "./shared.js";
 
 const OUTPUT_SCHEMA = {
@@ -42,9 +43,10 @@ interface CodexOutput {
 }
 
 export class CodexProvider implements WebProvider<CodexProviderConfig> {
-  readonly id = "codex";
+  readonly id: "codex" = "codex";
   readonly label = "Codex";
   readonly docsUrl = "https://github.com/openai/codex/tree/main/sdk/typescript";
+  readonly capabilities = ["search"] as const;
 
   createTemplate(): CodexProviderConfig {
     return {
@@ -52,7 +54,7 @@ export class CodexProvider implements WebProvider<CodexProviderConfig> {
       tools: {
         search: true,
       },
-      defaults: {
+      native: {
         networkAccessEnabled: true,
         webSearchEnabled: true,
         webSearchMode: "live",
@@ -85,6 +87,27 @@ export class CodexProvider implements WebProvider<CodexProviderConfig> {
       return { available: false, summary: "missing Codex auth" };
     }
     return { available: true, summary: "enabled" };
+  }
+
+  buildPlan(request: ProviderOperationRequest, config: CodexProviderConfig) {
+    if (request.capability !== "search") {
+      return null;
+    }
+
+    return {
+      capability: request.capability,
+      providerId: this.id,
+      providerLabel: this.label,
+      mode: "single" as const,
+      execute: (context: ProviderContext) =>
+        this.search(
+          request.query,
+          request.maxResults,
+          request.options,
+          config,
+          context,
+        ),
+    };
   }
 
   async search(
@@ -157,20 +180,20 @@ function buildCodexSearchThreadOptions(
   options: Record<string, unknown> | undefined,
 ) {
   const runtimeOptions = getCodexSearchRuntimeOptions(options);
+  const native = config.native ?? config.defaults;
 
   return {
-    additionalDirectories: config.defaults?.additionalDirectories,
+    additionalDirectories: native?.additionalDirectories,
     approvalPolicy: "never" as const,
-    model: runtimeOptions.model ?? config.defaults?.model,
+    model: runtimeOptions.model ?? native?.model,
     modelReasoningEffort:
-      runtimeOptions.modelReasoningEffort ??
-      config.defaults?.modelReasoningEffort,
-    networkAccessEnabled: config.defaults?.networkAccessEnabled ?? true,
+      runtimeOptions.modelReasoningEffort ?? native?.modelReasoningEffort,
+    networkAccessEnabled: native?.networkAccessEnabled ?? true,
     sandboxMode: "read-only" as const,
     skipGitRepoCheck: true,
-    webSearchEnabled: config.defaults?.webSearchEnabled ?? true,
+    webSearchEnabled: native?.webSearchEnabled ?? true,
     webSearchMode:
-      runtimeOptions.webSearchMode ?? config.defaults?.webSearchMode ?? "live",
+      runtimeOptions.webSearchMode ?? native?.webSearchMode ?? "live",
     workingDirectory: cwd,
   };
 }

--- a/src/providers/exa.ts
+++ b/src/providers/exa.ts
@@ -3,8 +3,8 @@ import { resolveConfigValue } from "../config.js";
 import { stripLocalExecutionOptions } from "../execution-policy.js";
 import { createDefaultLifecyclePolicy } from "../execution-policy-defaults.js";
 import {
-  createResearchJobPlan,
-  createSingleOperationPlan,
+  createBackgroundResearchPlan,
+  createSilentForegroundPlan,
 } from "../provider-plans.js";
 import type {
   ExaProviderConfig,
@@ -62,7 +62,7 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
   buildPlan(request: ProviderOperationRequest, config: ExaProviderConfig) {
     switch (request.capability) {
       case "search":
-        return createSingleOperationPlan({
+        return createSilentForegroundPlan({
           config,
           capability: request.capability,
           providerId: this.id,
@@ -77,7 +77,7 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
             ),
         });
       case "contents":
-        return createSingleOperationPlan({
+        return createSilentForegroundPlan({
           config,
           capability: request.capability,
           providerId: this.id,
@@ -86,7 +86,7 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
             this.contents(request.urls, request.options, config, context),
         });
       case "answer":
-        return createSingleOperationPlan({
+        return createSilentForegroundPlan({
           config,
           capability: request.capability,
           providerId: this.id,
@@ -95,7 +95,7 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
             this.answer(request.query, request.options, config, context),
         });
       case "research":
-        return createResearchJobPlan({
+        return createBackgroundResearchPlan({
           config,
           capability: request.capability,
           providerId: this.id,

--- a/src/providers/exa.ts
+++ b/src/providers/exa.ts
@@ -1,8 +1,10 @@
 import { Exa } from "exa-js";
 import { resolveConfigValue } from "../config.js";
+import { stripLocalExecutionOptions } from "../execution-policy.js";
 import type {
   ExaProviderConfig,
   ProviderContext,
+  ProviderOperationRequest,
   ProviderResearchJob,
   ProviderResearchPollResult,
   ProviderStatus,
@@ -13,9 +15,10 @@ import type {
 import { asJsonObject, formatJson, trimSnippet } from "./shared.js";
 
 export class ExaProvider implements WebProvider<ExaProviderConfig> {
-  readonly id = "exa";
+  readonly id: "exa" = "exa";
   readonly label = "Exa";
   readonly docsUrl = "https://exa.ai/docs/sdks/typescript-sdk-specification";
+  readonly capabilities = ["search", "contents", "answer", "research"] as const;
 
   createTemplate(): ExaProviderConfig {
     return {
@@ -27,7 +30,7 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
         research: true,
       },
       apiKey: "EXA_API_KEY",
-      defaults: {
+      native: {
         type: "auto",
         contents: {
           text: true,
@@ -50,6 +53,65 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
     return { available: true, summary: "enabled" };
   }
 
+  buildPlan(request: ProviderOperationRequest, config: ExaProviderConfig) {
+    const traits = {
+      policyDefaults: config.policy,
+    };
+
+    switch (request.capability) {
+      case "search":
+        return {
+          capability: request.capability,
+          providerId: this.id,
+          providerLabel: this.label,
+          mode: "single" as const,
+          traits,
+          execute: (context: ProviderContext) =>
+            this.search(
+              request.query,
+              request.maxResults,
+              request.options,
+              config,
+              context,
+            ),
+        };
+      case "contents":
+        return {
+          capability: request.capability,
+          providerId: this.id,
+          providerLabel: this.label,
+          mode: "single" as const,
+          traits,
+          execute: (context: ProviderContext) =>
+            this.contents(request.urls, request.options, config, context),
+        };
+      case "answer":
+        return {
+          capability: request.capability,
+          providerId: this.id,
+          providerLabel: this.label,
+          mode: "single" as const,
+          traits,
+          execute: (context: ProviderContext) =>
+            this.answer(request.query, request.options, config, context),
+        };
+      case "research":
+        return {
+          capability: request.capability,
+          providerId: this.id,
+          providerLabel: this.label,
+          mode: "job" as const,
+          traits,
+          start: (context: ProviderContext) =>
+            this.startResearch(request.input, request.options, config, context),
+          poll: (id: string, context: ProviderContext) =>
+            this.pollResearch(id, request.options, config, context),
+        };
+      default:
+        return null;
+    }
+  }
+
   async search(
     query: string,
     maxResults: number,
@@ -63,8 +125,9 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
     }
 
     const client = new Exa(apiKey, config.baseUrl);
+    const native = config.native ?? config.defaults;
     const options = {
-      ...asJsonObject(config.defaults),
+      ...(stripLocalExecutionOptions(asJsonObject(native)) ?? {}),
       ...(searchOptions ?? {}),
       numResults: maxResults,
     };

--- a/src/providers/exa.ts
+++ b/src/providers/exa.ts
@@ -101,6 +101,15 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
           providerId: this.id,
           providerLabel: this.label,
           traits: {
+            executionSupport: {
+              requestTimeoutMs: false,
+              retryCount: true,
+              retryDelayMs: true,
+              pollIntervalMs: true,
+              timeoutMs: true,
+              maxConsecutivePollErrors: true,
+              resumeId: true,
+            },
             researchLifecycle: {
               supportsStartRetries: false,
               supportsRequestTimeouts: false,

--- a/src/providers/exa.ts
+++ b/src/providers/exa.ts
@@ -1,13 +1,15 @@
 import { Exa } from "exa-js";
+import { resolveConfigValue } from "../config.js";
 import type {
   ExaProviderConfig,
   ProviderContext,
+  ProviderResearchJob,
+  ProviderResearchPollResult,
   ProviderStatus,
   ProviderToolOutput,
   SearchResponse,
   WebProvider,
 } from "../types.js";
-import { resolveConfigValue } from "../config.js";
 import { asJsonObject, formatJson, trimSnippet } from "./shared.js";
 
 export class ExaProvider implements WebProvider<ExaProviderConfig> {
@@ -184,12 +186,12 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
     };
   }
 
-  async research(
+  async startResearch(
     input: string,
     options: Record<string, unknown> | undefined,
     config: ExaProviderConfig,
     context: ProviderContext,
-  ): Promise<ProviderToolOutput> {
+  ): Promise<ProviderResearchJob> {
     const apiKey = resolveConfigValue(config.apiKey);
     if (!apiKey) {
       throw new Error("Exa is missing an API key.");
@@ -201,24 +203,55 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
       instructions: input,
       ...(options ?? {}),
     });
-    const result = await client.research.pollUntilFinished(task.researchId, {
-      pollInterval: 3000,
-    });
+
+    return { id: task.researchId };
+  }
+
+  async pollResearch(
+    id: string,
+    _options: Record<string, unknown> | undefined,
+    config: ExaProviderConfig,
+    _context: ProviderContext,
+  ): Promise<ProviderResearchPollResult> {
+    const apiKey = resolveConfigValue(config.apiKey);
+    if (!apiKey) {
+      throw new Error("Exa is missing an API key.");
+    }
+
+    const client = new Exa(apiKey, config.baseUrl);
+    const result = await client.research.get(id, { events: false });
+
+    if (result.status === "completed") {
+      const content = result.output?.content;
+      return {
+        status: "completed",
+        output: {
+          provider: this.id,
+          text:
+            typeof content === "string"
+              ? content
+              : content !== undefined
+                ? formatJson(content)
+                : "Exa research completed without textual output.",
+          summary: "Research via Exa",
+        },
+      };
+    }
 
     if (result.status === "failed") {
-      throw new Error(result.error ?? "Exa research failed.");
-    }
-    if (result.status === "canceled") {
-      throw new Error("Exa research was canceled.");
+      return {
+        status: "failed",
+        error: result.error ?? "Exa research failed.",
+      };
     }
 
-    return {
-      provider: this.id,
-      text:
-        typeof result.output.content === "string"
-          ? result.output.content
-          : formatJson(result.output.content),
-      summary: "Research via Exa",
-    };
+    if (result.status === "canceled") {
+      return {
+        status: "cancelled",
+        error: "Exa research was canceled.",
+      };
+    }
+
+    return { status: "in_progress" };
   }
 }

--- a/src/providers/exa.ts
+++ b/src/providers/exa.ts
@@ -1,6 +1,7 @@
 import { Exa } from "exa-js";
 import { resolveConfigValue } from "../config.js";
 import { stripLocalExecutionOptions } from "../execution-policy.js";
+import { createDefaultLifecyclePolicy } from "../execution-policy-defaults.js";
 import {
   createResearchJobPlan,
   createSingleOperationPlan,
@@ -40,6 +41,7 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
           text: true,
         },
       },
+      policy: createDefaultLifecyclePolicy(),
     };
   }
 

--- a/src/providers/exa.ts
+++ b/src/providers/exa.ts
@@ -1,6 +1,10 @@
 import { Exa } from "exa-js";
 import { resolveConfigValue } from "../config.js";
 import { stripLocalExecutionOptions } from "../execution-policy.js";
+import {
+  createResearchJobPlan,
+  createSingleOperationPlan,
+} from "../provider-plans.js";
 import type {
   ExaProviderConfig,
   ProviderContext,
@@ -54,18 +58,13 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
   }
 
   buildPlan(request: ProviderOperationRequest, config: ExaProviderConfig) {
-    const traits = {
-      policyDefaults: config.policy,
-    };
-
     switch (request.capability) {
       case "search":
-        return {
+        return createSingleOperationPlan({
+          config,
           capability: request.capability,
           providerId: this.id,
           providerLabel: this.label,
-          mode: "single" as const,
-          traits,
           execute: (context: ProviderContext) =>
             this.search(
               request.query,
@@ -74,39 +73,42 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
               config,
               context,
             ),
-        };
+        });
       case "contents":
-        return {
+        return createSingleOperationPlan({
+          config,
           capability: request.capability,
           providerId: this.id,
           providerLabel: this.label,
-          mode: "single" as const,
-          traits,
           execute: (context: ProviderContext) =>
             this.contents(request.urls, request.options, config, context),
-        };
+        });
       case "answer":
-        return {
+        return createSingleOperationPlan({
+          config,
           capability: request.capability,
           providerId: this.id,
           providerLabel: this.label,
-          mode: "single" as const,
-          traits,
           execute: (context: ProviderContext) =>
             this.answer(request.query, request.options, config, context),
-        };
+        });
       case "research":
-        return {
+        return createResearchJobPlan({
+          config,
           capability: request.capability,
           providerId: this.id,
           providerLabel: this.label,
-          mode: "job" as const,
-          traits,
+          traits: {
+            researchLifecycle: {
+              supportsStartRetries: false,
+              supportsRequestTimeouts: false,
+            },
+          },
           start: (context: ProviderContext) =>
             this.startResearch(request.input, request.options, config, context),
           poll: (id: string, context: ProviderContext) =>
             this.pollResearch(id, request.options, config, context),
-        };
+        });
       default:
         return null;
     }

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -4,6 +4,8 @@ import type {
   GeminiProviderConfig,
   JsonObject,
   ProviderContext,
+  ProviderResearchJob,
+  ProviderResearchPollResult,
   ProviderStatus,
   ProviderToolOutput,
   SearchResponse,
@@ -14,7 +16,12 @@ const DEFAULT_SEARCH_MODEL = "gemini-2.5-flash";
 const DEFAULT_CONTENTS_MODEL = "gemini-2.5-flash";
 const DEFAULT_ANSWER_MODEL = "gemini-2.5-flash";
 const DEFAULT_RESEARCH_AGENT = "deep-research-pro-preview-12-2025";
-const DEFAULT_POLL_INTERVAL_MS = 3000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 30000;
+const DEFAULT_RETRY_COUNT = 3;
+const DEFAULT_RETRY_DELAY_MS = 2000;
+const DEFAULT_RESEARCH_POLL_INTERVAL_MS = 3000;
+const DEFAULT_RESEARCH_TIMEOUT_MS = 21600000;
+const DEFAULT_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS = 10;
 
 export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
   readonly id = "gemini";
@@ -36,6 +43,13 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
         contentsModel: DEFAULT_CONTENTS_MODEL,
         answerModel: DEFAULT_ANSWER_MODEL,
         researchAgent: DEFAULT_RESEARCH_AGENT,
+        requestTimeoutMs: DEFAULT_REQUEST_TIMEOUT_MS,
+        retryCount: DEFAULT_RETRY_COUNT,
+        retryDelayMs: DEFAULT_RETRY_DELAY_MS,
+        researchPollIntervalMs: DEFAULT_RESEARCH_POLL_INTERVAL_MS,
+        researchTimeoutMs: DEFAULT_RESEARCH_TIMEOUT_MS,
+        researchMaxConsecutivePollErrors:
+          DEFAULT_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS,
       },
     };
   }
@@ -75,7 +89,10 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
       extractGoogleSearchResults(interaction.outputs)
         .slice(0, maxResults)
         .map(async (result) => {
-          const resolvedUrl = await resolveGoogleSearchUrl(result.url);
+          const resolvedUrl = await resolveGoogleSearchUrl(
+            result.url,
+            context.signal,
+          );
           return {
             title: result.title ?? resolvedUrl ?? result.url ?? "Untitled",
             url: resolvedUrl ?? result.url ?? "",
@@ -202,63 +219,60 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
     };
   }
 
-  async research(
+  async startResearch(
     input: string,
-    options: Record<string, unknown> | undefined,
+    options: JsonObject | undefined,
     config: GeminiProviderConfig,
-    context: ProviderContext,
-  ): Promise<ProviderToolOutput> {
+    _context: ProviderContext,
+  ): Promise<ProviderResearchJob> {
     const ai = this.createClient(config);
-    const agent = config.defaults?.researchAgent ?? DEFAULT_RESEARCH_AGENT;
-    const pollIntervalMs = getPollInterval(options);
-    const requestOptions = getGeminiResearchRequestOptions(
-      stripPollIntervalOption(options),
-    );
-    const startedAt = Date.now();
-    let lastStatus: string | undefined;
-
-    context.onProgress?.("Starting Gemini deep research");
-    const initialInteraction = await ai.interactions.create({
+    const requestOptions = getGeminiResearchRequestOptions(options);
+    const interaction = await ai.interactions.create({
       ...requestOptions,
       input,
-      agent,
+      agent: config.defaults?.researchAgent ?? DEFAULT_RESEARCH_AGENT,
       background: true,
     });
 
-    context.onProgress?.(`Gemini research started: ${initialInteraction.id}`);
+    return { id: interaction.id };
+  }
 
-    while (true) {
-      if (context.signal?.aborted) {
-        throw new Error("Gemini research aborted.");
-      }
+  async pollResearch(
+    id: string,
+    _options: JsonObject | undefined,
+    config: GeminiProviderConfig,
+    _context: ProviderContext,
+  ): Promise<ProviderResearchPollResult> {
+    const ai = this.createClient(config);
+    const interaction = await ai.interactions.get(id);
 
-      const interaction = await ai.interactions.get(initialInteraction.id);
-      const now = Date.now();
-      if (interaction.status !== lastStatus) {
-        context.onProgress?.(
-          `Gemini research status: ${interaction.status} (${formatElapsed(now - startedAt)} elapsed)`,
-        );
-        lastStatus = interaction.status;
-      }
-
-      if (interaction.status === "completed") {
-        const text = formatInteractionOutputs(interaction.outputs);
-        return {
+    if (interaction.status === "completed") {
+      const text = formatInteractionOutputs(interaction.outputs);
+      return {
+        status: "completed",
+        output: {
           provider: this.id,
           text: text || "Gemini research completed without textual output.",
           summary: "Research via Gemini",
-        };
-      }
-
-      if (
-        interaction.status === "failed" ||
-        interaction.status === "cancelled"
-      ) {
-        throw new Error(`Gemini research ${interaction.status}.`);
-      }
-
-      await sleep(pollIntervalMs, context.signal);
+        },
+      };
     }
+
+    if (interaction.status === "failed") {
+      return {
+        status: "failed",
+        error: "Gemini research failed.",
+      };
+    }
+
+    if (interaction.status === "cancelled") {
+      return {
+        status: "cancelled",
+        error: "Gemini research cancelled.",
+      };
+    }
+
+    return { status: "in_progress" };
   }
 
   private createClient(config: GeminiProviderConfig): GoogleGenAI {
@@ -541,6 +555,7 @@ function isBuiltInToolChoiceError(error: unknown): boolean {
 
 async function resolveGoogleSearchUrl(
   url: string | undefined,
+  signal: AbortSignal | undefined,
 ): Promise<string | undefined> {
   if (!url) {
     return undefined;
@@ -554,66 +569,12 @@ async function resolveGoogleSearchUrl(
     const response = await fetch(url, {
       method: "HEAD",
       redirect: "manual",
+      signal,
     });
     return response.headers.get("location") || url;
   } catch {
     return url;
   }
-}
-
-async function sleep(
-  ms: number,
-  signal: AbortSignal | undefined,
-): Promise<void> {
-  if (signal?.aborted) {
-    throw new Error("Operation aborted.");
-  }
-
-  await new Promise<void>((resolve, reject) => {
-    const timer = setTimeout(() => {
-      signal?.removeEventListener("abort", onAbort);
-      resolve();
-    }, ms);
-
-    const onAbort = () => {
-      clearTimeout(timer);
-      signal?.removeEventListener("abort", onAbort);
-      reject(new Error("Operation aborted."));
-    };
-
-    signal?.addEventListener("abort", onAbort, { once: true });
-  });
-}
-
-function formatElapsed(ms: number): string {
-  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-
-  if (minutes > 0) {
-    return `${minutes}m ${seconds}s`;
-  }
-
-  return `${totalSeconds}s`;
-}
-
-function getPollInterval(options: Record<string, unknown> | undefined): number {
-  const raw = options?.pollIntervalMs;
-  if (typeof raw === "number" && Number.isFinite(raw) && raw >= 1000) {
-    return Math.trunc(raw);
-  }
-  return DEFAULT_POLL_INTERVAL_MS;
-}
-
-function stripPollIntervalOption(
-  options: Record<string, unknown> | undefined,
-): Record<string, unknown> | undefined {
-  if (!options || !Object.hasOwn(options, "pollIntervalMs")) {
-    return options;
-  }
-
-  const { pollIntervalMs: _ignored, ...rest } = options;
-  return rest;
 }
 
 function buildGeminiSearchRequest(

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -115,6 +115,15 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
           providerId: this.id,
           providerLabel: this.label,
           traits: {
+            executionSupport: {
+              requestTimeoutMs: true,
+              retryCount: true,
+              retryDelayMs: true,
+              pollIntervalMs: true,
+              timeoutMs: true,
+              maxConsecutivePollErrors: true,
+              resumeId: true,
+            },
             researchLifecycle: {
               supportsStartRetries: true,
               supportsRequestTimeouts: true,

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -1,6 +1,10 @@
 import { GoogleGenAI } from "@google/genai";
 import { resolveConfigValue } from "../config.js";
 import {
+  createDefaultLifecyclePolicy,
+  DEFAULT_GEMINI_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS,
+} from "../execution-policy-defaults.js";
+import {
   createResearchJobPlan,
   createSingleOperationPlan,
 } from "../provider-plans.js";
@@ -21,12 +25,6 @@ const DEFAULT_SEARCH_MODEL = "gemini-2.5-flash";
 const DEFAULT_CONTENTS_MODEL = "gemini-2.5-flash";
 const DEFAULT_ANSWER_MODEL = "gemini-2.5-flash";
 const DEFAULT_RESEARCH_AGENT = "deep-research-pro-preview-12-2025";
-const DEFAULT_REQUEST_TIMEOUT_MS = 30000;
-const DEFAULT_RETRY_COUNT = 3;
-const DEFAULT_RETRY_DELAY_MS = 2000;
-const DEFAULT_RESEARCH_POLL_INTERVAL_MS = 3000;
-const DEFAULT_RESEARCH_TIMEOUT_MS = 21600000;
-const DEFAULT_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS = 10;
 
 export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
   readonly id: "gemini" = "gemini";
@@ -50,15 +48,10 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
         answerModel: DEFAULT_ANSWER_MODEL,
         researchAgent: DEFAULT_RESEARCH_AGENT,
       },
-      policy: {
-        requestTimeoutMs: DEFAULT_REQUEST_TIMEOUT_MS,
-        retryCount: DEFAULT_RETRY_COUNT,
-        retryDelayMs: DEFAULT_RETRY_DELAY_MS,
-        researchPollIntervalMs: DEFAULT_RESEARCH_POLL_INTERVAL_MS,
-        researchTimeoutMs: DEFAULT_RESEARCH_TIMEOUT_MS,
+      policy: createDefaultLifecyclePolicy({
         researchMaxConsecutivePollErrors:
-          DEFAULT_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS,
-      },
+          DEFAULT_GEMINI_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS,
+      }),
     };
   }
 

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -4,6 +4,7 @@ import type {
   GeminiProviderConfig,
   JsonObject,
   ProviderContext,
+  ProviderOperationRequest,
   ProviderResearchJob,
   ProviderResearchPollResult,
   ProviderStatus,
@@ -24,11 +25,10 @@ const DEFAULT_RESEARCH_TIMEOUT_MS = 21600000;
 const DEFAULT_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS = 10;
 
 export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
-  readonly id = "gemini";
+  readonly id: "gemini" = "gemini";
   readonly label = "Gemini";
   readonly docsUrl = "https://github.com/googleapis/js-genai";
-  readonly supportsIdempotentResearchStartRetries = true;
-  readonly supportsResearchPollingCancellation = true;
+  readonly capabilities = ["search", "contents", "answer", "research"] as const;
 
   createTemplate(): GeminiProviderConfig {
     return {
@@ -40,11 +40,13 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
         research: true,
       },
       apiKey: "GOOGLE_API_KEY",
-      defaults: {
+      native: {
         searchModel: DEFAULT_SEARCH_MODEL,
         contentsModel: DEFAULT_CONTENTS_MODEL,
         answerModel: DEFAULT_ANSWER_MODEL,
         researchAgent: DEFAULT_RESEARCH_AGENT,
+      },
+      policy: {
         requestTimeoutMs: DEFAULT_REQUEST_TIMEOUT_MS,
         retryCount: DEFAULT_RETRY_COUNT,
         retryDelayMs: DEFAULT_RETRY_DELAY_MS,
@@ -70,6 +72,69 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
     return { available: true, summary: "enabled" };
   }
 
+  buildPlan(request: ProviderOperationRequest, config: GeminiProviderConfig) {
+    const traits = {
+      policyDefaults: getGeminiExecutionPolicyDefaults(config),
+    };
+
+    switch (request.capability) {
+      case "search":
+        return {
+          capability: request.capability,
+          providerId: this.id,
+          providerLabel: this.label,
+          mode: "single" as const,
+          traits,
+          execute: (context: ProviderContext) =>
+            this.search(
+              request.query,
+              request.maxResults,
+              request.options,
+              config,
+              context,
+            ),
+        };
+      case "contents":
+        return {
+          capability: request.capability,
+          providerId: this.id,
+          providerLabel: this.label,
+          mode: "single" as const,
+          traits,
+          execute: (context: ProviderContext) =>
+            this.contents(request.urls, request.options, config, context),
+        };
+      case "answer":
+        return {
+          capability: request.capability,
+          providerId: this.id,
+          providerLabel: this.label,
+          mode: "single" as const,
+          traits,
+          execute: (context: ProviderContext) =>
+            this.answer(request.query, request.options, config, context),
+        };
+      case "research":
+        return {
+          capability: request.capability,
+          providerId: this.id,
+          providerLabel: this.label,
+          mode: "job" as const,
+          traits: {
+            ...traits,
+            supportsIdempotentStartRetries: true,
+            supportsPollCancellation: true,
+          },
+          start: (context: ProviderContext) =>
+            this.startResearch(request.input, request.options, config, context),
+          poll: (id: string, context: ProviderContext) =>
+            this.pollResearch(id, request.options, config, context),
+        };
+      default:
+        return null;
+    }
+  }
+
   async search(
     query: string,
     maxResults: number,
@@ -78,9 +143,10 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
     context: ProviderContext,
   ): Promise<SearchResponse> {
     const ai = this.createClient(config);
+    const native = getGeminiNativeConfig(config);
     const request = buildGeminiSearchRequest(
       query,
-      config.defaults?.searchModel ?? DEFAULT_SEARCH_MODEL,
+      native?.searchModel ?? DEFAULT_SEARCH_MODEL,
       options,
     );
 
@@ -126,8 +192,9 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
     );
 
     const urlList = urls.map((url) => `- ${url}`).join("\n");
+    const native = getGeminiNativeConfig(config);
     const request = buildGeminiGenerateContentRequest({
-      defaultModel: config.defaults?.contentsModel ?? DEFAULT_CONTENTS_MODEL,
+      defaultModel: native?.contentsModel ?? DEFAULT_CONTENTS_MODEL,
       prompt:
         `Extract the main textual content from each of the following URLs. ` +
         `For each URL, return the page title followed by the cleaned body text. ` +
@@ -186,8 +253,9 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
     context: ProviderContext,
   ): Promise<ProviderToolOutput> {
     const ai = this.createClient(config);
+    const native = getGeminiNativeConfig(config);
     const request = buildGeminiGenerateContentRequest({
-      defaultModel: config.defaults?.answerModel ?? DEFAULT_ANSWER_MODEL,
+      defaultModel: native?.answerModel ?? DEFAULT_ANSWER_MODEL,
       prompt: query,
       options,
       toolConfig: { googleSearch: {} },
@@ -237,7 +305,9 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
       {
         ...requestOptions,
         input,
-        agent: config.defaults?.researchAgent ?? DEFAULT_RESEARCH_AGENT,
+        agent:
+          getGeminiNativeConfig(config)?.researchAgent ??
+          DEFAULT_RESEARCH_AGENT,
         background: true,
       },
       buildGeminiRequestOptions(context.signal, context.idempotencyKey),
@@ -296,7 +366,7 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
 
     return new GoogleGenAI({
       apiKey,
-      apiVersion: config.defaults?.apiVersion,
+      apiVersion: getGeminiNativeConfig(config)?.apiVersion,
     });
   }
 }
@@ -698,6 +768,26 @@ function stripToolChoice(
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getGeminiNativeConfig(config: GeminiProviderConfig) {
+  return config.native ?? config.defaults;
+}
+
+function getGeminiExecutionPolicyDefaults(config: GeminiProviderConfig) {
+  if (config.policy) {
+    return config.policy;
+  }
+
+  return {
+    requestTimeoutMs: config.defaults?.requestTimeoutMs,
+    retryCount: config.defaults?.retryCount,
+    retryDelayMs: config.defaults?.retryDelayMs,
+    researchPollIntervalMs: config.defaults?.researchPollIntervalMs,
+    researchTimeoutMs: config.defaults?.researchTimeoutMs,
+    researchMaxConsecutivePollErrors:
+      config.defaults?.researchMaxConsecutivePollErrors,
+  };
 }
 
 function readNonEmptyString(value: unknown): string | undefined {

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -1,5 +1,9 @@
 import { GoogleGenAI } from "@google/genai";
 import { resolveConfigValue } from "../config.js";
+import {
+  createResearchJobPlan,
+  createSingleOperationPlan,
+} from "../provider-plans.js";
 import type {
   GeminiProviderConfig,
   JsonObject,
@@ -73,18 +77,17 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
   }
 
   buildPlan(request: ProviderOperationRequest, config: GeminiProviderConfig) {
-    const traits = {
-      policyDefaults: getGeminiExecutionPolicyDefaults(config),
+    const planConfig = {
+      policy: getGeminiExecutionPolicyDefaults(config),
     };
 
     switch (request.capability) {
       case "search":
-        return {
+        return createSingleOperationPlan({
+          config: planConfig,
           capability: request.capability,
           providerId: this.id,
           providerLabel: this.label,
-          mode: "single" as const,
-          traits,
           execute: (context: ProviderContext) =>
             this.search(
               request.query,
@@ -93,43 +96,42 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
               config,
               context,
             ),
-        };
+        });
       case "contents":
-        return {
+        return createSingleOperationPlan({
+          config: planConfig,
           capability: request.capability,
           providerId: this.id,
           providerLabel: this.label,
-          mode: "single" as const,
-          traits,
           execute: (context: ProviderContext) =>
             this.contents(request.urls, request.options, config, context),
-        };
+        });
       case "answer":
-        return {
+        return createSingleOperationPlan({
+          config: planConfig,
           capability: request.capability,
           providerId: this.id,
           providerLabel: this.label,
-          mode: "single" as const,
-          traits,
           execute: (context: ProviderContext) =>
             this.answer(request.query, request.options, config, context),
-        };
+        });
       case "research":
-        return {
+        return createResearchJobPlan({
+          config: planConfig,
           capability: request.capability,
           providerId: this.id,
           providerLabel: this.label,
-          mode: "job" as const,
           traits: {
-            ...traits,
-            supportsIdempotentStartRetries: true,
-            supportsPollCancellation: true,
+            researchLifecycle: {
+              supportsStartRetries: true,
+              supportsRequestTimeouts: true,
+            },
           },
           start: (context: ProviderContext) =>
             this.startResearch(request.input, request.options, config, context),
           poll: (id: string, context: ProviderContext) =>
             this.pollResearch(id, request.options, config, context),
-        };
+        });
       default:
         return null;
     }

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -27,6 +27,8 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
   readonly id = "gemini";
   readonly label = "Gemini";
   readonly docsUrl = "https://github.com/googleapis/js-genai";
+  readonly supportsIdempotentResearchStartRetries = true;
+  readonly supportsResearchPollingCancellation = true;
 
   createTemplate(): GeminiProviderConfig {
     return {

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -238,7 +238,7 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
         agent: config.defaults?.researchAgent ?? DEFAULT_RESEARCH_AGENT,
         background: true,
       },
-      buildGeminiRequestOptions(context.signal),
+      buildGeminiRequestOptions(context.signal, context.idempotencyKey),
     );
 
     return { id: interaction.id };
@@ -299,8 +299,18 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
   }
 }
 
-function buildGeminiRequestOptions(signal: AbortSignal | undefined) {
-  return signal ? { signal } : undefined;
+function buildGeminiRequestOptions(
+  signal: AbortSignal | undefined,
+  idempotencyKey?: string,
+) {
+  if (!signal && !idempotencyKey) {
+    return undefined;
+  }
+
+  return {
+    ...(signal ? { signal } : {}),
+    ...(idempotencyKey ? { idempotencyKey } : {}),
+  };
 }
 
 function addAbortSignalToGeminiConfig(

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -5,8 +5,8 @@ import {
   DEFAULT_GEMINI_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS,
 } from "../execution-policy-defaults.js";
 import {
-  createResearchJobPlan,
-  createSingleOperationPlan,
+  createBackgroundResearchPlan,
+  createSilentForegroundPlan,
 } from "../provider-plans.js";
 import type {
   GeminiProviderConfig,
@@ -76,7 +76,7 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
 
     switch (request.capability) {
       case "search":
-        return createSingleOperationPlan({
+        return createSilentForegroundPlan({
           config: planConfig,
           capability: request.capability,
           providerId: this.id,
@@ -91,7 +91,7 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
             ),
         });
       case "contents":
-        return createSingleOperationPlan({
+        return createSilentForegroundPlan({
           config: planConfig,
           capability: request.capability,
           providerId: this.id,
@@ -100,7 +100,7 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
             this.contents(request.urls, request.options, config, context),
         });
       case "answer":
-        return createSingleOperationPlan({
+        return createSilentForegroundPlan({
           config: planConfig,
           capability: request.capability,
           providerId: this.id,
@@ -109,7 +109,7 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
             this.answer(request.query, request.options, config, context),
         });
       case "research":
-        return createResearchJobPlan({
+        return createBackgroundResearchPlan({
           config: planConfig,
           capability: request.capability,
           providerId: this.id,

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -83,7 +83,11 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
     );
 
     context.onProgress?.(`Searching Gemini for: ${query}`);
-    const interaction = await createSearchInteraction(ai, request);
+    const interaction = await createSearchInteraction(
+      ai,
+      request,
+      context.signal,
+    );
 
     const results = await Promise.all(
       extractGoogleSearchResults(interaction.outputs)
@@ -133,7 +137,7 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
     const response = await ai.models.generateContent({
       model: request.model,
       contents: [request.contents],
-      config: request.config,
+      config: addAbortSignalToGeminiConfig(request.config, context.signal),
     });
 
     const text = response.text?.trim() || "";
@@ -191,7 +195,7 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
     const response = await ai.models.generateContent({
       model: request.model,
       contents: request.contents,
-      config: request.config,
+      config: addAbortSignalToGeminiConfig(request.config, context.signal),
     });
 
     const lines: string[] = [];
@@ -223,16 +227,19 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
     input: string,
     options: JsonObject | undefined,
     config: GeminiProviderConfig,
-    _context: ProviderContext,
+    context: ProviderContext,
   ): Promise<ProviderResearchJob> {
     const ai = this.createClient(config);
     const requestOptions = getGeminiResearchRequestOptions(options);
-    const interaction = await ai.interactions.create({
-      ...requestOptions,
-      input,
-      agent: config.defaults?.researchAgent ?? DEFAULT_RESEARCH_AGENT,
-      background: true,
-    });
+    const interaction = await ai.interactions.create(
+      {
+        ...requestOptions,
+        input,
+        agent: config.defaults?.researchAgent ?? DEFAULT_RESEARCH_AGENT,
+        background: true,
+      },
+      buildGeminiRequestOptions(context.signal),
+    );
 
     return { id: interaction.id };
   }
@@ -241,10 +248,14 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
     id: string,
     _options: JsonObject | undefined,
     config: GeminiProviderConfig,
-    _context: ProviderContext,
+    context: ProviderContext,
   ): Promise<ProviderResearchPollResult> {
     const ai = this.createClient(config);
-    const interaction = await ai.interactions.get(id);
+    const interaction = await ai.interactions.get(
+      id,
+      undefined,
+      buildGeminiRequestOptions(context.signal),
+    );
 
     if (interaction.status === "completed") {
       const text = formatInteractionOutputs(interaction.outputs);
@@ -286,6 +297,24 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
       apiVersion: config.defaults?.apiVersion,
     });
   }
+}
+
+function buildGeminiRequestOptions(signal: AbortSignal | undefined) {
+  return signal ? { signal } : undefined;
+}
+
+function addAbortSignalToGeminiConfig(
+  config: Record<string, unknown> | undefined,
+  signal: AbortSignal | undefined,
+): Record<string, unknown> | undefined {
+  if (!signal) {
+    return config;
+  }
+
+  return {
+    ...(config ?? {}),
+    abortSignal: signal,
+  };
 }
 
 function extractGoogleSearchResults(
@@ -498,6 +527,7 @@ async function createSearchInteraction(
     tools: Array<{ type: "google_search" }>;
     generation_config?: Record<string, unknown>;
   },
+  signal: AbortSignal | undefined,
 ) {
   const forcedRequest = {
     ...request,
@@ -516,19 +546,25 @@ async function createSearchInteraction(
   };
 
   try {
-    return await ai.interactions.create(forcedRequest);
+    return await ai.interactions.create(
+      forcedRequest,
+      buildGeminiRequestOptions(signal),
+    );
   } catch (error) {
     if (!isBuiltInToolChoiceError(error)) {
       throw error;
     }
 
     const fallbackGenerationConfig = stripToolChoice(request.generation_config);
-    return ai.interactions.create({
-      ...request,
-      ...(fallbackGenerationConfig
-        ? { generation_config: fallbackGenerationConfig }
-        : {}),
-    });
+    return ai.interactions.create(
+      {
+        ...request,
+        ...(fallbackGenerationConfig
+          ? { generation_config: fallbackGenerationConfig }
+          : {}),
+      },
+      buildGeminiRequestOptions(signal),
+    );
   }
 }
 

--- a/src/providers/parallel.ts
+++ b/src/providers/parallel.ts
@@ -2,7 +2,7 @@ import Parallel from "parallel-web";
 import { resolveConfigValue } from "../config.js";
 import { stripLocalExecutionOptions } from "../execution-policy.js";
 import { createDefaultRequestPolicy } from "../execution-policy-defaults.js";
-import { createSingleOperationPlan } from "../provider-plans.js";
+import { createSilentForegroundPlan } from "../provider-plans.js";
 import type {
   ParallelProviderConfig,
   ProviderContext,
@@ -58,7 +58,7 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
   buildPlan(request: ProviderOperationRequest, config: ParallelProviderConfig) {
     switch (request.capability) {
       case "search":
-        return createSingleOperationPlan({
+        return createSilentForegroundPlan({
           config,
           capability: request.capability,
           providerId: this.id,
@@ -73,7 +73,7 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
             ),
         });
       case "contents":
-        return createSingleOperationPlan({
+        return createSilentForegroundPlan({
           config,
           capability: request.capability,
           providerId: this.id,

--- a/src/providers/parallel.ts
+++ b/src/providers/parallel.ts
@@ -1,8 +1,10 @@
 import Parallel from "parallel-web";
 import { resolveConfigValue } from "../config.js";
+import { stripLocalExecutionOptions } from "../execution-policy.js";
 import type {
   ParallelProviderConfig,
   ProviderContext,
+  ProviderOperationRequest,
   ProviderStatus,
   ProviderToolOutput,
   SearchResponse,
@@ -11,9 +13,10 @@ import type {
 import { asJsonObject, trimSnippet } from "./shared.js";
 
 export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
-  readonly id = "parallel";
+  readonly id: "parallel" = "parallel";
   readonly label = "Parallel";
   readonly docsUrl = "https://github.com/parallel-web/parallel-sdk-typescript";
+  readonly capabilities = ["search", "contents"] as const;
 
   createTemplate(): ParallelProviderConfig {
     return {
@@ -23,7 +26,7 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
         contents: true,
       },
       apiKey: "PARALLEL_API_KEY",
-      defaults: {
+      native: {
         search: {
           mode: "agentic",
         },
@@ -49,6 +52,43 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
     return { available: true, summary: "enabled" };
   }
 
+  buildPlan(request: ProviderOperationRequest, config: ParallelProviderConfig) {
+    switch (request.capability) {
+      case "search":
+        return {
+          capability: request.capability,
+          providerId: this.id,
+          providerLabel: this.label,
+          mode: "single" as const,
+          traits: {
+            policyDefaults: config.policy,
+          },
+          execute: (context: ProviderContext) =>
+            this.search(
+              request.query,
+              request.maxResults,
+              request.options,
+              config,
+              context,
+            ),
+        };
+      case "contents":
+        return {
+          capability: request.capability,
+          providerId: this.id,
+          providerLabel: this.label,
+          mode: "single" as const,
+          traits: {
+            policyDefaults: config.policy,
+          },
+          execute: (context: ProviderContext) =>
+            this.contents(request.urls, request.options, config, context),
+        };
+      default:
+        return null;
+    }
+  }
+
   async search(
     query: string,
     maxResults: number,
@@ -57,7 +97,9 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
     context: ProviderContext,
   ): Promise<SearchResponse> {
     const client = this.createClient(config);
-    const defaults = asJsonObject(config.defaults?.search);
+    const native = config.native ?? config.defaults;
+    const defaults =
+      stripLocalExecutionOptions(asJsonObject(native?.search)) ?? {};
 
     context.onProgress?.(`Searching Parallel for: ${query}`);
     const response = await client.beta.search(
@@ -87,7 +129,9 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
     context: ProviderContext,
   ): Promise<ProviderToolOutput> {
     const client = this.createClient(config);
-    const defaults = asJsonObject(config.defaults?.extract);
+    const native = config.native ?? config.defaults;
+    const defaults =
+      stripLocalExecutionOptions(asJsonObject(native?.extract)) ?? {};
 
     context.onProgress?.(
       `Fetching contents from Parallel for ${urls.length} URL(s)`,

--- a/src/providers/parallel.ts
+++ b/src/providers/parallel.ts
@@ -1,6 +1,7 @@
 import Parallel from "parallel-web";
 import { resolveConfigValue } from "../config.js";
 import { stripLocalExecutionOptions } from "../execution-policy.js";
+import { createSingleOperationPlan } from "../provider-plans.js";
 import type {
   ParallelProviderConfig,
   ProviderContext,
@@ -55,14 +56,11 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
   buildPlan(request: ProviderOperationRequest, config: ParallelProviderConfig) {
     switch (request.capability) {
       case "search":
-        return {
+        return createSingleOperationPlan({
+          config,
           capability: request.capability,
           providerId: this.id,
           providerLabel: this.label,
-          mode: "single" as const,
-          traits: {
-            policyDefaults: config.policy,
-          },
           execute: (context: ProviderContext) =>
             this.search(
               request.query,
@@ -71,19 +69,16 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
               config,
               context,
             ),
-        };
+        });
       case "contents":
-        return {
+        return createSingleOperationPlan({
+          config,
           capability: request.capability,
           providerId: this.id,
           providerLabel: this.label,
-          mode: "single" as const,
-          traits: {
-            policyDefaults: config.policy,
-          },
           execute: (context: ProviderContext) =>
             this.contents(request.urls, request.options, config, context),
-        };
+        });
       default:
         return null;
     }

--- a/src/providers/parallel.ts
+++ b/src/providers/parallel.ts
@@ -1,6 +1,7 @@
 import Parallel from "parallel-web";
 import { resolveConfigValue } from "../config.js";
 import { stripLocalExecutionOptions } from "../execution-policy.js";
+import { createDefaultRequestPolicy } from "../execution-policy-defaults.js";
 import { createSingleOperationPlan } from "../provider-plans.js";
 import type {
   ParallelProviderConfig,
@@ -36,6 +37,7 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
           full_content: false,
         },
       },
+      policy: createDefaultRequestPolicy(),
     };
   }
 

--- a/src/providers/parallel.ts
+++ b/src/providers/parallel.ts
@@ -1,4 +1,5 @@
 import Parallel from "parallel-web";
+import { resolveConfigValue } from "../config.js";
 import type {
   ParallelProviderConfig,
   ProviderContext,
@@ -7,7 +8,6 @@ import type {
   SearchResponse,
   WebProvider,
 } from "../types.js";
-import { resolveConfigValue } from "../config.js";
 import { asJsonObject, trimSnippet } from "./shared.js";
 
 export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
@@ -60,12 +60,15 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
     const defaults = asJsonObject(config.defaults?.search);
 
     context.onProgress?.(`Searching Parallel for: ${query}`);
-    const response = await client.beta.search({
-      ...defaults,
-      ...(options ?? {}),
-      objective: query,
-      max_results: maxResults,
-    });
+    const response = await client.beta.search(
+      {
+        ...defaults,
+        ...(options ?? {}),
+        objective: query,
+        max_results: maxResults,
+      },
+      buildRequestOptions(context),
+    );
 
     return {
       provider: this.id,
@@ -89,11 +92,14 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
     context.onProgress?.(
       `Fetching contents from Parallel for ${urls.length} URL(s)`,
     );
-    const response = await client.beta.extract({
-      ...defaults,
-      ...(options ?? {}),
-      urls,
-    });
+    const response = await client.beta.extract(
+      {
+        ...defaults,
+        ...(options ?? {}),
+        urls,
+      },
+      buildRequestOptions(context),
+    );
 
     const lines: string[] = [];
     for (const [index, result] of response.results.entries()) {
@@ -137,4 +143,10 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
       baseURL: resolveConfigValue(config.baseUrl),
     });
   }
+}
+
+function buildRequestOptions(
+  context: ProviderContext,
+): { signal: AbortSignal } | undefined {
+  return context.signal ? { signal: context.signal } : undefined;
 }

--- a/src/providers/perplexity.ts
+++ b/src/providers/perplexity.ts
@@ -2,7 +2,10 @@ import Perplexity from "@perplexity-ai/perplexity_ai";
 import { resolveConfigValue } from "../config.js";
 import { stripLocalExecutionOptions } from "../execution-policy.js";
 import { createDefaultRequestPolicy } from "../execution-policy-defaults.js";
-import { createSingleOperationPlan } from "../provider-plans.js";
+import {
+  createSilentForegroundPlan,
+  createStreamingForegroundPlan,
+} from "../provider-plans.js";
 import type {
   PerplexityProviderConfig,
   ProviderContext,
@@ -16,6 +19,18 @@ import { asJsonObject, trimSnippet } from "./shared.js";
 
 const DEFAULT_ANSWER_MODEL = "sonar";
 const DEFAULT_RESEARCH_MODEL = "sonar-deep-research";
+
+type PerplexityForegroundChunk = {
+  choices: Array<{
+    message?: { content?: unknown };
+    delta?: { content?: unknown };
+  }>;
+  search_results?: Array<{
+    title?: string | null;
+    url?: string | null;
+  }> | null;
+  citations?: Array<string | null> | null;
+};
 
 export class PerplexityProvider
   implements WebProvider<PerplexityProviderConfig>
@@ -66,7 +81,7 @@ export class PerplexityProvider
   ) {
     switch (request.capability) {
       case "search":
-        return createSingleOperationPlan({
+        return createSilentForegroundPlan({
           config,
           capability: request.capability,
           providerId: this.id,
@@ -81,7 +96,7 @@ export class PerplexityProvider
             ),
         });
       case "answer":
-        return createSingleOperationPlan({
+        return createSilentForegroundPlan({
           config,
           capability: request.capability,
           providerId: this.id,
@@ -90,7 +105,7 @@ export class PerplexityProvider
             this.answer(request.query, request.options, config, context),
         });
       case "research":
-        return createSingleOperationPlan({
+        return createStreamingForegroundPlan({
           config,
           capability: request.capability,
           providerId: this.id,
@@ -151,7 +166,7 @@ export class PerplexityProvider
     context: ProviderContext,
   ): Promise<ProviderToolOutput> {
     context.onProgress?.(`Getting Perplexity answer for: ${query}`);
-    return this.runChatTool(
+    return this.runSilentForegroundChatTool(
       query,
       options,
       config,
@@ -167,21 +182,18 @@ export class PerplexityProvider
     config: PerplexityProviderConfig,
     context: ProviderContext,
   ): Promise<ProviderToolOutput> {
-    // This remains a provider-specific blocking bypass until the Perplexity SDK
-    // exposes a resumable start/poll research lifecycle.
     context.onProgress?.("Starting Perplexity research");
-    return this.runChatTool(
+    return this.runStreamingForegroundChatTool(
       input,
       options,
       config,
       context,
       DEFAULT_RESEARCH_MODEL,
       "Research",
-      true,
     );
   }
 
-  private async runChatTool(
+  private async runSilentForegroundChatTool(
     input: string,
     options: Record<string, unknown> | undefined,
     config: PerplexityProviderConfig,
@@ -232,6 +244,74 @@ export class PerplexityProvider
       text: lines.join("\n").trimEnd(),
       summary: `${label} via Perplexity with ${sources.length} source(s)`,
       itemCount: sources.length,
+    };
+  }
+
+  // Perplexity deep research currently fits streaming foreground mode: pi can
+  // surface incremental text while the request is active, but there is no
+  // durable job id to resume later.
+  private async runStreamingForegroundChatTool(
+    input: string,
+    options: Record<string, unknown> | undefined,
+    config: PerplexityProviderConfig,
+    context: ProviderContext,
+    fallbackModel: string,
+    label: "Answer" | "Research",
+  ): Promise<ProviderToolOutput> {
+    const client = this.createClient(config);
+    const native = config.native ?? config.defaults;
+    const defaults =
+      stripLocalExecutionOptions(asJsonObject(native?.research)) ?? {};
+    const request = {
+      ...defaults,
+      ...(options ?? {}),
+      messages: [{ role: "user", content: input }],
+      model:
+        resolveModel((options ?? {}).model, defaults.model, fallbackModel) ??
+        fallbackModel,
+      stream: true as const,
+    };
+
+    const stream = (await client.chat.completions.create(
+      request as never,
+      buildRequestOptions(context),
+    )) as unknown as AsyncIterable<PerplexityForegroundChunk>;
+
+    let partialText = "";
+    let lastChunk: PerplexityForegroundChunk | undefined;
+    const sources: Array<{ title: string; url: string }> = [];
+
+    for await (const chunk of stream) {
+      lastChunk = chunk;
+      const deltaText = extractDeltaText(chunk.choices[0]?.delta?.content);
+      if (deltaText) {
+        partialText = `${partialText}${deltaText}`;
+        context.onProgress?.(partialText.trim());
+      }
+      sources.push(...extractSources(chunk));
+    }
+
+    const finalText =
+      partialText.trim() ||
+      extractMessageText(lastChunk?.choices?.[0]?.message?.content) ||
+      `No ${label.toLowerCase()} returned.`;
+    const dedupedSources = dedupeSources(sources);
+    const lines: string[] = [finalText];
+
+    if (dedupedSources.length > 0) {
+      lines.push("");
+      lines.push("Sources:");
+      for (const [index, source] of dedupedSources.entries()) {
+        lines.push(`${index + 1}. ${source.title}`);
+        lines.push(`   ${source.url}`);
+      }
+    }
+
+    return {
+      provider: this.id,
+      text: lines.join("\n").trimEnd(),
+      summary: `${label} via Perplexity with ${dedupedSources.length} source(s)`,
+      itemCount: dedupedSources.length,
     };
   }
 
@@ -290,6 +370,32 @@ function extractMessageText(content: unknown): string {
     .trim();
 }
 
+function extractDeltaText(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  return content
+    .flatMap((chunk) => {
+      if (
+        typeof chunk === "object" &&
+        chunk !== null &&
+        "type" in chunk &&
+        chunk.type === "text" &&
+        "text" in chunk &&
+        typeof chunk.text === "string"
+      ) {
+        return [chunk.text];
+      }
+      return [];
+    })
+    .join("");
+}
+
 function dedupeSources(
   sources: Array<{ title: string; url: string }>,
 ): Array<{ title: string; url: string }> {
@@ -310,10 +416,9 @@ function dedupeSources(
   return unique;
 }
 
-function extractSources(response: {
-  search_results?: Array<{ title?: string | null; url?: string | null }> | null;
-  citations?: Array<string | null> | null;
-}): Array<{ title: string; url: string }> {
+function extractSources(
+  response: Pick<PerplexityForegroundChunk, "search_results" | "citations">,
+): Array<{ title: string; url: string }> {
   const searchResults =
     response.search_results?.flatMap((result) => {
       const url = result.url?.trim() ?? "";

--- a/src/providers/perplexity.ts
+++ b/src/providers/perplexity.ts
@@ -117,6 +117,8 @@ export class PerplexityProvider
     config: PerplexityProviderConfig,
     context: ProviderContext,
   ): Promise<ProviderToolOutput> {
+    // This remains a provider-specific blocking bypass until the Perplexity SDK
+    // exposes a resumable start/poll research lifecycle.
     context.onProgress?.("Starting Perplexity research");
     return this.runChatTool(
       input,

--- a/src/providers/perplexity.ts
+++ b/src/providers/perplexity.ts
@@ -110,6 +110,17 @@ export class PerplexityProvider
           capability: request.capability,
           providerId: this.id,
           providerLabel: this.label,
+          traits: {
+            executionSupport: {
+              requestTimeoutMs: true,
+              retryCount: true,
+              retryDelayMs: true,
+              pollIntervalMs: false,
+              timeoutMs: false,
+              maxConsecutivePollErrors: false,
+              resumeId: false,
+            },
+          },
           execute: (context: ProviderContext) =>
             this.research(request.input, request.options, config, context),
         });

--- a/src/providers/perplexity.ts
+++ b/src/providers/perplexity.ts
@@ -1,8 +1,10 @@
 import Perplexity from "@perplexity-ai/perplexity_ai";
 import { resolveConfigValue } from "../config.js";
+import { stripLocalExecutionOptions } from "../execution-policy.js";
 import type {
   PerplexityProviderConfig,
   ProviderContext,
+  ProviderOperationRequest,
   ProviderStatus,
   ProviderToolOutput,
   SearchResponse,
@@ -16,9 +18,10 @@ const DEFAULT_RESEARCH_MODEL = "sonar-deep-research";
 export class PerplexityProvider
   implements WebProvider<PerplexityProviderConfig>
 {
-  readonly id = "perplexity";
+  readonly id: "perplexity" = "perplexity";
   readonly label = "Perplexity";
   readonly docsUrl = "https://docs.perplexity.ai/docs/sdk/overview.md";
+  readonly capabilities = ["search", "answer", "research"] as const;
 
   createTemplate(): PerplexityProviderConfig {
     return {
@@ -29,7 +32,7 @@ export class PerplexityProvider
         research: true,
       },
       apiKey: "PERPLEXITY_API_KEY",
-      defaults: {
+      native: {
         answer: {
           model: DEFAULT_ANSWER_MODEL,
         },
@@ -54,6 +57,58 @@ export class PerplexityProvider
     return { available: true, summary: "enabled" };
   }
 
+  buildPlan(
+    request: ProviderOperationRequest,
+    config: PerplexityProviderConfig,
+  ) {
+    switch (request.capability) {
+      case "search":
+        return {
+          capability: request.capability,
+          providerId: this.id,
+          providerLabel: this.label,
+          mode: "single" as const,
+          traits: {
+            policyDefaults: config.policy,
+          },
+          execute: (context: ProviderContext) =>
+            this.search(
+              request.query,
+              request.maxResults,
+              request.options,
+              config,
+              context,
+            ),
+        };
+      case "answer":
+        return {
+          capability: request.capability,
+          providerId: this.id,
+          providerLabel: this.label,
+          mode: "single" as const,
+          traits: {
+            policyDefaults: config.policy,
+          },
+          execute: (context: ProviderContext) =>
+            this.answer(request.query, request.options, config, context),
+        };
+      case "research":
+        return {
+          capability: request.capability,
+          providerId: this.id,
+          providerLabel: this.label,
+          mode: "single" as const,
+          traits: {
+            policyDefaults: config.policy,
+          },
+          execute: (context: ProviderContext) =>
+            this.research(request.input, request.options, config, context),
+        };
+      default:
+        return null;
+    }
+  }
+
   async search(
     query: string,
     maxResults: number,
@@ -62,8 +117,9 @@ export class PerplexityProvider
     context: ProviderContext,
   ): Promise<SearchResponse> {
     const client = this.createClient(config);
+    const native = config.native ?? config.defaults;
     const request = {
-      ...asJsonObject(config.defaults?.search),
+      ...(stripLocalExecutionOptions(asJsonObject(native?.search)) ?? {}),
       ...(options ?? {}),
       query,
       max_results: maxResults,
@@ -141,19 +197,20 @@ export class PerplexityProvider
     isResearch = false,
   ): Promise<ProviderToolOutput> {
     const client = this.createClient(config);
-    const defaults = isResearch
-      ? config.defaults?.research
-      : config.defaults?.answer;
+    const native = config.native ?? config.defaults;
+    const defaults =
+      stripLocalExecutionOptions(
+        isResearch
+          ? asJsonObject(native?.research)
+          : asJsonObject(native?.answer),
+      ) ?? {};
     const request = {
-      ...asJsonObject(defaults),
+      ...defaults,
       ...(options ?? {}),
       messages: [{ role: "user", content: input }],
       model:
-        resolveModel(
-          (options ?? {}).model,
-          asJsonObject(defaults).model,
-          fallbackModel,
-        ) ?? fallbackModel,
+        resolveModel((options ?? {}).model, defaults.model, fallbackModel) ??
+        fallbackModel,
       stream: false,
     };
 

--- a/src/providers/perplexity.ts
+++ b/src/providers/perplexity.ts
@@ -1,6 +1,7 @@
 import Perplexity from "@perplexity-ai/perplexity_ai";
 import { resolveConfigValue } from "../config.js";
 import { stripLocalExecutionOptions } from "../execution-policy.js";
+import { createDefaultRequestPolicy } from "../execution-policy-defaults.js";
 import { createSingleOperationPlan } from "../provider-plans.js";
 import type {
   PerplexityProviderConfig,
@@ -41,6 +42,7 @@ export class PerplexityProvider
           model: DEFAULT_RESEARCH_MODEL,
         },
       },
+      policy: createDefaultRequestPolicy(),
     };
   }
 

--- a/src/providers/perplexity.ts
+++ b/src/providers/perplexity.ts
@@ -1,6 +1,7 @@
 import Perplexity from "@perplexity-ai/perplexity_ai";
 import { resolveConfigValue } from "../config.js";
 import { stripLocalExecutionOptions } from "../execution-policy.js";
+import { createSingleOperationPlan } from "../provider-plans.js";
 import type {
   PerplexityProviderConfig,
   ProviderContext,
@@ -63,14 +64,11 @@ export class PerplexityProvider
   ) {
     switch (request.capability) {
       case "search":
-        return {
+        return createSingleOperationPlan({
+          config,
           capability: request.capability,
           providerId: this.id,
           providerLabel: this.label,
-          mode: "single" as const,
-          traits: {
-            policyDefaults: config.policy,
-          },
           execute: (context: ProviderContext) =>
             this.search(
               request.query,
@@ -79,31 +77,25 @@ export class PerplexityProvider
               config,
               context,
             ),
-        };
+        });
       case "answer":
-        return {
+        return createSingleOperationPlan({
+          config,
           capability: request.capability,
           providerId: this.id,
           providerLabel: this.label,
-          mode: "single" as const,
-          traits: {
-            policyDefaults: config.policy,
-          },
           execute: (context: ProviderContext) =>
             this.answer(request.query, request.options, config, context),
-        };
+        });
       case "research":
-        return {
+        return createSingleOperationPlan({
+          config,
           capability: request.capability,
           providerId: this.id,
           providerLabel: this.label,
-          mode: "single" as const,
-          traits: {
-            policyDefaults: config.policy,
-          },
           execute: (context: ProviderContext) =>
             this.research(request.input, request.options, config, context),
-        };
+        });
       default:
         return null;
     }

--- a/src/providers/valyu.ts
+++ b/src/providers/valyu.ts
@@ -1,6 +1,7 @@
 import { Valyu } from "valyu-js";
 import { resolveConfigValue } from "../config.js";
 import { stripLocalExecutionOptions } from "../execution-policy.js";
+import { createDefaultLifecyclePolicy } from "../execution-policy-defaults.js";
 import {
   createResearchJobPlan,
   createSingleOperationPlan,
@@ -38,6 +39,7 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
         searchType: "all",
         responseLength: "short",
       },
+      policy: createDefaultLifecyclePolicy(),
     };
   }
 

--- a/src/providers/valyu.ts
+++ b/src/providers/valyu.ts
@@ -1,7 +1,9 @@
 import { Valyu } from "valyu-js";
 import { resolveConfigValue } from "../config.js";
+import { stripLocalExecutionOptions } from "../execution-policy.js";
 import type {
   ProviderContext,
+  ProviderOperationRequest,
   ProviderResearchJob,
   ProviderResearchPollResult,
   ProviderStatus,
@@ -13,9 +15,10 @@ import type {
 import { asJsonObject, formatJson, trimSnippet } from "./shared.js";
 
 export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
-  readonly id = "valyu";
+  readonly id: "valyu" = "valyu";
   readonly label = "Valyu";
   readonly docsUrl = "https://docs.valyu.ai/sdk/typescript-sdk";
+  readonly capabilities = ["search", "contents", "answer", "research"] as const;
 
   createTemplate(): ValyuProviderConfig {
     return {
@@ -27,7 +30,7 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
         research: true,
       },
       apiKey: "VALYU_API_KEY",
-      defaults: {
+      native: {
         searchType: "all",
         responseLength: "short",
       },
@@ -48,6 +51,65 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
     return { available: true, summary: "enabled" };
   }
 
+  buildPlan(request: ProviderOperationRequest, config: ValyuProviderConfig) {
+    const traits = {
+      policyDefaults: config.policy,
+    };
+
+    switch (request.capability) {
+      case "search":
+        return {
+          capability: request.capability,
+          providerId: this.id,
+          providerLabel: this.label,
+          mode: "single" as const,
+          traits,
+          execute: (context: ProviderContext) =>
+            this.search(
+              request.query,
+              request.maxResults,
+              request.options,
+              config,
+              context,
+            ),
+        };
+      case "contents":
+        return {
+          capability: request.capability,
+          providerId: this.id,
+          providerLabel: this.label,
+          mode: "single" as const,
+          traits,
+          execute: (context: ProviderContext) =>
+            this.contents(request.urls, request.options, config, context),
+        };
+      case "answer":
+        return {
+          capability: request.capability,
+          providerId: this.id,
+          providerLabel: this.label,
+          mode: "single" as const,
+          traits,
+          execute: (context: ProviderContext) =>
+            this.answer(request.query, request.options, config, context),
+        };
+      case "research":
+        return {
+          capability: request.capability,
+          providerId: this.id,
+          providerLabel: this.label,
+          mode: "job" as const,
+          traits,
+          start: (context: ProviderContext) =>
+            this.startResearch(request.input, request.options, config, context),
+          poll: (id: string, context: ProviderContext) =>
+            this.pollResearch(id, request.options, config, context),
+        };
+      default:
+        return null;
+    }
+  }
+
   async search(
     query: string,
     maxResults: number,
@@ -61,8 +123,9 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
     }
 
     const client = new Valyu(apiKey, config.baseUrl);
+    const native = config.native ?? config.defaults;
     const options = {
-      ...asJsonObject(config.defaults),
+      ...(stripLocalExecutionOptions(asJsonObject(native)) ?? {}),
       ...(searchOptions ?? {}),
       maxNumResults: maxResults,
     };

--- a/src/providers/valyu.ts
+++ b/src/providers/valyu.ts
@@ -1,6 +1,10 @@
 import { Valyu } from "valyu-js";
 import { resolveConfigValue } from "../config.js";
 import { stripLocalExecutionOptions } from "../execution-policy.js";
+import {
+  createResearchJobPlan,
+  createSingleOperationPlan,
+} from "../provider-plans.js";
 import type {
   ProviderContext,
   ProviderOperationRequest,
@@ -52,18 +56,13 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
   }
 
   buildPlan(request: ProviderOperationRequest, config: ValyuProviderConfig) {
-    const traits = {
-      policyDefaults: config.policy,
-    };
-
     switch (request.capability) {
       case "search":
-        return {
+        return createSingleOperationPlan({
+          config,
           capability: request.capability,
           providerId: this.id,
           providerLabel: this.label,
-          mode: "single" as const,
-          traits,
           execute: (context: ProviderContext) =>
             this.search(
               request.query,
@@ -72,39 +71,42 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
               config,
               context,
             ),
-        };
+        });
       case "contents":
-        return {
+        return createSingleOperationPlan({
+          config,
           capability: request.capability,
           providerId: this.id,
           providerLabel: this.label,
-          mode: "single" as const,
-          traits,
           execute: (context: ProviderContext) =>
             this.contents(request.urls, request.options, config, context),
-        };
+        });
       case "answer":
-        return {
+        return createSingleOperationPlan({
+          config,
           capability: request.capability,
           providerId: this.id,
           providerLabel: this.label,
-          mode: "single" as const,
-          traits,
           execute: (context: ProviderContext) =>
             this.answer(request.query, request.options, config, context),
-        };
+        });
       case "research":
-        return {
+        return createResearchJobPlan({
+          config,
           capability: request.capability,
           providerId: this.id,
           providerLabel: this.label,
-          mode: "job" as const,
-          traits,
+          traits: {
+            researchLifecycle: {
+              supportsStartRetries: false,
+              supportsRequestTimeouts: false,
+            },
+          },
           start: (context: ProviderContext) =>
             this.startResearch(request.input, request.options, config, context),
           poll: (id: string, context: ProviderContext) =>
             this.pollResearch(id, request.options, config, context),
-        };
+        });
       default:
         return null;
     }

--- a/src/providers/valyu.ts
+++ b/src/providers/valyu.ts
@@ -3,8 +3,8 @@ import { resolveConfigValue } from "../config.js";
 import { stripLocalExecutionOptions } from "../execution-policy.js";
 import { createDefaultLifecyclePolicy } from "../execution-policy-defaults.js";
 import {
-  createResearchJobPlan,
-  createSingleOperationPlan,
+  createBackgroundResearchPlan,
+  createSilentForegroundPlan,
 } from "../provider-plans.js";
 import type {
   ProviderContext,
@@ -60,7 +60,7 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
   buildPlan(request: ProviderOperationRequest, config: ValyuProviderConfig) {
     switch (request.capability) {
       case "search":
-        return createSingleOperationPlan({
+        return createSilentForegroundPlan({
           config,
           capability: request.capability,
           providerId: this.id,
@@ -75,7 +75,7 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
             ),
         });
       case "contents":
-        return createSingleOperationPlan({
+        return createSilentForegroundPlan({
           config,
           capability: request.capability,
           providerId: this.id,
@@ -84,7 +84,7 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
             this.contents(request.urls, request.options, config, context),
         });
       case "answer":
-        return createSingleOperationPlan({
+        return createSilentForegroundPlan({
           config,
           capability: request.capability,
           providerId: this.id,
@@ -93,7 +93,7 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
             this.answer(request.query, request.options, config, context),
         });
       case "research":
-        return createResearchJobPlan({
+        return createBackgroundResearchPlan({
           config,
           capability: request.capability,
           providerId: this.id,

--- a/src/providers/valyu.ts
+++ b/src/providers/valyu.ts
@@ -99,6 +99,15 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
           providerId: this.id,
           providerLabel: this.label,
           traits: {
+            executionSupport: {
+              requestTimeoutMs: false,
+              retryCount: true,
+              retryDelayMs: true,
+              pollIntervalMs: true,
+              timeoutMs: true,
+              maxConsecutivePollErrors: true,
+              resumeId: true,
+            },
             researchLifecycle: {
               supportsStartRetries: false,
               supportsRequestTimeouts: false,

--- a/src/providers/valyu.ts
+++ b/src/providers/valyu.ts
@@ -1,13 +1,15 @@
 import { Valyu } from "valyu-js";
+import { resolveConfigValue } from "../config.js";
 import type {
   ProviderContext,
+  ProviderResearchJob,
+  ProviderResearchPollResult,
   ProviderStatus,
   ProviderToolOutput,
   SearchResponse,
   ValyuProviderConfig,
   WebProvider,
 } from "../types.js";
-import { resolveConfigValue } from "../config.js";
 import { asJsonObject, formatJson, trimSnippet } from "./shared.js";
 
 export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
@@ -198,12 +200,12 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
     };
   }
 
-  async research(
+  async startResearch(
     input: string,
     options: Record<string, unknown> | undefined,
     config: ValyuProviderConfig,
     context: ProviderContext,
-  ): Promise<ProviderToolOutput> {
+  ): Promise<ProviderResearchJob> {
     const apiKey = resolveConfigValue(config.apiKey);
     if (!apiKey) {
       throw new Error("Valyu is missing an API key.");
@@ -220,43 +222,79 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
       throw new Error(task.error || "Valyu deep research creation failed.");
     }
 
-    const result = await client.deepresearch.wait(task.deepresearch_id, {
-      onProgress: (status) => {
-        const progress = status.progress;
-        if (progress) {
-          context.onProgress?.(
-            `Valyu deep research: ${progress.current_step}/${progress.total_steps}`,
-          );
-        }
-      },
-    });
+    return { id: task.deepresearch_id };
+  }
+
+  async pollResearch(
+    id: string,
+    _options: Record<string, unknown> | undefined,
+    config: ValyuProviderConfig,
+    context: ProviderContext,
+  ): Promise<ProviderResearchPollResult> {
+    const apiKey = resolveConfigValue(config.apiKey);
+    if (!apiKey) {
+      throw new Error("Valyu is missing an API key.");
+    }
+
+    const client = new Valyu(apiKey, config.baseUrl);
+    const result = await client.deepresearch.status(id);
 
     if (!result.success) {
       throw new Error(result.error || "Valyu deep research failed.");
     }
 
-    const lines: string[] = [];
-    lines.push(
-      typeof result.output === "string"
-        ? result.output
-        : formatJson(result.output),
-    );
-
-    const sources = result.sources ?? [];
-    if (sources.length > 0) {
-      lines.push("");
-      lines.push("Sources:");
-      for (const [index, source] of sources.entries()) {
-        lines.push(`${index + 1}. ${source.title}`);
-        lines.push(`   ${source.url}`);
-      }
+    const progress = result.progress;
+    if (progress) {
+      context.onProgress?.(
+        `Valyu deep research: ${progress.current_step}/${progress.total_steps}`,
+      );
     }
 
-    return {
-      provider: this.id,
-      text: lines.join("\n").trimEnd(),
-      summary: `Research via Valyu with ${sources.length} source(s)`,
-      itemCount: sources.length,
-    };
+    if (result.status === "completed") {
+      const lines: string[] = [];
+      lines.push(
+        typeof result.output === "string"
+          ? result.output
+          : result.output
+            ? formatJson(result.output)
+            : "Valyu deep research completed without textual output.",
+      );
+
+      const sources = result.sources ?? [];
+      if (sources.length > 0) {
+        lines.push("");
+        lines.push("Sources:");
+        for (const [index, source] of sources.entries()) {
+          lines.push(`${index + 1}. ${source.title}`);
+          lines.push(`   ${source.url}`);
+        }
+      }
+
+      return {
+        status: "completed",
+        output: {
+          provider: this.id,
+          text: lines.join("\n").trimEnd(),
+          summary: `Research via Valyu with ${sources.length} source(s)`,
+          itemCount: sources.length,
+        },
+      };
+    }
+
+    if (result.status === "failed") {
+      return {
+        status: "failed",
+        error: result.error || "Valyu deep research failed.",
+      };
+    }
+
+    if (result.status === "cancelled") {
+      return {
+        status: "cancelled",
+        error: result.error || "Valyu deep research was canceled.",
+      };
+    }
+
+    return { status: "in_progress" };
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export const PROVIDER_IDS = [
 ] as const;
 
 export type ProviderId = (typeof PROVIDER_IDS)[number];
+export type ProviderCapability = "search" | "contents" | "answer" | "research";
 
 export type JsonValue =
   | string
@@ -66,6 +67,40 @@ export interface ProviderToolDetails {
   itemCount?: number;
 }
 
+export interface ClaudeProviderNativeConfig {
+  model?: string;
+  effort?: "low" | "medium" | "high" | "max";
+  maxTurns?: number;
+}
+
+export interface CodexProviderNativeConfig {
+  model?: string;
+  modelReasoningEffort?: ModelReasoningEffort;
+  networkAccessEnabled?: boolean;
+  webSearchMode?: WebSearchMode;
+  webSearchEnabled?: boolean;
+  additionalDirectories?: string[];
+}
+
+export interface GeminiProviderNativeConfig {
+  apiVersion?: string;
+  searchModel?: string;
+  contentsModel?: string;
+  answerModel?: string;
+  researchAgent?: string;
+}
+
+export interface PerplexityProviderNativeConfig {
+  search?: JsonObject;
+  answer?: JsonObject;
+  research?: JsonObject;
+}
+
+export interface ParallelProviderNativeConfig {
+  search?: JsonObject;
+  extract?: JsonObject;
+}
+
 export interface ClaudeProviderConfig {
   enabled?: boolean;
   tools?: {
@@ -73,11 +108,9 @@ export interface ClaudeProviderConfig {
     answer?: boolean;
   };
   pathToClaudeCodeExecutable?: string;
-  defaults?: {
-    model?: string;
-    effort?: "low" | "medium" | "high" | "max";
-    maxTurns?: number;
-  };
+  native?: ClaudeProviderNativeConfig;
+  policy?: ExecutionPolicyDefaults;
+  defaults?: ClaudeProviderNativeConfig;
 }
 
 export interface CodexProviderConfig {
@@ -90,14 +123,9 @@ export interface CodexProviderConfig {
   apiKey?: string;
   env?: Record<string, string>;
   config?: JsonObject;
-  defaults?: {
-    model?: string;
-    modelReasoningEffort?: ModelReasoningEffort;
-    networkAccessEnabled?: boolean;
-    webSearchMode?: WebSearchMode;
-    webSearchEnabled?: boolean;
-    additionalDirectories?: string[];
-  };
+  native?: CodexProviderNativeConfig;
+  policy?: ExecutionPolicyDefaults;
+  defaults?: CodexProviderNativeConfig;
 }
 
 export interface ExaProviderConfig {
@@ -110,6 +138,8 @@ export interface ExaProviderConfig {
   };
   apiKey?: string;
   baseUrl?: string;
+  native?: JsonObject;
+  policy?: ExecutionPolicyDefaults;
   defaults?: JsonObject;
 }
 
@@ -122,19 +152,9 @@ export interface GeminiProviderConfig {
     research?: boolean;
   };
   apiKey?: string;
-  defaults?: {
-    apiVersion?: string;
-    searchModel?: string;
-    contentsModel?: string;
-    answerModel?: string;
-    researchAgent?: string;
-    requestTimeoutMs?: number;
-    retryCount?: number;
-    retryDelayMs?: number;
-    researchPollIntervalMs?: number;
-    researchTimeoutMs?: number;
-    researchMaxConsecutivePollErrors?: number;
-  };
+  native?: GeminiProviderNativeConfig;
+  policy?: ExecutionPolicyDefaults;
+  defaults?: GeminiProviderNativeConfig & ExecutionPolicyDefaults;
 }
 
 export interface PerplexityProviderConfig {
@@ -146,11 +166,9 @@ export interface PerplexityProviderConfig {
   };
   apiKey?: string;
   baseUrl?: string;
-  defaults?: {
-    search?: JsonObject;
-    answer?: JsonObject;
-    research?: JsonObject;
-  };
+  native?: PerplexityProviderNativeConfig;
+  policy?: ExecutionPolicyDefaults;
+  defaults?: PerplexityProviderNativeConfig;
 }
 
 export interface ParallelProviderConfig {
@@ -161,10 +179,9 @@ export interface ParallelProviderConfig {
   };
   apiKey?: string;
   baseUrl?: string;
-  defaults?: {
-    search?: JsonObject;
-    extract?: JsonObject;
-  };
+  native?: ParallelProviderNativeConfig;
+  policy?: ExecutionPolicyDefaults;
+  defaults?: ParallelProviderNativeConfig;
 }
 
 export interface ValyuProviderConfig {
@@ -177,6 +194,8 @@ export interface ValyuProviderConfig {
   };
   apiKey?: string;
   baseUrl?: string;
+  native?: JsonObject;
+  policy?: ExecutionPolicyDefaults;
   defaults?: JsonObject;
 }
 
@@ -205,44 +224,88 @@ export interface ProviderContext {
   idempotencyKey?: string;
 }
 
+export interface ExecutionPolicyDefaults {
+  requestTimeoutMs?: number;
+  retryCount?: number;
+  retryDelayMs?: number;
+  researchPollIntervalMs?: number;
+  researchTimeoutMs?: number;
+  researchMaxConsecutivePollErrors?: number;
+}
+
+export interface SearchOperationRequest {
+  capability: "search";
+  query: string;
+  maxResults: number;
+  options?: JsonObject;
+}
+
+export interface ContentsOperationRequest {
+  capability: "contents";
+  urls: string[];
+  options?: JsonObject;
+}
+
+export interface AnswerOperationRequest {
+  capability: "answer";
+  query: string;
+  options?: JsonObject;
+}
+
+export interface ResearchOperationRequest {
+  capability: "research";
+  input: string;
+  options?: JsonObject;
+}
+
+export type ProviderOperationRequest =
+  | SearchOperationRequest
+  | ContentsOperationRequest
+  | AnswerOperationRequest
+  | ResearchOperationRequest;
+
+export interface ProviderPlanTraits {
+  policyDefaults?: ExecutionPolicyDefaults;
+  supportsIdempotentStartRetries?: boolean;
+  supportsPollCancellation?: boolean;
+}
+
+export interface SingleProviderOperationPlan<TResult> {
+  capability: ProviderCapability;
+  providerId: ProviderId;
+  providerLabel: string;
+  mode: "single";
+  traits?: ProviderPlanTraits;
+  execute: (context: ProviderContext) => Promise<TResult>;
+}
+
+export interface JobProviderOperationPlan {
+  capability: "research";
+  providerId: ProviderId;
+  providerLabel: string;
+  mode: "job";
+  traits?: ProviderPlanTraits;
+  start: (context: ProviderContext) => Promise<ProviderResearchJob>;
+  poll: (
+    id: string,
+    context: ProviderContext,
+  ) => Promise<ProviderResearchPollResult>;
+}
+
+export type ProviderOperationPlan<
+  TResult = SearchResponse | ProviderToolOutput,
+> = SingleProviderOperationPlan<TResult> | JobProviderOperationPlan;
+
 export interface WebProvider<TConfig> {
   readonly id: ProviderId;
   readonly label: string;
   readonly docsUrl: string;
-  readonly supportsIdempotentResearchStartRetries?: boolean;
-  readonly supportsResearchPollingCancellation?: boolean;
+  readonly capabilities: readonly ProviderCapability[];
 
   createTemplate(): TConfig;
   getStatus(config: TConfig | undefined, cwd: string): ProviderStatus;
-  search?(
-    query: string,
-    maxResults: number,
-    options: JsonObject | undefined,
+  buildPlan(
+    request: ProviderOperationRequest,
     config: TConfig,
-    context: ProviderContext,
-  ): Promise<SearchResponse>;
-  contents?(
-    urls: string[],
-    options: JsonObject | undefined,
-    config: TConfig,
-    context: ProviderContext,
-  ): Promise<ProviderToolOutput>;
-  answer?(
-    query: string,
-    options: JsonObject | undefined,
-    config: TConfig,
-    context: ProviderContext,
-  ): Promise<ProviderToolOutput>;
-  startResearch?(
-    input: string,
-    options: JsonObject | undefined,
-    config: TConfig,
-    context: ProviderContext,
-  ): Promise<ProviderResearchJob>;
-  pollResearch?(
-    id: string,
-    options: JsonObject | undefined,
-    config: TConfig,
-    context: ProviderContext,
-  ): Promise<ProviderResearchPollResult>;
+  ): ProviderOperationPlan | null;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,16 @@ export interface ProviderToolOutput {
   itemCount?: number;
 }
 
+export interface ProviderResearchJob {
+  id: string;
+}
+
+export interface ProviderResearchPollResult {
+  status: "in_progress" | "completed" | "failed" | "cancelled";
+  output?: ProviderToolOutput;
+  error?: string;
+}
+
 export interface WebSearchDetails {
   tool: "web_search";
   query: string;
@@ -118,6 +128,12 @@ export interface GeminiProviderConfig {
     contentsModel?: string;
     answerModel?: string;
     researchAgent?: string;
+    requestTimeoutMs?: number;
+    retryCount?: number;
+    retryDelayMs?: number;
+    researchPollIntervalMs?: number;
+    researchTimeoutMs?: number;
+    researchMaxConsecutivePollErrors?: number;
   };
 }
 
@@ -220,4 +236,16 @@ export interface WebProvider<TConfig> {
     config: TConfig,
     context: ProviderContext,
   ): Promise<ProviderToolOutput>;
+  startResearch?(
+    input: string,
+    options: JsonObject | undefined,
+    config: TConfig,
+    context: ProviderContext,
+  ): Promise<ProviderResearchJob>;
+  pollResearch?(
+    id: string,
+    options: JsonObject | undefined,
+    config: TConfig,
+    context: ProviderContext,
+  ): Promise<ProviderResearchPollResult>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -264,10 +264,14 @@ export type ProviderOperationRequest =
   | AnswerOperationRequest
   | ResearchOperationRequest;
 
+export interface ProviderResearchLifecycleTraits {
+  supportsStartRetries?: boolean;
+  supportsRequestTimeouts?: boolean;
+}
+
 export interface ProviderPlanTraits {
   policyDefaults?: ExecutionPolicyDefaults;
-  supportsIdempotentStartRetries?: boolean;
-  supportsPollCancellation?: boolean;
+  researchLifecycle?: ProviderResearchLifecycleTraits;
 }
 
 export interface SingleProviderOperationPlan<TResult> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -233,12 +233,6 @@ export interface WebProvider<TConfig> {
     config: TConfig,
     context: ProviderContext,
   ): Promise<ProviderToolOutput>;
-  research?(
-    input: string,
-    options: JsonObject | undefined,
-    config: TConfig,
-    context: ProviderContext,
-  ): Promise<ProviderToolOutput>;
   startResearch?(
     input: string,
     options: JsonObject | undefined,

--- a/src/types.ts
+++ b/src/types.ts
@@ -202,6 +202,7 @@ export interface ProviderContext {
   cwd: string;
   signal?: AbortSignal;
   onProgress?: (message: string) => void;
+  idempotencyKey?: string;
 }
 
 export interface WebProvider<TConfig> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -274,20 +274,26 @@ export interface ProviderPlanTraits {
   researchLifecycle?: ProviderResearchLifecycleTraits;
 }
 
+// How a provider delivers a tool result back to pi.
+export type ProviderDeliveryMode =
+  | "silent-foreground"
+  | "streaming-foreground"
+  | "background-research";
+
 export interface SingleProviderOperationPlan<TResult> {
   capability: ProviderCapability;
   providerId: ProviderId;
   providerLabel: string;
-  mode: "single";
+  deliveryMode: "silent-foreground" | "streaming-foreground";
   traits?: ProviderPlanTraits;
   execute: (context: ProviderContext) => Promise<TResult>;
 }
 
-export interface JobProviderOperationPlan {
+export interface BackgroundResearchOperationPlan {
   capability: "research";
   providerId: ProviderId;
   providerLabel: string;
-  mode: "job";
+  deliveryMode: "background-research";
   traits?: ProviderPlanTraits;
   start: (context: ProviderContext) => Promise<ProviderResearchJob>;
   poll: (
@@ -298,7 +304,7 @@ export interface JobProviderOperationPlan {
 
 export type ProviderOperationPlan<
   TResult = SearchResponse | ProviderToolOutput,
-> = SingleProviderOperationPlan<TResult> | JobProviderOperationPlan;
+> = SingleProviderOperationPlan<TResult> | BackgroundResearchOperationPlan;
 
 export interface WebProvider<TConfig> {
   readonly id: ProviderId;

--- a/src/types.ts
+++ b/src/types.ts
@@ -209,6 +209,8 @@ export interface WebProvider<TConfig> {
   readonly id: ProviderId;
   readonly label: string;
   readonly docsUrl: string;
+  readonly supportsIdempotentResearchStartRetries?: boolean;
+  readonly supportsResearchPollingCancellation?: boolean;
 
   createTemplate(): TConfig;
   getStatus(config: TConfig | undefined, cwd: string): ProviderStatus;

--- a/src/types.ts
+++ b/src/types.ts
@@ -269,8 +269,31 @@ export interface ProviderResearchLifecycleTraits {
   supportsRequestTimeouts?: boolean;
 }
 
+export const EXECUTION_CONTROL_KEYS = [
+  "requestTimeoutMs",
+  "retryCount",
+  "retryDelayMs",
+  "pollIntervalMs",
+  "timeoutMs",
+  "maxConsecutivePollErrors",
+  "resumeId",
+] as const;
+
+export type ExecutionControlKey = (typeof EXECUTION_CONTROL_KEYS)[number];
+
+export interface ExecutionSupport {
+  requestTimeoutMs?: boolean;
+  retryCount?: boolean;
+  retryDelayMs?: boolean;
+  pollIntervalMs?: boolean;
+  timeoutMs?: boolean;
+  maxConsecutivePollErrors?: boolean;
+  resumeId?: boolean;
+}
+
 export interface ProviderPlanTraits {
   policyDefaults?: ExecutionPolicyDefaults;
+  executionSupport?: ExecutionSupport;
   researchLifecycle?: ProviderResearchLifecycleTraits;
 }
 

--- a/test/claude-provider.test.ts
+++ b/test/claude-provider.test.ts
@@ -110,7 +110,7 @@ describe("ClaudeProvider", () => {
     );
 
     expect(plan).toMatchObject({
-      mode: "single",
+      deliveryMode: "silent-foreground",
       traits: {
         policyDefaults: {
           requestTimeoutMs: 1500,

--- a/test/claude-provider.test.ts
+++ b/test/claude-provider.test.ts
@@ -91,6 +91,36 @@ describe("ClaudeProvider", () => {
     expect(execFileSyncMock).toHaveBeenCalledTimes(1);
   });
 
+  it("attaches config policy defaults to Claude operation plans", () => {
+    const provider = new ClaudeProvider();
+    const plan = provider.buildPlan(
+      {
+        capability: "search",
+        query: "latest Claude docs",
+        maxResults: 5,
+      },
+      {
+        enabled: true,
+        policy: {
+          requestTimeoutMs: 1500,
+          retryCount: 2,
+          retryDelayMs: 250,
+        },
+      },
+    );
+
+    expect(plan).toMatchObject({
+      mode: "single",
+      traits: {
+        policyDefaults: {
+          requestTimeoutMs: 1500,
+          retryCount: 2,
+          retryDelayMs: 250,
+        },
+      },
+    });
+  });
+
   it("disables Claude session persistence for provider queries", async () => {
     queryMock.mockImplementation(() => ({
       async *[Symbol.asyncIterator]() {

--- a/test/codex-provider.test.ts
+++ b/test/codex-provider.test.ts
@@ -42,7 +42,7 @@ describe("CodexProvider", () => {
     );
 
     expect(plan).toMatchObject({
-      mode: "single",
+      deliveryMode: "silent-foreground",
       traits: {
         policyDefaults: {
           requestTimeoutMs: 1500,

--- a/test/codex-provider.test.ts
+++ b/test/codex-provider.test.ts
@@ -23,6 +23,36 @@ afterEach(() => {
 });
 
 describe("CodexProvider", () => {
+  it("attaches config policy defaults to Codex operation plans", () => {
+    const provider = new CodexProvider();
+    const plan = provider.buildPlan(
+      {
+        capability: "search",
+        query: "latest docs",
+        maxResults: 5,
+      },
+      {
+        enabled: true,
+        policy: {
+          requestTimeoutMs: 1500,
+          retryCount: 2,
+          retryDelayMs: 250,
+        },
+      },
+    );
+
+    expect(plan).toMatchObject({
+      mode: "single",
+      traits: {
+        policyDefaults: {
+          requestTimeoutMs: 1500,
+          retryCount: 2,
+          retryDelayMs: 250,
+        },
+      },
+    });
+  });
+
   it("forwards only user-facing search options and keeps managed thread settings fixed", async () => {
     startThreadMock.mockReturnValue({
       runStreamed: runStreamedMock.mockResolvedValue({

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -10,6 +10,7 @@ import {
   resolveConfigValue,
   serializeConfig,
 } from "../src/config.js";
+import { PROVIDER_MAP } from "../src/providers/index.js";
 
 const cleanupDirs: string[] = [];
 
@@ -206,6 +207,81 @@ describe("config parsing", () => {
     expect(loaded.providers?.gemini?.policy?.requestTimeoutMs).toBe(45000);
     expect(loaded.providers?.gemini?.policy?.retryCount).toBe(5);
     expect(loaded.providers?.gemini).not.toHaveProperty("defaults");
+  });
+
+  it("seeds managed execution policy defaults for every provider template", () => {
+    const config = createDefaultConfig();
+
+    expect(config.providers?.claude?.policy).toEqual({
+      requestTimeoutMs: 30000,
+      retryCount: 3,
+      retryDelayMs: 2000,
+    });
+    expect(config.providers?.codex?.policy).toEqual({
+      requestTimeoutMs: 30000,
+      retryCount: 3,
+      retryDelayMs: 2000,
+    });
+    expect(config.providers?.exa?.policy).toEqual({
+      requestTimeoutMs: 30000,
+      retryCount: 3,
+      retryDelayMs: 2000,
+      researchPollIntervalMs: 3000,
+      researchTimeoutMs: 21600000,
+      researchMaxConsecutivePollErrors: 3,
+    });
+    expect(config.providers?.gemini?.policy).toEqual({
+      requestTimeoutMs: 30000,
+      retryCount: 3,
+      retryDelayMs: 2000,
+      researchPollIntervalMs: 3000,
+      researchTimeoutMs: 21600000,
+      researchMaxConsecutivePollErrors: 10,
+    });
+    expect(config.providers?.perplexity?.policy).toEqual({
+      requestTimeoutMs: 30000,
+      retryCount: 3,
+      retryDelayMs: 2000,
+    });
+    expect(config.providers?.parallel?.policy).toEqual({
+      requestTimeoutMs: 30000,
+      retryCount: 3,
+      retryDelayMs: 2000,
+    });
+    expect(config.providers?.valyu?.policy).toEqual({
+      requestTimeoutMs: 30000,
+      retryCount: 3,
+      retryDelayMs: 2000,
+      researchPollIntervalMs: 3000,
+      researchTimeoutMs: 21600000,
+      researchMaxConsecutivePollErrors: 3,
+    });
+  });
+
+  it("keeps provider templates aligned with the default config policy blocks", () => {
+    const config = createDefaultConfig();
+
+    expect(PROVIDER_MAP.claude.createTemplate().policy).toEqual(
+      config.providers?.claude?.policy,
+    );
+    expect(PROVIDER_MAP.codex.createTemplate().policy).toEqual(
+      config.providers?.codex?.policy,
+    );
+    expect(PROVIDER_MAP.exa.createTemplate().policy).toEqual(
+      config.providers?.exa?.policy,
+    );
+    expect(PROVIDER_MAP.gemini.createTemplate().policy).toEqual(
+      config.providers?.gemini?.policy,
+    );
+    expect(PROVIDER_MAP.perplexity.createTemplate().policy).toEqual(
+      config.providers?.perplexity?.policy,
+    );
+    expect(PROVIDER_MAP.parallel.createTemplate().policy).toEqual(
+      config.providers?.parallel?.policy,
+    );
+    expect(PROVIDER_MAP.valyu.createTemplate().policy).toEqual(
+      config.providers?.valyu?.policy,
+    );
   });
 
   it("caches command-backed config values within the process", async () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -101,6 +101,12 @@ describe("config parsing", () => {
         apiVersion: "v1alpha",
         searchModel: "gemini-2.5-flash",
         contentsModel: "gemini-2.5-pro",
+        requestTimeoutMs: 45000,
+        retryCount: 5,
+        retryDelayMs: 4000,
+        researchPollIntervalMs: 6000,
+        researchTimeoutMs: 28800000,
+        researchMaxConsecutivePollErrors: 12,
       },
     };
     config.providers!.perplexity = {
@@ -140,6 +146,18 @@ describe("config parsing", () => {
     expect(loaded.providers?.gemini?.defaults?.contentsModel).toBe(
       "gemini-2.5-pro",
     );
+    expect(loaded.providers?.gemini?.defaults?.requestTimeoutMs).toBe(45000);
+    expect(loaded.providers?.gemini?.defaults?.retryCount).toBe(5);
+    expect(loaded.providers?.gemini?.defaults?.retryDelayMs).toBe(4000);
+    expect(loaded.providers?.gemini?.defaults?.researchPollIntervalMs).toBe(
+      6000,
+    );
+    expect(loaded.providers?.gemini?.defaults?.researchTimeoutMs).toBe(
+      28800000,
+    );
+    expect(
+      loaded.providers?.gemini?.defaults?.researchMaxConsecutivePollErrors,
+    ).toBe(12);
     expect(loaded.providers?.perplexity?.defaults?.search?.country).toBe("US");
     expect(loaded.providers?.perplexity?.defaults?.research?.model).toBe(
       "sonar-deep-research",

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -89,24 +89,24 @@ describe("config parsing", () => {
     config.providers!.claude = {
       enabled: false,
       pathToClaudeCodeExecutable: "/tmp/claude-code",
-      defaults: {
+      native: {
         model: "claude-sonnet-4-5",
         effort: "high",
         maxTurns: 6,
       },
     };
-    config.providers!.codex!.defaults!.additionalDirectories = ["docs"];
+    config.providers!.codex!.native!.additionalDirectories = ["docs"];
     config.providers!.exa = {
       enabled: true,
       apiKey: "EXA_API_KEY",
-      defaults: {
+      native: {
         type: "auto",
       },
     };
     config.providers!.parallel = {
       enabled: false,
       apiKey: "PARALLEL_API_KEY",
-      defaults: {
+      native: {
         search: {
           mode: "one-shot",
         },
@@ -115,10 +115,12 @@ describe("config parsing", () => {
     config.providers!.gemini = {
       enabled: false,
       apiKey: "GOOGLE_API_KEY",
-      defaults: {
+      native: {
         apiVersion: "v1alpha",
         searchModel: "gemini-2.5-flash",
         contentsModel: "gemini-2.5-pro",
+      },
+      policy: {
         requestTimeoutMs: 45000,
         retryCount: 5,
         retryDelayMs: 4000,
@@ -130,7 +132,7 @@ describe("config parsing", () => {
     config.providers!.perplexity = {
       enabled: true,
       apiKey: "PERPLEXITY_API_KEY",
-      defaults: {
+      native: {
         search: {
           country: "US",
         },
@@ -143,8 +145,8 @@ describe("config parsing", () => {
       },
     };
 
-    config.providers!.codex!.defaults!.webSearchMode = "cached";
-    config.providers!.codex!.defaults!.additionalDirectories = ["notes"];
+    config.providers!.codex!.native!.webSearchMode = "cached";
+    config.providers!.codex!.native!.additionalDirectories = ["notes"];
 
     await writeFile(getConfigPath(), serializeConfig(config), "utf-8");
 
@@ -152,35 +154,58 @@ describe("config parsing", () => {
     expect(loaded.providers?.claude?.pathToClaudeCodeExecutable).toBe(
       "/tmp/claude-code",
     );
-    expect(loaded.providers?.claude?.defaults?.model).toBe("claude-sonnet-4-5");
-    expect(loaded.providers?.claude?.defaults?.effort).toBe("high");
-    expect(loaded.providers?.claude?.defaults?.maxTurns).toBe(6);
-    expect(loaded.providers?.codex?.defaults?.webSearchMode).toBe("cached");
-    expect(loaded.providers?.codex?.defaults?.additionalDirectories).toEqual([
+    expect(loaded.providers?.claude?.native?.model).toBe("claude-sonnet-4-5");
+    expect(loaded.providers?.claude?.native?.effort).toBe("high");
+    expect(loaded.providers?.claude?.native?.maxTurns).toBe(6);
+    expect(loaded.providers?.codex?.native?.webSearchMode).toBe("cached");
+    expect(loaded.providers?.codex?.native?.additionalDirectories).toEqual([
       "notes",
     ]);
     expect(loaded.providers?.exa?.enabled).toBe(true);
-    expect(loaded.providers?.gemini?.defaults?.apiVersion).toBe("v1alpha");
-    expect(loaded.providers?.gemini?.defaults?.contentsModel).toBe(
+    expect(loaded.providers?.gemini?.native?.apiVersion).toBe("v1alpha");
+    expect(loaded.providers?.gemini?.native?.contentsModel).toBe(
       "gemini-2.5-pro",
     );
-    expect(loaded.providers?.gemini?.defaults?.requestTimeoutMs).toBe(45000);
-    expect(loaded.providers?.gemini?.defaults?.retryCount).toBe(5);
-    expect(loaded.providers?.gemini?.defaults?.retryDelayMs).toBe(4000);
-    expect(loaded.providers?.gemini?.defaults?.researchPollIntervalMs).toBe(
-      6000,
-    );
-    expect(loaded.providers?.gemini?.defaults?.researchTimeoutMs).toBe(
-      28800000,
-    );
+    expect(loaded.providers?.gemini?.policy?.requestTimeoutMs).toBe(45000);
+    expect(loaded.providers?.gemini?.policy?.retryCount).toBe(5);
+    expect(loaded.providers?.gemini?.policy?.retryDelayMs).toBe(4000);
+    expect(loaded.providers?.gemini?.policy?.researchPollIntervalMs).toBe(6000);
+    expect(loaded.providers?.gemini?.policy?.researchTimeoutMs).toBe(28800000);
     expect(
-      loaded.providers?.gemini?.defaults?.researchMaxConsecutivePollErrors,
+      loaded.providers?.gemini?.policy?.researchMaxConsecutivePollErrors,
     ).toBe(12);
-    expect(loaded.providers?.perplexity?.defaults?.search?.country).toBe("US");
-    expect(loaded.providers?.perplexity?.defaults?.research?.model).toBe(
+    expect(loaded.providers?.perplexity?.native?.search?.country).toBe("US");
+    expect(loaded.providers?.perplexity?.native?.research?.model).toBe(
       "sonar-deep-research",
     );
-    expect(loaded.providers?.parallel?.defaults?.search?.mode).toBe("one-shot");
+    expect(loaded.providers?.parallel?.native?.search?.mode).toBe("one-shot");
+  });
+
+  it("maps legacy defaults into native and policy config blocks", () => {
+    const loaded = parseConfig(
+      JSON.stringify({
+        version: 1,
+        providers: {
+          gemini: {
+            enabled: true,
+            apiKey: "GOOGLE_API_KEY",
+            defaults: {
+              searchModel: "gemini-2.5-flash",
+              requestTimeoutMs: 45000,
+              retryCount: 5,
+            },
+          },
+        },
+      }),
+      "test-config.json",
+    );
+
+    expect(loaded.providers?.gemini?.native?.searchModel).toBe(
+      "gemini-2.5-flash",
+    );
+    expect(loaded.providers?.gemini?.policy?.requestTimeoutMs).toBe(45000);
+    expect(loaded.providers?.gemini?.policy?.retryCount).toBe(5);
+    expect(loaded.providers?.gemini).not.toHaveProperty("defaults");
   });
 
   it("caches command-backed config values within the process", async () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -60,6 +60,24 @@ describe("config parsing", () => {
     ).toThrow(/Unknown tools for codex/);
   });
 
+  it("rejects removed provider tool aliases", () => {
+    expect(() =>
+      parseConfig(
+        JSON.stringify({
+          version: 1,
+          providers: {
+            valyu: {
+              tools: {
+                deepResearch: true,
+              },
+            },
+          },
+        }),
+        "test-config.json",
+      ),
+    ).toThrow(/Unknown tools for valyu/);
+  });
+
   it("loads the global config", async () => {
     const root = await mkdtemp(join(tmpdir(), "pi-web-providers-config-"));
     cleanupDirs.push(root);

--- a/test/execution-policy.test.ts
+++ b/test/execution-policy.test.ts
@@ -209,6 +209,73 @@ describe("execution policy", () => {
     }
   });
 
+  it("retries timed-out idempotent research starts", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const progress: string[] = [];
+      const startContexts: ProviderContext[] = [];
+      const start = vi
+        .fn<
+          (
+            input: string,
+            options: JsonObject | undefined,
+            context: ProviderContext,
+          ) => Promise<{ id: string }>
+        >()
+        .mockImplementationOnce(async (_input, _options, context) => {
+          startContexts.push(context);
+          return await new Promise<{ id: string }>(() => {});
+        })
+        .mockImplementationOnce(async (_input, _options, context) => {
+          startContexts.push(context);
+          return { id: "research-123" };
+        });
+      const poll = vi.fn().mockResolvedValue({
+        status: "completed" as const,
+        output: {
+          provider: "gemini" as const,
+          text: "done",
+          summary: "Research via Gemini",
+        },
+      });
+
+      const promise = executeResearchWithLifecycle({
+        providerLabel: "Gemini",
+        providerId: "gemini",
+        input: "Investigate Tenzir use cases",
+        options: { requestTimeoutMs: 10, retryCount: 1 },
+        context: createContext(progress),
+        policy: {
+          requestTimeoutMs: 10,
+          retryCount: 1,
+          retryDelayMs: 1,
+          pollIntervalMs: 1,
+          timeoutMs: 60000,
+          maxConsecutivePollErrors: 3,
+        },
+        startRetryCount: 1,
+        startIdempotencyKey: "stable-key",
+        startRetryOnTimeout: true,
+        start,
+        poll,
+      });
+
+      await vi.advanceTimersByTimeAsync(11);
+      const result = await promise;
+
+      expect(result.text).toBe("done");
+      expect(start).toHaveBeenCalledTimes(2);
+      expect(startContexts[0]?.idempotencyKey).toBe("stable-key");
+      expect(startContexts[1]?.idempotencyKey).toBe("stable-key");
+      expect(progress).toContain(
+        "Gemini research start failed (Gemini research start timed out after 10ms.). Retrying in 1ms (attempt 2/2).",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not attach resume advice to terminal research failures", async () => {
     await expect(
       executeResearchWithLifecycle({

--- a/test/execution-policy.test.ts
+++ b/test/execution-policy.test.ts
@@ -111,6 +111,104 @@ describe("execution policy", () => {
     }
   });
 
+  it("aborts hung requests when the parent signal is aborted without a per-request timeout", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const controller = new AbortController();
+      const operation = vi.fn(async () => await new Promise<string>(() => {}));
+
+      const promise = runWithExecutionPolicy(
+        "Gemini answer request",
+        operation,
+        {
+          requestTimeoutMs: undefined,
+          retryCount: 0,
+          retryDelayMs: 1,
+        },
+        {
+          cwd: process.cwd(),
+          signal: controller.signal,
+        },
+      );
+      const rejection = expect(promise).rejects.toThrow("parent aborted");
+
+      controller.abort(new Error("parent aborted"));
+      await vi.runAllTimersAsync();
+      await rejection;
+
+      expect(operation).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retries research start when a stable idempotency key is available", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const progress: string[] = [];
+      const startContexts: ProviderContext[] = [];
+      const start = vi
+        .fn<
+          (
+            input: string,
+            options: JsonObject | undefined,
+            context: ProviderContext,
+          ) => Promise<{ id: string }>
+        >()
+        .mockImplementationOnce(async (_input, _options, context) => {
+          startContexts.push(context);
+          throw new Error("fetch failed");
+        })
+        .mockImplementationOnce(async (_input, _options, context) => {
+          startContexts.push(context);
+          return { id: "research-123" };
+        });
+      const poll = vi.fn().mockResolvedValue({
+        status: "completed" as const,
+        output: {
+          provider: "gemini" as const,
+          text: "done",
+          summary: "Research via Gemini",
+        },
+      });
+
+      const promise = executeResearchWithLifecycle({
+        providerLabel: "Gemini",
+        providerId: "gemini",
+        input: "Investigate Tenzir use cases",
+        options: { retryCount: 1 },
+        context: createContext(progress),
+        policy: {
+          requestTimeoutMs: undefined,
+          retryCount: 1,
+          retryDelayMs: 1,
+          pollIntervalMs: 1,
+          timeoutMs: 60000,
+          maxConsecutivePollErrors: 3,
+        },
+        startRetryCount: 1,
+        startIdempotencyKey: "stable-key",
+        start,
+        poll,
+      });
+
+      await vi.advanceTimersByTimeAsync(1);
+      const result = await promise;
+
+      expect(result.text).toBe("done");
+      expect(start).toHaveBeenCalledTimes(2);
+      expect(startContexts[0]?.idempotencyKey).toBe("stable-key");
+      expect(startContexts[1]?.idempotencyKey).toBe("stable-key");
+      expect(progress).toContain(
+        "Gemini research start failed (fetch failed). Retrying in 1ms (attempt 2/2).",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not attach resume advice to terminal research failures", async () => {
     await expect(
       executeResearchWithLifecycle({
@@ -171,6 +269,44 @@ describe("execution policy", () => {
       const poll = vi
         .fn()
         .mockResolvedValue({ status: "in_progress" as const });
+
+      const promise = executeResearchWithLifecycle({
+        providerLabel: "Gemini",
+        providerId: "gemini",
+        input: "ignored while resuming",
+        options: { resumeId: "research-123" },
+        context: createContext([]),
+        policy: {
+          requestTimeoutMs: undefined,
+          retryCount: 0,
+          retryDelayMs: 1,
+          pollIntervalMs: 30000,
+          timeoutMs: 10000,
+          maxConsecutivePollErrors: 3,
+          resumeId: "research-123",
+        },
+        start: vi.fn(),
+        poll,
+      });
+      const rejection = expect(promise).rejects.toThrow(
+        'Gemini research exceeded 10s. Resume the background job with options.resumeId="research-123".',
+      );
+
+      await vi.advanceTimersByTimeAsync(10000);
+      await rejection;
+      expect(poll).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("turns total research timeouts into resumable errors even when a poll request ignores aborts", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const poll = vi
+        .fn()
+        .mockImplementationOnce(() => new Promise<never>(() => {}));
 
       const promise = executeResearchWithLifecycle({
         providerLabel: "Gemini",

--- a/test/execution-policy.test.ts
+++ b/test/execution-policy.test.ts
@@ -40,7 +40,13 @@ describe("execution policy", () => {
       },
     };
 
-    expect(resolveRequestExecutionPolicy("gemini", config, undefined)).toEqual({
+    expect(
+      resolveRequestExecutionPolicy(undefined, {
+        requestTimeoutMs: config.defaults?.requestTimeoutMs,
+        retryCount: config.defaults?.retryCount,
+        retryDelayMs: config.defaults?.retryDelayMs,
+      }),
+    ).toEqual({
       requestTimeoutMs: 45000,
       retryCount: 5,
       retryDelayMs: 4000,
@@ -150,18 +156,12 @@ describe("execution policy", () => {
       const progress: string[] = [];
       const startContexts: ProviderContext[] = [];
       const start = vi
-        .fn<
-          (
-            input: string,
-            options: JsonObject | undefined,
-            context: ProviderContext,
-          ) => Promise<{ id: string }>
-        >()
-        .mockImplementationOnce(async (_input, _options, context) => {
+        .fn<(context: ProviderContext) => Promise<{ id: string }>>()
+        .mockImplementationOnce(async (context) => {
           startContexts.push(context);
           throw new Error("fetch failed");
         })
-        .mockImplementationOnce(async (_input, _options, context) => {
+        .mockImplementationOnce(async (context) => {
           startContexts.push(context);
           return { id: "research-123" };
         });
@@ -177,8 +177,6 @@ describe("execution policy", () => {
       const promise = executeResearchWithLifecycle({
         providerLabel: "Gemini",
         providerId: "gemini",
-        input: "Investigate Tenzir use cases",
-        options: { retryCount: 1 },
         context: createContext(progress),
         policy: {
           requestTimeoutMs: undefined,
@@ -216,18 +214,12 @@ describe("execution policy", () => {
       const progress: string[] = [];
       const startContexts: ProviderContext[] = [];
       const start = vi
-        .fn<
-          (
-            input: string,
-            options: JsonObject | undefined,
-            context: ProviderContext,
-          ) => Promise<{ id: string }>
-        >()
-        .mockImplementationOnce(async (_input, _options, context) => {
+        .fn<(context: ProviderContext) => Promise<{ id: string }>>()
+        .mockImplementationOnce(async (context) => {
           startContexts.push(context);
           return await new Promise<{ id: string }>(() => {});
         })
-        .mockImplementationOnce(async (_input, _options, context) => {
+        .mockImplementationOnce(async (context) => {
           startContexts.push(context);
           return { id: "research-123" };
         });
@@ -243,8 +235,6 @@ describe("execution policy", () => {
       const promise = executeResearchWithLifecycle({
         providerLabel: "Gemini",
         providerId: "gemini",
-        input: "Investigate Tenzir use cases",
-        options: { requestTimeoutMs: 10, retryCount: 1 },
         context: createContext(progress),
         policy: {
           requestTimeoutMs: 10,
@@ -296,8 +286,6 @@ describe("execution policy", () => {
       const promise = executeResearchWithLifecycle({
         providerLabel: "Exa",
         providerId: "exa",
-        input: "Investigate Exa lifecycle polling",
-        options: { timeoutMs: 10 },
         context: createContext([]),
         policy: {
           requestTimeoutMs: undefined,
@@ -335,8 +323,6 @@ describe("execution policy", () => {
       executeResearchWithLifecycle({
         providerLabel: "Gemini",
         providerId: "gemini",
-        input: "Investigate Tenzir use cases",
-        options: { resumeId: "research-123" },
         context: createContext([]),
         policy: {
           requestTimeoutMs: undefined,
@@ -359,8 +345,6 @@ describe("execution policy", () => {
       executeResearchWithLifecycle({
         providerLabel: "Gemini",
         providerId: "gemini",
-        input: "Investigate Tenzir use cases",
-        options: { resumeId: "research-123" },
         context: createContext([]),
         policy: {
           requestTimeoutMs: undefined,
@@ -394,8 +378,6 @@ describe("execution policy", () => {
       const promise = executeResearchWithLifecycle({
         providerLabel: "Gemini",
         providerId: "gemini",
-        input: "ignored while resuming",
-        options: { resumeId: "research-123" },
         context: createContext([]),
         policy: {
           requestTimeoutMs: undefined,
@@ -432,8 +414,6 @@ describe("execution policy", () => {
       const promise = executeResearchWithLifecycle({
         providerLabel: "Gemini",
         providerId: "gemini",
-        input: "ignored while resuming",
-        options: { resumeId: "research-123" },
         context: createContext([]),
         policy: {
           requestTimeoutMs: undefined,
@@ -479,8 +459,6 @@ describe("execution policy", () => {
       const promise = executeResearchWithLifecycle({
         providerLabel: "Gemini",
         providerId: "gemini",
-        input: "ignored while resuming",
-        options: { resumeId: "research-123" },
         context: createContext(progress),
         policy: {
           requestTimeoutMs: 10,
@@ -528,8 +506,6 @@ describe("execution policy", () => {
       const promise = executeResearchWithLifecycle({
         providerLabel: "Gemini",
         providerId: "gemini",
-        input: "ignored while resuming",
-        options: { resumeId: "research-123" },
         context: createContext(progress),
         policy: {
           requestTimeoutMs: undefined,
@@ -550,7 +526,6 @@ describe("execution policy", () => {
       expect(result.text).toBe("done");
       expect(poll).toHaveBeenCalledWith(
         "research-123",
-        undefined,
         expect.objectContaining({ cwd: process.cwd() }),
       );
       expect(progress).toContain("Resuming Gemini research: research-123");

--- a/test/execution-policy.test.ts
+++ b/test/execution-policy.test.ts
@@ -276,6 +276,60 @@ describe("execution policy", () => {
     }
   });
 
+  it("starts the overall research deadline after non-idempotent job creation", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const start = vi.fn().mockImplementationOnce(
+        () =>
+          new Promise<{ id: string }>((resolve) => {
+            setTimeout(() => {
+              resolve({ id: "research-123" });
+            }, 20);
+          }),
+      );
+      const poll = vi
+        .fn()
+        .mockResolvedValueOnce({ status: "in_progress" as const });
+
+      let settled = false;
+      const promise = executeResearchWithLifecycle({
+        providerLabel: "Exa",
+        providerId: "exa",
+        input: "Investigate Exa lifecycle polling",
+        options: { timeoutMs: 10 },
+        context: createContext([]),
+        policy: {
+          requestTimeoutMs: undefined,
+          retryCount: 0,
+          retryDelayMs: 1,
+          pollIntervalMs: 30000,
+          timeoutMs: 10,
+          maxConsecutivePollErrors: 3,
+        },
+        deferDeadlineUntilStarted: true,
+        start,
+        poll,
+      }).finally(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(15);
+      expect(settled).toBe(false);
+
+      const rejection = expect(promise).rejects.toThrow(
+        'Exa research exceeded 10ms. Resume the background job with options.resumeId="research-123".',
+      );
+      await vi.advanceTimersByTimeAsync(15);
+      await rejection;
+
+      expect(start).toHaveBeenCalledTimes(1);
+      expect(poll).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not attach resume advice to terminal research failures", async () => {
     await expect(
       executeResearchWithLifecycle({

--- a/test/execution-policy.test.ts
+++ b/test/execution-policy.test.ts
@@ -49,7 +49,7 @@ describe("execution policy", () => {
 
   it("retries transient failures in the parent execution wrapper", async () => {
     const operation = vi
-      .fn<() => Promise<string>>()
+      .fn<(context: ProviderContext) => Promise<string>>()
       .mockRejectedValueOnce(new Error("fetch failed"))
       .mockResolvedValueOnce("ok");
     const progress: string[] = [];
@@ -73,6 +73,95 @@ describe("execution policy", () => {
     expect(progress).toContain(
       "Gemini answer request failed (fetch failed). Retrying in 1ms (attempt 2/2).",
     );
+  });
+
+  it("does not retry timed out requests and aborts the attempt signal", async () => {
+    vi.useFakeTimers();
+
+    try {
+      let attemptSignal: AbortSignal | undefined;
+      const operation = vi.fn(async (context: ProviderContext) => {
+        attemptSignal = context.signal;
+        return await new Promise<string>(() => {});
+      });
+
+      const promise = runWithExecutionPolicy(
+        "Gemini answer request",
+        operation,
+        {
+          requestTimeoutMs: 10,
+          retryCount: 2,
+          retryDelayMs: 1,
+        },
+        {
+          cwd: process.cwd(),
+        },
+      );
+      const rejection = expect(promise).rejects.toThrow(
+        "Gemini answer request timed out after 10ms.",
+      );
+
+      await vi.advanceTimersByTimeAsync(10);
+      await rejection;
+
+      expect(operation).toHaveBeenCalledTimes(1);
+      expect(attemptSignal?.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not attach resume advice to terminal research failures", async () => {
+    await expect(
+      executeResearchWithLifecycle({
+        providerLabel: "Gemini",
+        providerId: "gemini",
+        input: "Investigate Tenzir use cases",
+        options: { resumeId: "research-123" },
+        context: createContext([]),
+        policy: {
+          requestTimeoutMs: undefined,
+          retryCount: 1,
+          retryDelayMs: 1,
+          pollIntervalMs: 1,
+          timeoutMs: 60000,
+          maxConsecutivePollErrors: 3,
+          resumeId: "research-123",
+        },
+        start: vi.fn(),
+        poll: vi.fn().mockResolvedValue({
+          status: "failed" as const,
+          error: "Gemini research failed.",
+        }),
+      }),
+    ).rejects.toThrow("Gemini research failed.");
+
+    await expect(
+      executeResearchWithLifecycle({
+        providerLabel: "Gemini",
+        providerId: "gemini",
+        input: "Investigate Tenzir use cases",
+        options: { resumeId: "research-123" },
+        context: createContext([]),
+        policy: {
+          requestTimeoutMs: undefined,
+          retryCount: 1,
+          retryDelayMs: 1,
+          pollIntervalMs: 1,
+          timeoutMs: 60000,
+          maxConsecutivePollErrors: 3,
+          resumeId: "research-123",
+        },
+        start: vi.fn(),
+        poll: vi.fn().mockResolvedValue({
+          status: "failed" as const,
+          error: "Gemini research failed.",
+        }),
+      }).catch((error) => {
+        expect((error as Error).message).not.toContain("options.resumeId");
+        throw error;
+      }),
+    ).rejects.toThrow("Gemini research failed.");
   });
 
   it("polls research jobs in the parent and supports resume ids", async () => {

--- a/test/execution-policy.test.ts
+++ b/test/execution-policy.test.ts
@@ -266,7 +266,7 @@ describe("execution policy", () => {
     }
   });
 
-  it("starts the overall research deadline after non-idempotent job creation", async () => {
+  it("applies the overall research deadline while a non-idempotent job is still starting", async () => {
     vi.useFakeTimers();
 
     try {
@@ -278,11 +278,8 @@ describe("execution policy", () => {
             }, 20);
           }),
       );
-      const poll = vi
-        .fn()
-        .mockResolvedValueOnce({ status: "in_progress" as const });
+      const poll = vi.fn();
 
-      let settled = false;
       const promise = executeResearchWithLifecycle({
         providerLabel: "Exa",
         providerId: "exa",
@@ -295,24 +292,18 @@ describe("execution policy", () => {
           timeoutMs: 10,
           maxConsecutivePollErrors: 3,
         },
-        deferDeadlineUntilStarted: true,
         start,
         poll,
-      }).finally(() => {
-        settled = true;
       });
 
-      await vi.advanceTimersByTimeAsync(15);
-      expect(settled).toBe(false);
-
       const rejection = expect(promise).rejects.toThrow(
-        'Exa research exceeded 10ms. Resume the background job with options.resumeId="research-123".',
+        "Exa research exceeded 10ms. The provider may still create a background job, but no job id was returned so this run cannot be resumed automatically.",
       );
-      await vi.advanceTimersByTimeAsync(15);
+      await vi.advanceTimersByTimeAsync(10);
       await rejection;
 
       expect(start).toHaveBeenCalledTimes(1);
-      expect(poll).toHaveBeenCalledTimes(1);
+      expect(poll).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }

--- a/test/execution-policy.test.ts
+++ b/test/execution-policy.test.ts
@@ -358,6 +358,30 @@ describe("execution policy", () => {
     ).rejects.toThrow("Gemini research failed.");
   });
 
+  it("does not attach resume advice to invalid resume ids", async () => {
+    await expect(
+      executeResearchWithLifecycle({
+        providerLabel: "Gemini",
+        providerId: "gemini",
+        context: createContext([]),
+        policy: {
+          requestTimeoutMs: undefined,
+          retryCount: 0,
+          retryDelayMs: 1,
+          pollIntervalMs: 1,
+          timeoutMs: 60000,
+          maxConsecutivePollErrors: 3,
+          resumeId: "missing-job",
+        },
+        start: vi.fn(),
+        poll: vi.fn().mockRejectedValue(new Error("404 not found")),
+      }).catch((error) => {
+        expect((error as Error).message).not.toContain("options.resumeId");
+        throw error;
+      }),
+    ).rejects.toThrow("404 not found");
+  });
+
   it("turns total research timeouts into resumable errors even while sleeping between polls", async () => {
     vi.useFakeTimers();
 

--- a/test/execution-policy.test.ts
+++ b/test/execution-policy.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  executeResearchWithLifecycle,
+  resolveRequestExecutionPolicy,
+  runWithExecutionPolicy,
+  stripLocalExecutionOptions,
+} from "../src/execution-policy.js";
+import type {
+  GeminiProviderConfig,
+  JsonObject,
+  ProviderContext,
+} from "../src/types.js";
+
+describe("execution policy", () => {
+  it("strips local execution control fields before calling providers", () => {
+    const options: JsonObject = {
+      model: "gemini-2.5-pro",
+      requestTimeoutMs: 45000,
+      retryCount: 4,
+      retryDelayMs: 3000,
+      pollIntervalMs: 5000,
+      timeoutMs: 7200000,
+      maxConsecutivePollErrors: 8,
+      resumeId: "job-1",
+    };
+
+    expect(stripLocalExecutionOptions(options)).toEqual({
+      model: "gemini-2.5-pro",
+    });
+  });
+
+  it("uses Gemini config defaults for parent-side request execution", () => {
+    const config: GeminiProviderConfig = {
+      enabled: true,
+      apiKey: "literal-key",
+      defaults: {
+        requestTimeoutMs: 45000,
+        retryCount: 5,
+        retryDelayMs: 4000,
+      },
+    };
+
+    expect(resolveRequestExecutionPolicy("gemini", config, undefined)).toEqual({
+      requestTimeoutMs: 45000,
+      retryCount: 5,
+      retryDelayMs: 4000,
+    });
+  });
+
+  it("retries transient failures in the parent execution wrapper", async () => {
+    const operation = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error("fetch failed"))
+      .mockResolvedValueOnce("ok");
+    const progress: string[] = [];
+
+    const result = await runWithExecutionPolicy(
+      "Gemini answer request",
+      operation,
+      {
+        requestTimeoutMs: undefined,
+        retryCount: 1,
+        retryDelayMs: 1,
+      },
+      {
+        cwd: process.cwd(),
+        onProgress: (message) => progress.push(message),
+      },
+    );
+
+    expect(result).toBe("ok");
+    expect(operation).toHaveBeenCalledTimes(2);
+    expect(progress).toContain(
+      "Gemini answer request failed (fetch failed). Retrying in 1ms (attempt 2/2).",
+    );
+  });
+
+  it("polls research jobs in the parent and supports resume ids", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const progress: string[] = [];
+      const poll = vi
+        .fn()
+        .mockResolvedValueOnce({ status: "in_progress" as const })
+        .mockResolvedValueOnce({
+          status: "completed" as const,
+          output: {
+            provider: "gemini" as const,
+            text: "done",
+            summary: "Research via Gemini",
+          },
+        });
+
+      const promise = executeResearchWithLifecycle({
+        providerLabel: "Gemini",
+        providerId: "gemini",
+        input: "ignored while resuming",
+        options: { resumeId: "research-123" },
+        context: createContext(progress),
+        policy: {
+          requestTimeoutMs: undefined,
+          retryCount: 0,
+          retryDelayMs: 1,
+          pollIntervalMs: 5000,
+          timeoutMs: 60000,
+          maxConsecutivePollErrors: 3,
+          resumeId: "research-123",
+        },
+        start: vi.fn(),
+        poll,
+      });
+
+      await vi.advanceTimersByTimeAsync(5000);
+      const result = await promise;
+
+      expect(result.text).toBe("done");
+      expect(poll).toHaveBeenCalledWith(
+        "research-123",
+        undefined,
+        expect.objectContaining({ cwd: process.cwd() }),
+      );
+      expect(progress).toContain("Resuming Gemini research: research-123");
+      expect(progress).toContain(
+        "Gemini research status: in_progress (0s elapsed)",
+      );
+      expect(progress).toContain(
+        "Gemini research status: completed (5s elapsed)",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+function createContext(progress: string[]): ProviderContext {
+  return {
+    cwd: process.cwd(),
+    onProgress: (message) => progress.push(message),
+  };
+}

--- a/test/execution-policy.test.ts
+++ b/test/execution-policy.test.ts
@@ -164,6 +164,93 @@ describe("execution policy", () => {
     ).rejects.toThrow("Gemini research failed.");
   });
 
+  it("turns total research timeouts into resumable errors even while sleeping between polls", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const poll = vi
+        .fn()
+        .mockResolvedValue({ status: "in_progress" as const });
+
+      const promise = executeResearchWithLifecycle({
+        providerLabel: "Gemini",
+        providerId: "gemini",
+        input: "ignored while resuming",
+        options: { resumeId: "research-123" },
+        context: createContext([]),
+        policy: {
+          requestTimeoutMs: undefined,
+          retryCount: 0,
+          retryDelayMs: 1,
+          pollIntervalMs: 30000,
+          timeoutMs: 10000,
+          maxConsecutivePollErrors: 3,
+          resumeId: "research-123",
+        },
+        start: vi.fn(),
+        poll,
+      });
+      const rejection = expect(promise).rejects.toThrow(
+        'Gemini research exceeded 10s. Resume the background job with options.resumeId="research-123".',
+      );
+
+      await vi.advanceTimersByTimeAsync(10000);
+      await rejection;
+      expect(poll).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("treats timed out poll requests as transient research poll failures", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const progress: string[] = [];
+      const poll = vi
+        .fn()
+        .mockImplementationOnce(() => new Promise<never>(() => {}))
+        .mockResolvedValueOnce({
+          status: "completed" as const,
+          output: {
+            provider: "gemini" as const,
+            text: "done",
+            summary: "Research via Gemini",
+          },
+        });
+
+      const promise = executeResearchWithLifecycle({
+        providerLabel: "Gemini",
+        providerId: "gemini",
+        input: "ignored while resuming",
+        options: { resumeId: "research-123" },
+        context: createContext(progress),
+        policy: {
+          requestTimeoutMs: 10,
+          retryCount: 0,
+          retryDelayMs: 1,
+          pollIntervalMs: 5,
+          timeoutMs: 60000,
+          maxConsecutivePollErrors: 3,
+          resumeId: "research-123",
+        },
+        start: vi.fn(),
+        poll,
+      });
+
+      await vi.advanceTimersByTimeAsync(20);
+      const result = await promise;
+
+      expect(result.text).toBe("done");
+      expect(poll).toHaveBeenCalledTimes(2);
+      expect(progress).toContain(
+        "Gemini research poll is still retrying after transient errors (1/3 consecutive poll failures). Background job id: research-123",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("polls research jobs in the parent and supports resume ids", async () => {
     vi.useFakeTimers();
 

--- a/test/gemini-provider.test.ts
+++ b/test/gemini-provider.test.ts
@@ -38,14 +38,17 @@ describe("GeminiProvider search", () => {
       createContext(),
     );
 
-    expect(create).toHaveBeenCalledWith({
-      model: "gemini-2.5-flash",
-      input: "example query",
-      tools: [{ type: "google_search" }],
-      generation_config: {
-        tool_choice: "any",
+    expect(create).toHaveBeenCalledWith(
+      {
+        model: "gemini-2.5-flash",
+        input: "example query",
+        tools: [{ type: "google_search" }],
+        generation_config: {
+          tool_choice: "any",
+        },
       },
-    });
+      undefined,
+    );
     expect(response.results).toEqual([
       {
         title: "Alpha",
@@ -140,19 +143,27 @@ describe("GeminiProvider search", () => {
     );
 
     expect(create).toHaveBeenCalledTimes(2);
-    expect(create).toHaveBeenNthCalledWith(1, {
-      model: "gemini-2.5-flash",
-      input: "fallback query",
-      tools: [{ type: "google_search" }],
-      generation_config: {
-        tool_choice: "any",
+    expect(create).toHaveBeenNthCalledWith(
+      1,
+      {
+        model: "gemini-2.5-flash",
+        input: "fallback query",
+        tools: [{ type: "google_search" }],
+        generation_config: {
+          tool_choice: "any",
+        },
       },
-    });
-    expect(create).toHaveBeenNthCalledWith(2, {
-      model: "gemini-2.5-flash",
-      input: "fallback query",
-      tools: [{ type: "google_search" }],
-    });
+      undefined,
+    );
+    expect(create).toHaveBeenNthCalledWith(
+      2,
+      {
+        model: "gemini-2.5-flash",
+        input: "fallback query",
+        tools: [{ type: "google_search" }],
+      },
+      undefined,
+    );
     expect(response.results).toEqual([
       {
         title: "Fallback",
@@ -236,15 +247,18 @@ describe("GeminiProvider search", () => {
       createContext(),
     );
 
-    expect(create).toHaveBeenCalledWith({
-      model: "gemini-2.5-pro",
-      input: "configured query",
-      tools: [{ type: "google_search" }],
-      generation_config: {
-        temperature: 0.1,
-        tool_choice: "any",
+    expect(create).toHaveBeenCalledWith(
+      {
+        model: "gemini-2.5-pro",
+        input: "configured query",
+        tools: [{ type: "google_search" }],
+        generation_config: {
+          temperature: 0.1,
+          tool_choice: "any",
+        },
       },
-    });
+      undefined,
+    );
   });
 });
 
@@ -599,21 +613,24 @@ describe("GeminiProvider research", () => {
     );
 
     expect(job).toEqual({ id: "research-1" });
-    expect(create).toHaveBeenCalledWith({
-      agent_config: {
-        response_length: "short",
+    expect(create).toHaveBeenCalledWith(
+      {
+        agent_config: {
+          response_length: "short",
+        },
+        store: true,
+        response_format: {
+          type: "json_schema",
+        },
+        response_modalities: ["TEXT"],
+        system_instruction: "Focus on official sources.",
+        tools: [{ urlContext: {} }],
+        input: "Investigate Tenzir use cases",
+        agent: "deep-research-pro-preview-12-2025",
+        background: true,
       },
-      store: true,
-      response_format: {
-        type: "json_schema",
-      },
-      response_modalities: ["TEXT"],
-      system_instruction: "Focus on official sources.",
-      tools: [{ urlContext: {} }],
-      input: "Investigate Tenzir use cases",
-      agent: "deep-research-pro-preview-12-2025",
-      background: true,
-    });
+      undefined,
+    );
   });
 
   it("returns in-progress Gemini research status from polling", async () => {
@@ -632,7 +649,7 @@ describe("GeminiProvider research", () => {
       createContext(),
     );
 
-    expect(get).toHaveBeenCalledWith("research-1");
+    expect(get).toHaveBeenCalledWith("research-1", undefined, undefined);
     expect(result).toEqual({ status: "in_progress" });
   });
 

--- a/test/gemini-provider.test.ts
+++ b/test/gemini-provider.test.ts
@@ -568,79 +568,16 @@ describe("GeminiProvider contents", () => {
 });
 
 describe("GeminiProvider research", () => {
-  it("emits elapsed-time heartbeats while research stays in progress", async () => {
-    vi.useFakeTimers();
-
-    try {
-      const get = vi
-        .fn()
-        .mockResolvedValueOnce({
-          status: "in_progress",
-        })
-        .mockResolvedValueOnce({
-          status: "in_progress",
-        })
-        .mockResolvedValueOnce({
-          status: "in_progress",
-        })
-        .mockResolvedValueOnce({
-          status: "in_progress",
-        })
-        .mockResolvedValueOnce({
-          status: "completed",
-          outputs: [{ type: "text", text: "Research result" }],
-        });
-
-      const provider = createProvider({
-        interactions: {
-          create: vi.fn().mockResolvedValue({ id: "research-1" }),
-          get,
-        },
-      });
-      const messages: string[] = [];
-
-      const promise = provider.research(
-        "Investigate Tenzir use cases",
-        { pollIntervalMs: 5000 },
-        createConfig(),
-        {
-          ...createContext(),
-          onProgress: (message) => messages.push(message),
-        },
-      );
-
-      await vi.advanceTimersByTimeAsync(20000);
-      const response = await promise;
-
-      expect(response.text).toBe("Research result");
-      expect(messages).toContain("Starting Gemini deep research");
-      expect(messages).toContain("Gemini research started: research-1");
-      expect(messages).toContain(
-        "Gemini research status: in_progress (0s elapsed)",
-      );
-      expect(messages).toContain(
-        "Gemini research status: completed (20s elapsed)",
-      );
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("forwards Gemini research request options and strips pollIntervalMs", async () => {
+  it("starts Gemini deep research and forwards provider-native request options", async () => {
     const create = vi.fn().mockResolvedValue({ id: "research-1" });
-    const get = vi.fn().mockResolvedValue({
-      status: "completed",
-      outputs: [{ type: "text", text: "Research result" }],
-    });
 
     const provider = createProvider({
       interactions: {
         create,
-        get,
       },
     });
 
-    await provider.research(
+    const job = await provider.startResearch!(
       "Investigate Tenzir use cases",
       {
         agent_config: {
@@ -652,16 +589,16 @@ describe("GeminiProvider research", () => {
         },
         response_modalities: ["TEXT"],
         system_instruction: "Focus on official sources.",
-        pollIntervalMs: 5000,
+        tools: [{ urlContext: {} }],
         agent: "override-agent",
         background: false,
         input: "override",
-        tools: [{ urlContext: {} }],
       },
       createConfig(),
       createContext(),
     );
 
+    expect(job).toEqual({ id: "research-1" });
     expect(create).toHaveBeenCalledWith({
       agent_config: {
         response_length: "short",
@@ -676,6 +613,77 @@ describe("GeminiProvider research", () => {
       input: "Investigate Tenzir use cases",
       agent: "deep-research-pro-preview-12-2025",
       background: true,
+    });
+  });
+
+  it("returns in-progress Gemini research status from polling", async () => {
+    const get = vi.fn().mockResolvedValue({ status: "in_progress" });
+
+    const provider = createProvider({
+      interactions: {
+        get,
+      },
+    });
+
+    const result = await provider.pollResearch!(
+      "research-1",
+      undefined,
+      createConfig(),
+      createContext(),
+    );
+
+    expect(get).toHaveBeenCalledWith("research-1");
+    expect(result).toEqual({ status: "in_progress" });
+  });
+
+  it("formats completed Gemini research output from polling", async () => {
+    const get = vi.fn().mockResolvedValue({
+      status: "completed",
+      outputs: [{ type: "text", text: "Research result" }],
+    });
+
+    const provider = createProvider({
+      interactions: {
+        get,
+      },
+    });
+
+    const result = await provider.pollResearch!(
+      "research-1",
+      undefined,
+      createConfig(),
+      createContext(),
+    );
+
+    expect(result).toEqual({
+      status: "completed",
+      output: {
+        provider: "gemini",
+        text: "Research result",
+        summary: "Research via Gemini",
+      },
+    });
+  });
+
+  it("maps failed Gemini research polling to a terminal status", async () => {
+    const get = vi.fn().mockResolvedValue({ status: "failed" });
+
+    const provider = createProvider({
+      interactions: {
+        get,
+      },
+    });
+
+    const result = await provider.pollResearch!(
+      "research-1",
+      undefined,
+      createConfig(),
+      createContext(),
+    );
+
+    expect(result).toEqual({
+      status: "failed",
+      error: "Gemini research failed.",
     });
   });
 });

--- a/test/gemini-provider.test.ts
+++ b/test/gemini-provider.test.ts
@@ -609,7 +609,7 @@ describe("GeminiProvider research", () => {
         input: "override",
       },
       createConfig(),
-      createContext(),
+      { ...createContext(), idempotencyKey: "stable-key" },
     );
 
     expect(job).toEqual({ id: "research-1" });
@@ -629,7 +629,7 @@ describe("GeminiProvider research", () => {
         agent: "deep-research-pro-preview-12-2025",
         background: true,
       },
-      undefined,
+      { idempotencyKey: "stable-key" },
     );
   });
 

--- a/test/perplexity-provider.test.ts
+++ b/test/perplexity-provider.test.ts
@@ -143,18 +143,41 @@ describe("PerplexityProvider", () => {
     expect(response.itemCount).toBe(1);
   });
 
-  it("defaults research calls to sonar-deep-research", async () => {
+  it("streams research calls with sonar-deep-research", async () => {
     process.env.PERPLEXITY_API_KEY = "test-key";
+    const progress: string[] = [];
     chatCreateMock.mockResolvedValue({
-      choices: [
-        {
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "Research result" }],
-          },
-        },
-      ],
-      citations: ["https://example.com/research"],
+      async *[Symbol.asyncIterator]() {
+        yield {
+          choices: [
+            {
+              delta: {
+                role: "assistant",
+                content: "Research ",
+              },
+              message: {
+                role: "assistant",
+                content: null,
+              },
+            },
+          ],
+        };
+        yield {
+          choices: [
+            {
+              delta: {
+                role: "assistant",
+                content: "result",
+              },
+              message: {
+                role: "assistant",
+                content: [{ type: "text", text: "Research result" }],
+              },
+            },
+          ],
+          citations: ["https://example.com/research"],
+        };
+      },
     });
 
     const provider = new PerplexityProvider();
@@ -165,17 +188,22 @@ describe("PerplexityProvider", () => {
         enabled: true,
         apiKey: "PERPLEXITY_API_KEY",
       },
-      { cwd: process.cwd() },
+      {
+        cwd: process.cwd(),
+        onProgress: (message) => progress.push(message),
+      },
     );
 
     expect(chatCreateMock).toHaveBeenCalledWith(
       {
         messages: [{ role: "user", content: "Investigate the topic" }],
         model: "sonar-deep-research",
-        stream: false,
+        stream: true,
       },
       undefined,
     );
+    expect(progress).toContain("Research");
+    expect(progress).toContain("Research result");
     expect(response.text).toBe(
       "Research result\n\nSources:\n1. https://example.com/research\n   https://example.com/research",
     );

--- a/test/provider-resolution.test.ts
+++ b/test/provider-resolution.test.ts
@@ -218,6 +218,31 @@ describe("provider resolution", () => {
     );
     expect(provider.id).toBe("parallel");
   });
+
+  it("treats Perplexity research as an explicit blocking-provider exception", () => {
+    process.env.PERPLEXITY_API_KEY = "test-key";
+
+    const config: WebProvidersConfig = {
+      version: 1,
+      providers: {
+        perplexity: {
+          enabled: true,
+          apiKey: "PERPLEXITY_API_KEY",
+          tools: {
+            research: true,
+          },
+        },
+      },
+    };
+
+    const provider = resolveProviderForCapability(
+      config,
+      undefined,
+      process.cwd(),
+      "research",
+    );
+    expect(provider.id).toBe("perplexity");
+  });
 });
 
 function mockClaudeAvailable(): void {

--- a/test/provider-tool-output.test.ts
+++ b/test/provider-tool-output.test.ts
@@ -152,7 +152,7 @@ describe("provider tool output", () => {
     );
   });
 
-  it("does not inherit short request timeouts for streaming foreground plans", async () => {
+  it("inherits request timeouts for streaming foreground plans that declare support", async () => {
     vi.useFakeTimers();
 
     try {
@@ -181,6 +181,15 @@ describe("provider tool output", () => {
           providerLabel: "Perplexity",
           deliveryMode: "streaming-foreground",
           traits: {
+            executionSupport: {
+              requestTimeoutMs: true,
+              retryCount: true,
+              retryDelayMs: true,
+              pollIntervalMs: false,
+              timeoutMs: false,
+              maxConsecutivePollErrors: false,
+              resumeId: false,
+            },
             policyDefaults: {
               requestTimeoutMs: 1,
               retryCount: 0,
@@ -198,11 +207,12 @@ describe("provider tool output", () => {
             }),
         },
       });
+      const rejection = expect(resultPromise).rejects.toThrow(
+        "Perplexity research request timed out after 1ms.",
+      );
 
-      await vi.advanceTimersByTimeAsync(5);
-      await expect(resultPromise).resolves.toMatchObject({
-        content: [{ type: "text", text: "Research complete" }],
-      });
+      await vi.advanceTimersByTimeAsync(1);
+      await rejection;
     } finally {
       vi.useRealTimers();
     }
@@ -325,6 +335,21 @@ describe("provider tool output", () => {
       }),
     ).rejects.toThrow(
       "Exa contents does not support timeoutMs, resumeId. These controls only apply to web_research. Use requestTimeoutMs/retryCount/retryDelayMs instead.",
+    );
+  });
+
+  it("describes supported local execution controls in tool option help", () => {
+    expect(__test__.describeOptionsField("contents", ["exa"])).toBe(
+      "Provider-specific extraction options. Local execution controls: requestTimeoutMs, retryCount, retryDelayMs.",
+    );
+    expect(
+      __test__.describeOptionsField("research", [
+        "perplexity",
+        "exa",
+        "gemini",
+      ]),
+    ).toBe(
+      "Provider-specific research options. Depending on provider, local execution controls may include: requestTimeoutMs, retryCount, retryDelayMs, pollIntervalMs, timeoutMs, maxConsecutivePollErrors, resumeId.",
     );
   });
 

--- a/test/provider-tool-output.test.ts
+++ b/test/provider-tool-output.test.ts
@@ -35,15 +35,22 @@ describe("provider tool output", () => {
       signal: undefined,
       onUpdate: undefined,
       options: undefined,
-      invoke: async () => ({
-        provider: "exa",
-        text: Array.from(
-          { length: 2500 },
-          (_, index) => `line ${index + 1}: ${"x".repeat(40)}`,
-        ).join("\n"),
-        summary: "Large contents via Exa",
-        itemCount: 2500,
-      }),
+      urls: ["https://example.com"],
+      planOverride: {
+        capability: "contents",
+        providerId: "exa",
+        providerLabel: "Exa",
+        mode: "single",
+        execute: async () => ({
+          provider: "exa",
+          text: Array.from(
+            { length: 2500 },
+            (_, index) => `line ${index + 1}: ${"x".repeat(40)}`,
+          ).join("\n"),
+          summary: "Large contents via Exa",
+          itemCount: 2500,
+        }),
+      },
     });
 
     const text = result.content[0]?.text ?? "";
@@ -85,19 +92,20 @@ describe("provider tool output", () => {
         },
         options: undefined,
         input: "Investigate the topic",
-        invoke: async (
-          _provider,
-          _providerConfig,
-          _providerOptions,
-          context,
-        ) => {
-          context.onProgress?.("Starting research");
-          await new Promise((resolve) => setTimeout(resolve, 20000));
-          return {
-            provider: "perplexity",
-            text: "Research complete",
-            summary: "Research via Perplexity",
-          };
+        planOverride: {
+          capability: "research",
+          providerId: "perplexity",
+          providerLabel: "Perplexity",
+          mode: "single",
+          execute: async (context) => {
+            context.onProgress?.("Starting research");
+            await new Promise((resolve) => setTimeout(resolve, 20000));
+            return {
+              provider: "perplexity",
+              text: "Research complete",
+              summary: "Research via Perplexity",
+            };
+          },
         },
       });
 
@@ -138,10 +146,6 @@ describe("provider tool output", () => {
           timeoutMs: 60000,
         },
         input: "Investigate the topic",
-        invoke: async () => ({
-          provider: "perplexity",
-          text: "done",
-        }),
       }),
     ).rejects.toThrow(
       "Perplexity research runs synchronously and does not support timeoutMs, resumeId. Use requestTimeoutMs/retryCount/retryDelayMs instead.",
@@ -171,10 +175,6 @@ describe("provider tool output", () => {
           resumeInteractionId: "job-1",
         },
         input: "Investigate the topic",
-        invoke: async () => ({
-          provider: "gemini",
-          text: "done",
-        }),
       }),
     ).rejects.toThrow(
       "resumeInteractionId is not supported. Use resumeId instead.",

--- a/test/provider-tool-output.test.ts
+++ b/test/provider-tool-output.test.ts
@@ -152,6 +152,126 @@ describe("provider tool output", () => {
     );
   });
 
+  it("rejects requestTimeoutMs for research providers that cannot safely enforce it", async () => {
+    const config: WebProvidersConfig = {
+      version: 1,
+      providers: {
+        exa: {
+          enabled: true,
+          apiKey: "literal-key",
+        },
+      },
+    };
+
+    await expect(
+      __test__.executeProviderTool({
+        capability: "research",
+        config,
+        explicitProvider: "exa",
+        ctx: { cwd: process.cwd() },
+        signal: undefined,
+        onUpdate: undefined,
+        options: {
+          requestTimeoutMs: 1000,
+        },
+        input: "Investigate the topic",
+        planOverride: {
+          capability: "research",
+          providerId: "exa",
+          providerLabel: "Exa",
+          mode: "job",
+          start: async () => ({ id: "job-1" }),
+          poll: async () => ({
+            status: "completed",
+            output: {
+              provider: "exa",
+              text: "done",
+            },
+          }),
+        },
+      }),
+    ).rejects.toThrow(
+      "Exa research does not support requestTimeoutMs. Use retryCount/retryDelayMs/pollIntervalMs/timeoutMs/maxConsecutivePollErrors/resumeId instead.",
+    );
+  });
+
+  it("rejects malformed local execution control fields", async () => {
+    const config: WebProvidersConfig = {
+      version: 1,
+      providers: {
+        exa: {
+          enabled: true,
+          apiKey: "literal-key",
+        },
+      },
+    };
+
+    await expect(
+      __test__.executeProviderTool({
+        capability: "contents",
+        config,
+        explicitProvider: "exa",
+        ctx: { cwd: process.cwd() },
+        signal: undefined,
+        onUpdate: undefined,
+        options: {
+          requestTimeoutMs: "1000" as never,
+        },
+        urls: ["https://example.com"],
+        planOverride: {
+          capability: "contents",
+          providerId: "exa",
+          providerLabel: "Exa",
+          mode: "single",
+          execute: async () => ({
+            provider: "exa",
+            text: "contents",
+          }),
+        },
+      }),
+    ).rejects.toThrow("options.requestTimeoutMs must be a positive integer.");
+  });
+
+  it("rejects research-only execution controls on non-research tools", async () => {
+    const config: WebProvidersConfig = {
+      version: 1,
+      providers: {
+        exa: {
+          enabled: true,
+          apiKey: "literal-key",
+        },
+      },
+    };
+
+    await expect(
+      __test__.executeProviderTool({
+        capability: "contents",
+        config,
+        explicitProvider: "exa",
+        ctx: { cwd: process.cwd() },
+        signal: undefined,
+        onUpdate: undefined,
+        options: {
+          timeoutMs: 1000,
+          resumeId: "job-1",
+        },
+        urls: ["https://example.com"],
+        planOverride: {
+          capability: "contents",
+          providerId: "exa",
+          providerLabel: "Exa",
+          mode: "single",
+          execute: async () => ({
+            provider: "exa",
+            text: "contents",
+          }),
+        },
+      }),
+    ).rejects.toThrow(
+      "Exa contents does not support timeoutMs, resumeId. These controls only apply to web_research. Use requestTimeoutMs/retryCount/retryDelayMs instead.",
+    );
+  });
+
   it("rejects removed resumeInteractionId compatibility for research", async () => {
     const config: WebProvidersConfig = {
       version: 1,

--- a/test/provider-tool-output.test.ts
+++ b/test/provider-tool-output.test.ts
@@ -56,14 +56,14 @@ describe("provider tool output", () => {
     }
   });
 
-  it("emits heartbeat updates for long-running research tools", async () => {
+  it("emits heartbeat updates for long-running blocking research tools", async () => {
     vi.useFakeTimers();
 
     try {
       const config: WebProvidersConfig = {
         version: 1,
         providers: {
-          gemini: {
+          perplexity: {
             enabled: true,
             apiKey: "literal-key",
           },
@@ -74,7 +74,7 @@ describe("provider tool output", () => {
       const resultPromise = __test__.executeProviderTool({
         capability: "research",
         config,
-        explicitProvider: "gemini",
+        explicitProvider: "perplexity",
         ctx: { cwd: process.cwd() },
         signal: undefined,
         onUpdate: (update) => {
@@ -84,7 +84,7 @@ describe("provider tool output", () => {
           }
         },
         options: undefined,
-        useProviderLifecycle: false,
+        input: "Investigate the topic",
         invoke: async (
           _provider,
           _providerConfig,
@@ -94,9 +94,9 @@ describe("provider tool output", () => {
           context.onProgress?.("Starting research");
           await new Promise((resolve) => setTimeout(resolve, 20000));
           return {
-            provider: "gemini",
+            provider: "perplexity",
             text: "Research complete",
-            summary: "Research via Gemini",
+            summary: "Research via Perplexity",
           };
         },
       });
@@ -107,10 +107,77 @@ describe("provider tool output", () => {
       expect(result.content[0]?.text).toBe("Research complete");
       expect(updates).toContain("Starting research");
       expect(updates).toContain(
-        "web_research still running via gemini (15s elapsed)",
+        "web_research still running via perplexity (15s elapsed)",
       );
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("rejects lifecycle-only options for blocking Perplexity research", async () => {
+    const config: WebProvidersConfig = {
+      version: 1,
+      providers: {
+        perplexity: {
+          enabled: true,
+          apiKey: "literal-key",
+        },
+      },
+    };
+
+    await expect(
+      __test__.executeProviderTool({
+        capability: "research",
+        config,
+        explicitProvider: "perplexity",
+        ctx: { cwd: process.cwd() },
+        signal: undefined,
+        onUpdate: undefined,
+        options: {
+          resumeId: "job-1",
+          timeoutMs: 60000,
+        },
+        input: "Investigate the topic",
+        invoke: async () => ({
+          provider: "perplexity",
+          text: "done",
+        }),
+      }),
+    ).rejects.toThrow(
+      "Perplexity research runs synchronously and does not support timeoutMs, resumeId. Use requestTimeoutMs/retryCount/retryDelayMs instead.",
+    );
+  });
+
+  it("rejects removed resumeInteractionId compatibility for research", async () => {
+    const config: WebProvidersConfig = {
+      version: 1,
+      providers: {
+        gemini: {
+          enabled: true,
+          apiKey: "literal-key",
+        },
+      },
+    };
+
+    await expect(
+      __test__.executeProviderTool({
+        capability: "research",
+        config,
+        explicitProvider: "gemini",
+        ctx: { cwd: process.cwd() },
+        signal: undefined,
+        onUpdate: undefined,
+        options: {
+          resumeInteractionId: "job-1",
+        },
+        input: "Investigate the topic",
+        invoke: async () => ({
+          provider: "gemini",
+          text: "done",
+        }),
+      }),
+    ).rejects.toThrow(
+      "resumeInteractionId is not supported. Use resumeId instead.",
+    );
   });
 });

--- a/test/provider-tool-output.test.ts
+++ b/test/provider-tool-output.test.ts
@@ -34,6 +34,7 @@ describe("provider tool output", () => {
       ctx: { cwd: process.cwd() },
       signal: undefined,
       onUpdate: undefined,
+      options: undefined,
       invoke: async () => ({
         provider: "exa",
         text: Array.from(
@@ -82,7 +83,14 @@ describe("provider tool output", () => {
             updates.push(text);
           }
         },
-        invoke: async (_provider, _providerConfig, context) => {
+        options: undefined,
+        useProviderLifecycle: false,
+        invoke: async (
+          _provider,
+          _providerConfig,
+          _providerOptions,
+          context,
+        ) => {
           context.onProgress?.("Starting research");
           await new Promise((resolve) => setTimeout(resolve, 20000));
           return {

--- a/test/provider-tool-output.test.ts
+++ b/test/provider-tool-output.test.ts
@@ -40,7 +40,7 @@ describe("provider tool output", () => {
         capability: "contents",
         providerId: "exa",
         providerLabel: "Exa",
-        mode: "single",
+        deliveryMode: "silent-foreground",
         execute: async () => ({
           provider: "exa",
           text: Array.from(
@@ -63,7 +63,7 @@ describe("provider tool output", () => {
     }
   });
 
-  it("emits heartbeat updates for long-running blocking research tools", async () => {
+  it("emits heartbeat updates for long-running foreground research tools", async () => {
     vi.useFakeTimers();
 
     try {
@@ -96,7 +96,7 @@ describe("provider tool output", () => {
           capability: "research",
           providerId: "perplexity",
           providerLabel: "Perplexity",
-          mode: "single",
+          deliveryMode: "streaming-foreground",
           execute: async (context) => {
             context.onProgress?.("Starting research");
             await new Promise((resolve) => setTimeout(resolve, 20000));
@@ -122,7 +122,7 @@ describe("provider tool output", () => {
     }
   });
 
-  it("rejects lifecycle-only options for blocking Perplexity research", async () => {
+  it("rejects lifecycle-only options for streaming foreground Perplexity research", async () => {
     const config: WebProvidersConfig = {
       version: 1,
       providers: {
@@ -148,8 +148,64 @@ describe("provider tool output", () => {
         input: "Investigate the topic",
       }),
     ).rejects.toThrow(
-      "Perplexity research runs synchronously and does not support timeoutMs, resumeId. Use requestTimeoutMs/retryCount/retryDelayMs instead.",
+      "Perplexity research runs in streaming foreground mode and does not support timeoutMs, resumeId. Use requestTimeoutMs/retryCount/retryDelayMs instead.",
     );
+  });
+
+  it("does not inherit short request timeouts for streaming foreground plans", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const config: WebProvidersConfig = {
+        version: 1,
+        providers: {
+          perplexity: {
+            enabled: true,
+            apiKey: "literal-key",
+          },
+        },
+      };
+
+      const resultPromise = __test__.executeProviderTool({
+        capability: "research",
+        config,
+        explicitProvider: "perplexity",
+        ctx: { cwd: process.cwd() },
+        signal: undefined,
+        onUpdate: undefined,
+        options: undefined,
+        input: "Investigate the topic",
+        planOverride: {
+          capability: "research",
+          providerId: "perplexity",
+          providerLabel: "Perplexity",
+          deliveryMode: "streaming-foreground",
+          traits: {
+            policyDefaults: {
+              requestTimeoutMs: 1,
+              retryCount: 0,
+              retryDelayMs: 1,
+            },
+          },
+          execute: async () =>
+            await new Promise((resolve) => {
+              setTimeout(() => {
+                resolve({
+                  provider: "perplexity" as const,
+                  text: "Research complete",
+                });
+              }, 5);
+            }),
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(5);
+      await expect(resultPromise).resolves.toMatchObject({
+        content: [{ type: "text", text: "Research complete" }],
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("rejects requestTimeoutMs for research providers that cannot safely enforce it", async () => {
@@ -179,7 +235,7 @@ describe("provider tool output", () => {
           capability: "research",
           providerId: "exa",
           providerLabel: "Exa",
-          mode: "job",
+          deliveryMode: "background-research",
           start: async () => ({ id: "job-1" }),
           poll: async () => ({
             status: "completed",
@@ -222,7 +278,7 @@ describe("provider tool output", () => {
           capability: "contents",
           providerId: "exa",
           providerLabel: "Exa",
-          mode: "single",
+          deliveryMode: "silent-foreground",
           execute: async () => ({
             provider: "exa",
             text: "contents",
@@ -260,7 +316,7 @@ describe("provider tool output", () => {
           capability: "contents",
           providerId: "exa",
           providerLabel: "Exa",
-          mode: "single",
+          deliveryMode: "silent-foreground",
           execute: async () => ({
             provider: "exa",
             text: "contents",

--- a/test/research-lifecycle-providers.test.ts
+++ b/test/research-lifecycle-providers.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const {
+  exaCtorMock,
+  exaResearchCreateMock,
+  exaResearchGetMock,
+  valyuCtorMock,
+  valyuDeepResearchCreateMock,
+  valyuDeepResearchStatusMock,
+} = vi.hoisted(() => ({
+  exaCtorMock: vi.fn(),
+  exaResearchCreateMock: vi.fn(),
+  exaResearchGetMock: vi.fn(),
+  valyuCtorMock: vi.fn(),
+  valyuDeepResearchCreateMock: vi.fn(),
+  valyuDeepResearchStatusMock: vi.fn(),
+}));
+
+vi.mock("exa-js", () => ({
+  Exa: exaCtorMock.mockImplementation(function MockExa() {
+    return {
+      research: {
+        create: exaResearchCreateMock,
+        get: exaResearchGetMock,
+      },
+    };
+  }),
+}));
+
+vi.mock("valyu-js", () => ({
+  Valyu: valyuCtorMock.mockImplementation(function MockValyu() {
+    return {
+      deepresearch: {
+        create: valyuDeepResearchCreateMock,
+        status: valyuDeepResearchStatusMock,
+      },
+    };
+  }),
+}));
+
+import { __test__ } from "../src/index.js";
+import type { WebProvidersConfig } from "../src/types.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+  exaCtorMock.mockClear();
+  exaResearchCreateMock.mockReset();
+  exaResearchGetMock.mockReset();
+  valyuCtorMock.mockClear();
+  valyuDeepResearchCreateMock.mockReset();
+  valyuDeepResearchStatusMock.mockReset();
+});
+
+describe("research lifecycle providers", () => {
+  it("uses Exa lifecycle polling so transient poll errors do not create duplicate jobs", async () => {
+    vi.useFakeTimers();
+
+    exaResearchCreateMock.mockResolvedValue({ researchId: "exa-job-1" });
+    exaResearchGetMock
+      .mockRejectedValueOnce(new Error("fetch failed"))
+      .mockResolvedValueOnce({
+        status: "completed",
+        output: {
+          content: "Exa research result",
+        },
+      });
+
+    const invoke = vi.fn(async () => {
+      throw new Error("generic invoke should not run");
+    });
+
+    const promise = __test__.executeProviderTool({
+      capability: "research",
+      config: {
+        version: 1,
+        providers: {
+          exa: {
+            enabled: true,
+            apiKey: "literal-key",
+          },
+        },
+      } satisfies WebProvidersConfig,
+      explicitProvider: "exa",
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: { pollIntervalMs: 1 },
+      input: "Investigate Exa lifecycle polling",
+      invoke,
+    });
+
+    await vi.advanceTimersByTimeAsync(1);
+    const result = await promise;
+
+    expect(invoke).not.toHaveBeenCalled();
+    expect(exaCtorMock).toHaveBeenCalledWith("literal-key", undefined);
+    expect(exaResearchCreateMock).toHaveBeenCalledTimes(1);
+    expect(exaResearchGetMock).toHaveBeenCalledTimes(2);
+    expect(exaResearchGetMock).toHaveBeenNthCalledWith(1, "exa-job-1", {
+      events: false,
+    });
+    expect(result.content[0]?.text).toBe("Exa research result");
+  });
+
+  it("uses Valyu lifecycle polling so transient poll errors do not create duplicate jobs", async () => {
+    vi.useFakeTimers();
+
+    valyuDeepResearchCreateMock.mockResolvedValue({
+      success: true,
+      deepresearch_id: "valyu-job-1",
+    });
+    valyuDeepResearchStatusMock
+      .mockResolvedValueOnce({
+        success: false,
+        error: "fetch failed",
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        status: "completed",
+        output: "Valyu research result",
+        sources: [
+          {
+            title: "Source A",
+            url: "https://example.com/a",
+          },
+        ],
+      });
+
+    const invoke = vi.fn(async () => {
+      throw new Error("generic invoke should not run");
+    });
+
+    const promise = __test__.executeProviderTool({
+      capability: "research",
+      config: {
+        version: 1,
+        providers: {
+          valyu: {
+            enabled: true,
+            apiKey: "literal-key",
+          },
+        },
+      } satisfies WebProvidersConfig,
+      explicitProvider: "valyu",
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: { pollIntervalMs: 1 },
+      input: "Investigate Valyu lifecycle polling",
+      invoke,
+    });
+
+    await vi.advanceTimersByTimeAsync(1);
+    const result = await promise;
+
+    expect(invoke).not.toHaveBeenCalled();
+    expect(valyuCtorMock).toHaveBeenCalledWith("literal-key", undefined);
+    expect(valyuDeepResearchCreateMock).toHaveBeenCalledTimes(1);
+    expect(valyuDeepResearchStatusMock).toHaveBeenCalledTimes(2);
+    expect(valyuDeepResearchStatusMock).toHaveBeenNthCalledWith(
+      1,
+      "valyu-job-1",
+    );
+    expect(result.content[0]?.text).toBe(
+      "Valyu research result\n\nSources:\n1. Source A\n   https://example.com/a",
+    );
+  });
+});

--- a/test/research-lifecycle-providers.test.ts
+++ b/test/research-lifecycle-providers.test.ts
@@ -148,6 +148,46 @@ describe("research lifecycle providers", () => {
     expect(result.content[0]?.text).toBe("Exa research result");
   });
 
+  it("applies the overall research timeout while Exa job creation is still pending", async () => {
+    vi.useFakeTimers();
+
+    exaResearchCreateMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({ researchId: "exa-job-1" });
+          }, 5);
+        }),
+    );
+
+    const promise = __test__.executeProviderTool({
+      capability: "research",
+      config: {
+        version: 1,
+        providers: {
+          exa: {
+            enabled: true,
+            apiKey: "literal-key",
+          },
+        },
+      } satisfies WebProvidersConfig,
+      explicitProvider: "exa",
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: { timeoutMs: 1 },
+      input: "Investigate Exa lifecycle polling",
+    });
+    const rejection = expect(promise).rejects.toThrow(
+      "Exa research exceeded 1ms. The provider may still create a background job, but no job id was returned so this run cannot be resumed automatically.",
+    );
+
+    await vi.advanceTimersByTimeAsync(1);
+    await rejection;
+    expect(exaResearchCreateMock).toHaveBeenCalledTimes(1);
+    expect(exaResearchGetMock).not.toHaveBeenCalled();
+  });
+
   it("filters unsupported request timeout defaults from uncancellable Exa polls", async () => {
     vi.useFakeTimers();
 

--- a/test/research-lifecycle-providers.test.ts
+++ b/test/research-lifecycle-providers.test.ts
@@ -102,6 +102,59 @@ describe("research lifecycle providers", () => {
     expect(result.content[0]?.text).toBe("Exa research result");
   });
 
+  it("does not locally time out uncancellable Exa poll requests", async () => {
+    vi.useFakeTimers();
+
+    exaResearchCreateMock.mockResolvedValue({ researchId: "exa-job-1" });
+    exaResearchGetMock
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(() => {
+              resolve({ status: "running" });
+            }, 5);
+          }),
+      )
+      .mockResolvedValueOnce({
+        status: "completed",
+        output: {
+          content: "Exa research result",
+        },
+      });
+
+    const promise = __test__.executeProviderTool({
+      capability: "research",
+      config: {
+        version: 1,
+        providers: {
+          exa: {
+            enabled: true,
+            apiKey: "literal-key",
+          },
+        },
+      } satisfies WebProvidersConfig,
+      explicitProvider: "exa",
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: { requestTimeoutMs: 1, pollIntervalMs: 1 },
+      input: "Investigate Exa lifecycle polling",
+      invoke: async () => {
+        throw new Error("generic invoke should not run");
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(4);
+    expect(exaResearchGetMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(2);
+    const result = await promise;
+
+    expect(exaResearchCreateMock).toHaveBeenCalledTimes(1);
+    expect(exaResearchGetMock).toHaveBeenCalledTimes(2);
+    expect(result.content[0]?.text).toBe("Exa research result");
+  });
+
   it("uses Valyu lifecycle polling so transient poll errors do not create duplicate jobs", async () => {
     vi.useFakeTimers();
 

--- a/test/research-lifecycle-providers.test.ts
+++ b/test/research-lifecycle-providers.test.ts
@@ -102,6 +102,58 @@ describe("research lifecycle providers", () => {
     expect(result.content[0]?.text).toBe("Exa research result");
   });
 
+  it("does not locally time out non-idempotent Exa research starts", async () => {
+    vi.useFakeTimers();
+
+    exaResearchCreateMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({ researchId: "exa-job-1" });
+          }, 5);
+        }),
+    );
+    exaResearchGetMock.mockResolvedValueOnce({
+      status: "completed",
+      output: {
+        content: "Exa research result",
+      },
+    });
+
+    const promise = __test__.executeProviderTool({
+      capability: "research",
+      config: {
+        version: 1,
+        providers: {
+          exa: {
+            enabled: true,
+            apiKey: "literal-key",
+          },
+        },
+      } satisfies WebProvidersConfig,
+      explicitProvider: "exa",
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: { requestTimeoutMs: 1, pollIntervalMs: 1 },
+      input: "Investigate Exa lifecycle polling",
+      invoke: async () => {
+        throw new Error("generic invoke should not run");
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(4);
+    expect(exaResearchCreateMock).toHaveBeenCalledTimes(1);
+    expect(exaResearchGetMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(2);
+    const result = await promise;
+
+    expect(exaResearchCreateMock).toHaveBeenCalledTimes(1);
+    expect(exaResearchGetMock).toHaveBeenCalledTimes(1);
+    expect(result.content[0]?.text).toBe("Exa research result");
+  });
+
   it("does not locally time out uncancellable Exa poll requests", async () => {
     vi.useFakeTimers();
 

--- a/test/research-lifecycle-providers.test.ts
+++ b/test/research-lifecycle-providers.test.ts
@@ -65,10 +65,6 @@ describe("research lifecycle providers", () => {
         },
       });
 
-    const invoke = vi.fn(async () => {
-      throw new Error("generic invoke should not run");
-    });
-
     const promise = __test__.executeProviderTool({
       capability: "research",
       config: {
@@ -86,13 +82,11 @@ describe("research lifecycle providers", () => {
       onUpdate: undefined,
       options: { pollIntervalMs: 1 },
       input: "Investigate Exa lifecycle polling",
-      invoke,
     });
 
     await vi.advanceTimersByTimeAsync(1);
     const result = await promise;
 
-    expect(invoke).not.toHaveBeenCalled();
     expect(exaCtorMock).toHaveBeenCalledWith("literal-key", undefined);
     expect(exaResearchCreateMock).toHaveBeenCalledTimes(1);
     expect(exaResearchGetMock).toHaveBeenCalledTimes(2);
@@ -137,9 +131,6 @@ describe("research lifecycle providers", () => {
       onUpdate: undefined,
       options: { requestTimeoutMs: 1, pollIntervalMs: 1 },
       input: "Investigate Exa lifecycle polling",
-      invoke: async () => {
-        throw new Error("generic invoke should not run");
-      },
     });
 
     await vi.advanceTimersByTimeAsync(4);
@@ -191,9 +182,6 @@ describe("research lifecycle providers", () => {
       onUpdate: undefined,
       options: { requestTimeoutMs: 1, pollIntervalMs: 1 },
       input: "Investigate Exa lifecycle polling",
-      invoke: async () => {
-        throw new Error("generic invoke should not run");
-      },
     });
 
     await vi.advanceTimersByTimeAsync(4);
@@ -231,10 +219,6 @@ describe("research lifecycle providers", () => {
         ],
       });
 
-    const invoke = vi.fn(async () => {
-      throw new Error("generic invoke should not run");
-    });
-
     const promise = __test__.executeProviderTool({
       capability: "research",
       config: {
@@ -252,13 +236,11 @@ describe("research lifecycle providers", () => {
       onUpdate: undefined,
       options: { pollIntervalMs: 1 },
       input: "Investigate Valyu lifecycle polling",
-      invoke,
     });
 
     await vi.advanceTimersByTimeAsync(1);
     const result = await promise;
 
-    expect(invoke).not.toHaveBeenCalled();
     expect(valyuCtorMock).toHaveBeenCalledWith("literal-key", undefined);
     expect(valyuDeepResearchCreateMock).toHaveBeenCalledTimes(1);
     expect(valyuDeepResearchStatusMock).toHaveBeenCalledTimes(2);

--- a/test/research-lifecycle-providers.test.ts
+++ b/test/research-lifecycle-providers.test.ts
@@ -96,7 +96,7 @@ describe("research lifecycle providers", () => {
     expect(result.content[0]?.text).toBe("Exa research result");
   });
 
-  it("does not locally time out non-idempotent Exa research starts", async () => {
+  it("filters unsupported request timeout defaults from non-idempotent Exa research starts", async () => {
     vi.useFakeTimers();
 
     exaResearchCreateMock.mockImplementationOnce(
@@ -122,6 +122,9 @@ describe("research lifecycle providers", () => {
           exa: {
             enabled: true,
             apiKey: "literal-key",
+            policy: {
+              requestTimeoutMs: 1,
+            },
           },
         },
       } satisfies WebProvidersConfig,
@@ -129,7 +132,7 @@ describe("research lifecycle providers", () => {
       ctx: { cwd: process.cwd() },
       signal: undefined,
       onUpdate: undefined,
-      options: { requestTimeoutMs: 1, pollIntervalMs: 1 },
+      options: { pollIntervalMs: 1 },
       input: "Investigate Exa lifecycle polling",
     });
 
@@ -145,7 +148,7 @@ describe("research lifecycle providers", () => {
     expect(result.content[0]?.text).toBe("Exa research result");
   });
 
-  it("does not locally time out uncancellable Exa poll requests", async () => {
+  it("filters unsupported request timeout defaults from uncancellable Exa polls", async () => {
     vi.useFakeTimers();
 
     exaResearchCreateMock.mockResolvedValue({ researchId: "exa-job-1" });
@@ -173,6 +176,9 @@ describe("research lifecycle providers", () => {
           exa: {
             enabled: true,
             apiKey: "literal-key",
+            policy: {
+              requestTimeoutMs: 1,
+            },
           },
         },
       } satisfies WebProvidersConfig,
@@ -180,7 +186,7 @@ describe("research lifecycle providers", () => {
       ctx: { cwd: process.cwd() },
       signal: undefined,
       onUpdate: undefined,
-      options: { requestTimeoutMs: 1, pollIntervalMs: 1 },
+      options: { pollIntervalMs: 1 },
       input: "Investigate Exa lifecycle polling",
     });
 

--- a/test/tool-availability.test.ts
+++ b/test/tool-availability.test.ts
@@ -263,6 +263,13 @@ describe("managed tool availability", () => {
         "answer",
       ),
     ).toEqual(["perplexity"]);
+    expect(
+      __test__.getAvailableProviderIdsForCapability(
+        config,
+        process.cwd(),
+        "research",
+      ),
+    ).toEqual(["perplexity"]);
   });
 });
 


### PR DESCRIPTION
## Summary
- centralize request timeout handling around per-attempt execution contexts
- stop retrying timed-out and research-start requests to avoid duplicate background jobs
- pass abort signals into Gemini and Parallel requests and remove misleading resume hints for terminal research failures

## Testing
- npm test
- npm run check