### PR TITLE
Async search prefetch and in-memory content cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ your active provider are exposed to the agent.
   explicitly enabled and the local CLI is installed and authenticated
 - **Per-provider tool toggles** — disable individual capabilities without
   switching providers
-- **Multi-query search** — run several search queries in a single `web_search`
-  call and get grouped results back in one response
+- **Batched search and answers** — run several related queries in a single
+  `web_search` or `web_answer` call and get grouped results back in one response
+- **Async contents prefetch** — optionally start background `web_contents`
+  extraction from `web_search` results and reuse the cached pages later
 - **Timeout and retry controls** — configurable request timeouts, retries,
   research polling, deadlines, and resumable background jobs
 - **Truncated output with temp-file spillover** for large results
@@ -57,12 +59,17 @@ provider supports a given capability, the corresponding tool is never exposed.
 Find likely sources on the public web for up to 10 queries in a single call
 and return titles, URLs, and snippets grouped by query.
 
-| Parameter    | Type     | Default  | Description                                |
-| ------------ | -------- | -------- | ------------------------------------------ |
-| `queries`    | string[] | required | One or more search queries to run (max 10) |
-| `maxResults` | integer  | `5`      | Result count per query, clamped to `1–20`  |
-| `options`    | object   | —        | Provider-specific search options           |
-| `provider`   | string   | auto     | Optional provider override                 |
+| Parameter    | Type     | Default  | Description                                                          |
+| ------------ | -------- | -------- | -------------------------------------------------------------------- |
+| `queries`    | string[] | required | One or more search queries to run (max 10)                           |
+| `maxResults` | integer  | `5`      | Result count per query, clamped to `1–20`                            |
+| `options`    | object   | —        | Provider-specific search options plus local `prefetch` orchestration |
+| `provider`   | string   | auto     | Optional provider override                                           |
+
+`web_search.options.prefetch` is local-only and not forwarded into the provider
+SDK. It accepts `enabled`, `maxUrls`, `provider`, `ttlMs`, and
+`contentsOptions`, and starts a background page-extraction workflow that writes
+results into the local content store.
 
 ### `web_contents`
 
@@ -74,15 +81,20 @@ Read and extract the main contents of one or more web pages.
 | `options`  | object   | —        | Provider-specific extraction options |
 | `provider` | string   | auto     | Optional provider override           |
 
+`web_contents` reuses any matching prefetched pages already present in the local
+content store and only fetches missing or stale URLs.
+
 ### `web_answer`
 
-Answer a question using web-grounded evidence.
+Answer one or more questions using web-grounded evidence.
 
-| Parameter  | Type   | Default  | Description                |
-| ---------- | ------ | -------- | -------------------------- |
-| `query`    | string | required | Question to answer         |
-| `options`  | object | —        | Provider-specific options  |
-| `provider` | string | auto     | Optional provider override |
+| Parameter  | Type     | Default  | Description                                          |
+| ---------- | -------- | -------- | ---------------------------------------------------- |
+| `queries`  | string[] | required | One or more questions to answer in one call (max 10) |
+| `options`  | object   | —        | Provider-specific options                            |
+| `provider` | string   | auto     | Optional provider override                           |
+
+Responses are grouped into per-question sections when more than one question is provided.
 
 ### `web_research`
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ Read and extract the main contents of one or more web pages.
 | `options`  | object   | —        | Provider-specific extraction options |
 | `provider` | string   | auto     | Optional provider override           |
 
-`web_contents` reuses any matching prefetched pages already present in the local
-content store and only fetches missing or stale URLs.
+`web_contents` reuses any matching cached pages already present in the local
+content store—whether they came from prefetch or an earlier read—and only
+fetches missing or stale URLs.
 
 ### `web_answer`
 

--- a/changelog/unreleased/async-search-prefetch-and-local-content-store.md
+++ b/changelog/unreleased/async-search-prefetch-and-local-content-store.md
@@ -1,5 +1,5 @@
 ---
-title: Async search prefetch and local content store
+title: Async search prefetch and in-memory content cache
 type: feature
 authors:
   - mavam
@@ -7,7 +7,7 @@ authors:
 created: 2026-03-15T20:54:55.904964Z
 ---
 
-`web_search` now supports background page prefetching through `options.prefetch`, so you can warm a local content cache while the search results are returned.
+`web_search` now supports background page prefetching through `options.prefetch`, so you can warm an in-memory content cache while the search results are returned.
 
 ```json
 {
@@ -21,4 +21,4 @@ created: 2026-03-15T20:54:55.904964Z
 }
 ```
 
-Later `web_contents` calls can reuse those prefetched pages instead of refetching matching URLs, which speeds up search-to-read workflows and avoids redundant network requests.
+Later `web_contents` calls can reuse those prefetched pages instead of refetching matching URLs, which speeds up search-to-read workflows and avoids redundant network requests. The cache lives in memory for the duration of the session and is not persisted to disk.

--- a/changelog/unreleased/async-search-prefetch-and-local-content-store.md
+++ b/changelog/unreleased/async-search-prefetch-and-local-content-store.md
@@ -21,4 +21,16 @@ created: 2026-03-15T20:54:55.904964Z
 }
 ```
 
-Later `web_contents` calls can reuse those prefetched pages instead of refetching matching URLs, which speeds up search-to-read workflows and avoids redundant network requests. The cache lives in memory for the duration of the session and is not persisted to disk.
+Later `web_contents` calls reuse cached or in-flight pages instead of
+re-fetching them. Concurrent requests for the same URL are deduplicated
+automatically—if a prefetch is still running when `web_contents` asks for the
+same page, it piggybacks on the existing request rather than issuing a second
+one. Partial cache hits fetch only the missing URLs while serving the rest from
+the store.
+
+The prefetch object also accepts `provider`, `ttlMs`, and `contentsOptions` for
+finer control over which provider extracts the pages, how long entries stay
+valid, and what extraction options to pass through.
+
+The cache lives in memory for the duration of the session and is cleared on
+session start.

--- a/changelog/unreleased/async-search-prefetch-and-local-content-store.md
+++ b/changelog/unreleased/async-search-prefetch-and-local-content-store.md
@@ -21,16 +21,8 @@ created: 2026-03-15T20:54:55.904964Z
 }
 ```
 
-Later `web_contents` calls reuse cached or in-flight pages instead of
-re-fetching them. Concurrent requests for the same URL are deduplicated
-automatically—if a prefetch is still running when `web_contents` asks for the
-same page, it piggybacks on the existing request rather than issuing a second
-one. Partial cache hits fetch only the missing URLs while serving the rest from
-the store.
+Later `web_contents` calls reuse cached or in-flight pages instead of re-fetching them. Concurrent requests for the same URL are deduplicated automatically—if a prefetch is still running when `web_contents` asks for the same page, it piggybacks on the existing request rather than issuing a second one. Partial cache hits fetch only the missing URLs while serving the rest from the store.
 
-The prefetch object also accepts `provider`, `ttlMs`, and `contentsOptions` for
-finer control over which provider extracts the pages, how long entries stay
-valid, and what extraction options to pass through.
+The prefetch object also accepts `provider`, `ttlMs`, and `contentsOptions` for finer control over which provider extracts the pages, how long entries stay valid, and what extraction options to pass through.
 
-The cache lives in memory for the duration of the session and is cleared on
-session start.
+The cache lives in memory for the duration of the session and is cleared on session start.

--- a/changelog/unreleased/async-search-prefetch-and-local-content-store.md
+++ b/changelog/unreleased/async-search-prefetch-and-local-content-store.md
@@ -1,0 +1,24 @@
+---
+title: Async search prefetch and local content store
+type: feature
+authors:
+  - mavam
+  - codex
+created: 2026-03-15T20:54:55.904964Z
+---
+
+`web_search` now supports background page prefetching through `options.prefetch`, so you can warm a local content cache while the search results are returned.
+
+```json
+{
+  "queries": ["exa docs"],
+  "options": {
+    "prefetch": {
+      "enabled": true,
+      "maxUrls": 2
+    }
+  }
+}
+```
+
+Later `web_contents` calls can reuse those prefetched pages instead of refetching matching URLs, which speeds up search-to-read workflows and avoids redundant network requests.

--- a/changelog/unreleased/batched-web-answers-and-multiline-tool-call-rendering.md
+++ b/changelog/unreleased/batched-web-answers-and-multiline-tool-call-rendering.md
@@ -1,0 +1,21 @@
+---
+title: Batched web answers and multiline tool-call rendering
+type: change
+authors:
+  - mavam
+  - codex
+created: 2026-03-15T20:53:25.89995Z
+---
+
+`web_answer` now accepts a required `queries` array, matching `web_search`, so you can batch several related questions into one grounded-answer call.
+
+```json
+{
+  "queries": [
+    "What are common Tenzir use cases?",
+    "How does Tenzir help with SIEM migration?"
+  ]
+}
+```
+
+Tool-call rendering is also easier to scan: `web_answer` shows the tool name on the first line and each question on its own line below it, and multi-query `web_search` calls now list each query the same way instead of collapsing them into a count. Partial foreground updates for `web_search`, `web_contents`, and `web_answer` no longer clutter the pending tool box.

--- a/src/content-store.ts
+++ b/src/content-store.ts
@@ -1,0 +1,151 @@
+import { createHash } from "node:crypto";
+import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { JsonObject, JsonValue } from "./types.js";
+
+export type ContentStoreEntryStatus = "pending" | "ready" | "failed";
+
+export interface ContentStoreEntry<TValue extends JsonValue = JsonValue> {
+  key: string;
+  kind: string;
+  status: ContentStoreEntryStatus;
+  createdAt: number;
+  updatedAt: number;
+  expiresAt?: number;
+  value?: TValue;
+  error?: string;
+  metadata?: JsonObject;
+}
+
+export interface ContentStore {
+  get<TValue extends JsonValue = JsonValue>(
+    key: string,
+  ): Promise<ContentStoreEntry<TValue> | undefined>;
+  put<TValue extends JsonValue = JsonValue>(
+    entry: ContentStoreEntry<TValue>,
+  ): Promise<void>;
+  delete(key: string): Promise<void>;
+  listByKind<TValue extends JsonValue = JsonValue>(
+    kind: string,
+  ): Promise<Array<ContentStoreEntry<TValue>>>;
+  cleanup(now?: number): Promise<void>;
+}
+
+export class FileContentStore implements ContentStore {
+  constructor(private readonly rootDir?: string) {}
+
+  async get<TValue extends JsonValue = JsonValue>(
+    key: string,
+  ): Promise<ContentStoreEntry<TValue> | undefined> {
+    try {
+      const raw = await readFile(this.entryPath(key), "utf8");
+      const parsed = JSON.parse(raw) as ContentStoreEntry<TValue>;
+      if (parsed.key !== key) {
+        return undefined;
+      }
+      return parsed;
+    } catch (error) {
+      if (isNotFoundError(error)) {
+        return undefined;
+      }
+      throw error;
+    }
+  }
+
+  async put<TValue extends JsonValue = JsonValue>(
+    entry: ContentStoreEntry<TValue>,
+  ): Promise<void> {
+    await mkdir(this.getRootDir(), { recursive: true });
+    await writeFile(this.entryPath(entry.key), JSON.stringify(entry, null, 2));
+  }
+
+  async delete(key: string): Promise<void> {
+    await rm(this.entryPath(key), { force: true });
+  }
+
+  async listByKind<TValue extends JsonValue = JsonValue>(
+    kind: string,
+  ): Promise<Array<ContentStoreEntry<TValue>>> {
+    try {
+      const files = await readdir(this.getRootDir());
+      const entries = await Promise.all(
+        files
+          .filter((file) => file.endsWith(".json"))
+          .map(async (file) => {
+            try {
+              const raw = await readFile(join(this.getRootDir(), file), "utf8");
+              return JSON.parse(raw) as ContentStoreEntry<TValue>;
+            } catch {
+              return undefined;
+            }
+          }),
+      );
+      return entries.filter(
+        (entry): entry is ContentStoreEntry<TValue> => entry?.kind === kind,
+      );
+    } catch (error) {
+      if (isNotFoundError(error)) {
+        return [];
+      }
+      throw error;
+    }
+  }
+
+  async cleanup(now = Date.now()): Promise<void> {
+    try {
+      const files = await readdir(this.getRootDir());
+      await Promise.all(
+        files
+          .filter((file) => file.endsWith(".json"))
+          .map(async (file) => {
+            try {
+              const raw = await readFile(join(this.getRootDir(), file), "utf8");
+              const entry = JSON.parse(raw) as ContentStoreEntry;
+              if (entry.expiresAt !== undefined && entry.expiresAt <= now) {
+                await rm(join(this.getRootDir(), file), { force: true });
+              }
+            } catch {
+              // Ignore unreadable cache files during best-effort cleanup.
+            }
+          }),
+      );
+    } catch (error) {
+      if (isNotFoundError(error)) {
+        return;
+      }
+      throw error;
+    }
+  }
+
+  private entryPath(key: string): string {
+    return join(this.getRootDir(), `${hashKey(key)}.json`);
+  }
+
+  private getRootDir(): string {
+    return this.rootDir ?? getDefaultStoreRoot();
+  }
+}
+
+export function hashKey(key: string): string {
+  return createHash("sha256").update(key).digest("hex");
+}
+
+export function createStoreKey(
+  parts: Array<string | number | boolean>,
+): string {
+  return parts.map((part) => String(part)).join(":");
+}
+
+function getDefaultStoreRoot(): string {
+  return join(homedir(), ".pi", "agent", "web-providers-cache");
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "ENOENT"
+  );
+}

--- a/src/content-store.ts
+++ b/src/content-store.ts
@@ -1,7 +1,4 @@
 import { createHash } from "node:crypto";
-import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import type { JsonObject, JsonValue } from "./types.js";
 
 export type ContentStoreEntryStatus = "pending" | "ready" | "failed";
@@ -32,98 +29,47 @@ export interface ContentStore {
   cleanup(now?: number): Promise<void>;
 }
 
-export class FileContentStore implements ContentStore {
-  constructor(private readonly rootDir?: string) {}
+export class MemoryContentStore implements ContentStore {
+  private entries = new Map<string, ContentStoreEntry>();
+
+  clear(): void {
+    this.entries.clear();
+  }
 
   async get<TValue extends JsonValue = JsonValue>(
     key: string,
   ): Promise<ContentStoreEntry<TValue> | undefined> {
-    try {
-      const raw = await readFile(this.entryPath(key), "utf8");
-      const parsed = JSON.parse(raw) as ContentStoreEntry<TValue>;
-      if (parsed.key !== key) {
-        return undefined;
-      }
-      return parsed;
-    } catch (error) {
-      if (isNotFoundError(error)) {
-        return undefined;
-      }
-      throw error;
-    }
+    return this.entries.get(key) as ContentStoreEntry<TValue> | undefined;
   }
 
   async put<TValue extends JsonValue = JsonValue>(
     entry: ContentStoreEntry<TValue>,
   ): Promise<void> {
-    await mkdir(this.getRootDir(), { recursive: true });
-    await writeFile(this.entryPath(entry.key), JSON.stringify(entry, null, 2));
+    this.entries.set(entry.key, entry as ContentStoreEntry);
   }
 
   async delete(key: string): Promise<void> {
-    await rm(this.entryPath(key), { force: true });
+    this.entries.delete(key);
   }
 
   async listByKind<TValue extends JsonValue = JsonValue>(
     kind: string,
   ): Promise<Array<ContentStoreEntry<TValue>>> {
-    try {
-      const files = await readdir(this.getRootDir());
-      const entries = await Promise.all(
-        files
-          .filter((file) => file.endsWith(".json"))
-          .map(async (file) => {
-            try {
-              const raw = await readFile(join(this.getRootDir(), file), "utf8");
-              return JSON.parse(raw) as ContentStoreEntry<TValue>;
-            } catch {
-              return undefined;
-            }
-          }),
-      );
-      return entries.filter(
-        (entry): entry is ContentStoreEntry<TValue> => entry?.kind === kind,
-      );
-    } catch (error) {
-      if (isNotFoundError(error)) {
-        return [];
+    const result: Array<ContentStoreEntry<TValue>> = [];
+    for (const entry of this.entries.values()) {
+      if (entry.kind === kind) {
+        result.push(entry as ContentStoreEntry<TValue>);
       }
-      throw error;
     }
+    return result;
   }
 
   async cleanup(now = Date.now()): Promise<void> {
-    try {
-      const files = await readdir(this.getRootDir());
-      await Promise.all(
-        files
-          .filter((file) => file.endsWith(".json"))
-          .map(async (file) => {
-            try {
-              const raw = await readFile(join(this.getRootDir(), file), "utf8");
-              const entry = JSON.parse(raw) as ContentStoreEntry;
-              if (entry.expiresAt !== undefined && entry.expiresAt <= now) {
-                await rm(join(this.getRootDir(), file), { force: true });
-              }
-            } catch {
-              // Ignore unreadable cache files during best-effort cleanup.
-            }
-          }),
-      );
-    } catch (error) {
-      if (isNotFoundError(error)) {
-        return;
+    for (const [key, entry] of this.entries) {
+      if (entry.expiresAt !== undefined && entry.expiresAt <= now) {
+        this.entries.delete(key);
       }
-      throw error;
     }
-  }
-
-  private entryPath(key: string): string {
-    return join(this.getRootDir(), `${hashKey(key)}.json`);
-  }
-
-  private getRootDir(): string {
-    return this.rootDir ?? getDefaultStoreRoot();
   }
 }
 
@@ -135,17 +81,4 @@ export function createStoreKey(
   parts: Array<string | number | boolean>,
 ): string {
   return parts.map((part) => String(part)).join(":");
-}
-
-function getDefaultStoreRoot(): string {
-  return join(homedir(), ".pi", "agent", "web-providers-cache");
-}
-
-function isNotFoundError(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    error.code === "ENOENT"
-  );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1055,9 +1055,10 @@ async function executeProviderOperation({
       }),
     );
 
-  // Route all contents requests through the local content store so successful
-  // live reads become reusable cache entries. Exact cache hits are served
-  // immediately, and partial cache hits only fetch the missing or stale URLs.
+  // Route contents requests through the local content store whenever we can
+  // reuse an exact batch hit or at least one per-URL cache entry. Exact cache
+  // hits are served immediately, and partial cache hits fetch only missing or
+  // stale URLs.
   if (capability === "contents" && planOverride === undefined) {
     const resolved = await resolveContentsFromStore({
       urls: urls ?? [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,6 @@ import {
 } from "./execution-policy.js";
 import {
   canResolveContentsFromStore,
-  cleanupContentStore,
   formatPrefetchStatusText,
   getPrefetchStatus,
   parseSearchContentsPrefetchOptions,
@@ -116,8 +115,6 @@ export default function webProvidersExtension(pi: ExtensionAPI) {
 
   pi.on("session_start", async (_event, ctx) => {
     await refreshManagedTools(pi, ctx.cwd, { addAvailable: true });
-    // Best-effort eviction of expired content-store entries on startup.
-    void cleanupContentStore();
   });
 
   pi.on("before_agent_start", async (_event, ctx) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,14 @@ import {
   stripLocalExecutionOptions,
 } from "./execution-policy.js";
 import {
+  formatPrefetchStatusText,
+  getPrefetchStatus,
+  parseSearchContentsPrefetchOptions,
+  resolveContentsFromStore,
+  startContentsPrefetch,
+  stripSearchContentsPrefetchOptions,
+} from "./prefetch-manager.js";
+import {
   getProviderConfigManifest,
   type ProviderSettingDescriptor,
 } from "./provider-config-manifests.js";
@@ -201,7 +209,7 @@ function registerWebSearchTool(
       const isError = Boolean((result as { isError?: boolean }).isError);
 
       if (isPartial) {
-        return renderSimpleText(text ?? "Searching…", theme, "warning");
+        return undefined;
       }
 
       if (isError) {
@@ -301,6 +309,7 @@ function registerWebContentsTool(
         state.isPartial,
         "web_contents failed",
         theme,
+        { hidePartial: true },
       );
     },
   });
@@ -315,35 +324,42 @@ function registerWebAnswerTool(
   pi.registerTool({
     name: "web_answer",
     label: "Web Answer",
-    description: "Answer a question using web-grounded evidence.",
+    description: `Answer one or more questions using web-grounded evidence (up to ${MAX_SEARCH_QUERIES} per call).`,
     parameters: Type.Object({
-      query: Type.String({ description: "Question to answer" }),
+      queries: Type.Array(Type.String({ minLength: 1 }), {
+        minItems: 1,
+        maxItems: MAX_SEARCH_QUERIES,
+        description: `One or more questions to answer in one call (max ${MAX_SEARCH_QUERIES})`,
+      }),
       options: jsonOptionsSchema(describeOptionsField("answer", providerIds)),
       provider: providerEnum(
         providerIds,
         "Provider override. If omitted, uses the active configured provider that supports web answers.",
       ),
     }),
-    promptGuidelines: PROVIDER_OVERRIDE_GUIDELINES,
+    promptGuidelines: [
+      ...PROVIDER_OVERRIDE_GUIDELINES,
+      "Prefer batching related questions into one web_answer call instead of making multiple calls.",
+    ],
     async execute(_toolCallId, params, signal, onUpdate, ctx) {
-      return executeProviderTool({
-        capability: "answer",
+      return executeAnswerTool({
         config: await loadConfig(),
         explicitProvider: params.provider,
         ctx,
         signal,
         onUpdate,
         options: normalizeOptions(params.options),
-        query: params.query,
+        queries: params.queries,
       });
     },
     renderCall(args, theme) {
-      return renderToolCallHeader(
-        "web_answer",
-        formatQuotedPreview(String((args as { query?: string }).query ?? "")),
-        [
-          `provider=${String((args as { provider?: string }).provider ?? "auto")}`,
-        ],
+      return renderQuestionCallHeader(
+        {
+          queries: Array.isArray((args as { queries?: unknown }).queries)
+            ? ((args as { queries?: string[] }).queries ?? [])
+            : [],
+          provider: (args as { provider?: ProviderId }).provider,
+        },
         theme,
       );
     },
@@ -354,6 +370,7 @@ function registerWebAnswerTool(
         state.isPartial,
         "web_answer failed",
         theme,
+        { hidePartial: true },
       );
     },
   });
@@ -574,16 +591,22 @@ function describeOptionsField(
     providerIds,
   );
 
-  if (supportedControls.length === 0) {
-    return labels[capability];
+  let description = labels[capability];
+
+  if (supportedControls.length > 0) {
+    const qualifier =
+      capability === "research"
+        ? " Depending on provider, local execution controls may include: "
+        : " Local execution controls: ";
+    description += `${qualifier}${supportedControls.join(", ")}.`;
   }
 
-  const qualifier =
-    capability === "research"
-      ? " Depending on provider, local execution controls may include: "
-      : " Local execution controls: ";
+  if (capability === "search") {
+    description +=
+      " Local orchestration options may include prefetch={ enabled, maxUrls, provider, ttlMs, contentsOptions }.";
+  }
 
-  return `${labels[capability]}${qualifier}${supportedControls.join(", ")}.`;
+  return description;
 }
 
 function getSupportedExecutionControlsForCapability(
@@ -673,6 +696,8 @@ async function executeSearchTool({
     throw new Error(`Provider '${provider.id}' is not configured.`);
   }
 
+  const prefetchOptions = parseSearchContentsPrefetchOptions(options);
+  const providerOptions = stripSearchContentsPrefetchOptions(options);
   const searchQueries = resolveSearchQueries(queries);
   if (
     planOverrides !== undefined &&
@@ -699,9 +724,9 @@ async function executeSearchTool({
           providerConfig: providerConfig as ProviderConfigUnion,
           query: searchQuery,
           maxResults: clampedMaxResults,
-          options,
+          options: providerOptions,
           providerContext,
-          onProgress: createSearchProgressReporter(
+          onProgress: createBatchProgressReporter(
             progress.report,
             searchQueries,
             index,
@@ -726,8 +751,19 @@ async function executeSearchTool({
     throw buildSearchBatchError(outcomes);
   }
 
+  const prefetch =
+    prefetchOptions?.enabled === true && planOverrides === undefined
+      ? await startContentsPrefetch({
+          config,
+          cwd: ctx.cwd,
+          urls: collectSearchResultUrls(outcomes),
+          searchProviderId: provider.id,
+          options: prefetchOptions,
+        })
+      : undefined;
+
   const rendered = await truncateAndSave(
-    formatSearchResponses(outcomes),
+    formatSearchResponses(outcomes, prefetch),
     "web-search",
   );
 
@@ -796,6 +832,249 @@ async function executeSingleSearchQuery({
   return result;
 }
 
+type AnswerQueryOutcome =
+  | { query: string; response: ProviderToolOutput; error?: undefined }
+  | { query: string; error: string; response?: undefined };
+
+async function executeAnswerTool({
+  config,
+  explicitProvider,
+  ctx,
+  signal,
+  onUpdate,
+  options,
+  queries,
+  planOverrides,
+}: {
+  config: WebProvidersConfig;
+  explicitProvider: ProviderId | undefined;
+  ctx: { cwd: string };
+  signal: AbortSignal | null | undefined;
+  onUpdate:
+    | ((update: {
+        content: Array<{ type: "text"; text: string }>;
+        details: {};
+      }) => void)
+    | undefined;
+  options: JsonObject | undefined;
+  queries: string[];
+  planOverrides?: ProviderOperationPlan<ProviderToolOutput>[];
+}) {
+  const provider = resolveProviderForCapability(
+    config,
+    explicitProvider,
+    ctx.cwd,
+    "answer",
+  );
+  const providerConfig = getEffectiveProviderConfig(config, provider.id);
+  if (!providerConfig) {
+    throw new Error(`Provider '${provider.id}' is not configured.`);
+  }
+
+  const answerQueries = resolveAnswerQueries(queries);
+  if (
+    planOverrides !== undefined &&
+    planOverrides.length !== answerQueries.length
+  ) {
+    throw new Error(
+      "planOverrides length must match the number of answer queries.",
+    );
+  }
+
+  const progress = createToolProgressReporter("answer", provider.id, onUpdate);
+  const providerContext = {
+    cwd: ctx.cwd,
+    signal: signal ?? undefined,
+  };
+
+  let outcomes: AnswerQueryOutcome[];
+  try {
+    const settled = await Promise.allSettled(
+      answerQueries.map((answerQuery, index) =>
+        executeProviderOperation({
+          capability: "answer",
+          config,
+          provider,
+          providerConfig: providerConfig as ProviderConfigUnion,
+          ctx,
+          signal,
+          options,
+          query: answerQuery,
+          onProgress: createBatchProgressReporter(
+            progress.report,
+            answerQueries,
+            index,
+          ),
+          planOverride: planOverrides?.[index],
+        }),
+      ),
+    );
+    outcomes = settled.map((result, index) =>
+      result.status === "fulfilled"
+        ? { query: answerQueries[index] ?? "", response: result.value }
+        : {
+            query: answerQueries[index] ?? "",
+            error: formatErrorMessage(result.reason),
+          },
+    );
+  } finally {
+    progress.stop();
+  }
+
+  if (outcomes.every((outcome) => outcome.error !== undefined)) {
+    throw buildAnswerBatchError(outcomes);
+  }
+
+  const text = await truncateAndSave(
+    formatAnswerResponses(outcomes),
+    "web-answer",
+  );
+  const details = buildWebAnswerDetails(provider.id, outcomes);
+
+  return {
+    content: [{ type: "text" as const, text }],
+    details,
+  };
+}
+
+function buildAnswerBatchError(outcomes: AnswerQueryOutcome[]): Error {
+  const failed = outcomes.filter((outcome) => outcome.error !== undefined);
+  if (failed.length === 1) {
+    return new Error(failed[0]?.error ?? "web_answer failed.");
+  }
+
+  const summary = failed
+    .map(
+      (outcome, index) =>
+        `${index + 1}. ${formatQuotedPreview(outcome.query, 40)} — ${outcome.error}`,
+    )
+    .join("; ");
+  return new Error(
+    `All ${failed.length} web_answer queries failed: ${summary}`,
+  );
+}
+
+function formatAnswerResponses(outcomes: AnswerQueryOutcome[]): string {
+  if (outcomes.length === 1) {
+    return formatSingleAnswerOutcome(outcomes[0]);
+  }
+
+  return outcomes
+    .map((outcome, index) => {
+      const section = outcome.response
+        ? outcome.response.text
+        : `Answer failed: ${outcome.error ?? "Unknown error."}`;
+      return `Question ${index + 1}: ${formatQuotedPreview(outcome.query)}\n${section}`;
+    })
+    .join("\n\n");
+}
+
+function formatSingleAnswerOutcome(
+  outcome: AnswerQueryOutcome | undefined,
+): string {
+  if (outcome?.response) {
+    return outcome.response.text;
+  }
+  return `Answer failed: ${outcome?.error ?? "Unknown error."}`;
+}
+
+function buildWebAnswerDetails(
+  provider: ProviderId,
+  outcomes: AnswerQueryOutcome[],
+): ProviderToolDetails {
+  const successfulOutcomes = outcomes.filter(
+    (
+      outcome,
+    ): outcome is Extract<
+      AnswerQueryOutcome,
+      { response: ProviderToolOutput }
+    > => outcome.response !== undefined,
+  );
+  const summary =
+    successfulOutcomes.length === 1 && outcomes.length === 1
+      ? successfulOutcomes[0]?.response.summary
+      : undefined;
+
+  return {
+    tool: "web_answer",
+    provider,
+    summary,
+    itemCount:
+      successfulOutcomes.length === 1
+        ? successfulOutcomes[0]?.response.itemCount
+        : undefined,
+    queryCount: outcomes.length,
+    failedQueryCount: outcomes.filter((outcome) => outcome.error !== undefined)
+      .length,
+  };
+}
+
+async function executeProviderOperation({
+  capability,
+  config,
+  provider,
+  providerConfig,
+  ctx,
+  signal,
+  options,
+  urls,
+  query,
+  input,
+  onProgress,
+  planOverride,
+}: {
+  capability: Exclude<ProviderCapability, "search">;
+  config: WebProvidersConfig;
+  provider: (typeof PROVIDERS)[number];
+  providerConfig: ProviderConfigUnion;
+  ctx: { cwd: string };
+  signal: AbortSignal | null | undefined;
+  options: JsonObject | undefined;
+  urls?: string[];
+  query?: string;
+  input?: string;
+  onProgress?: (message: string) => void;
+  planOverride?: ProviderOperationPlan<ProviderToolOutput>;
+}): Promise<ProviderToolOutput> {
+  const plan =
+    planOverride ??
+    buildProviderPlan(
+      provider,
+      providerConfig,
+      buildOperationRequest(capability, {
+        urls,
+        query,
+        input,
+        options: stripLocalExecutionOptions(options),
+      }),
+    );
+
+  if (capability === "contents" && planOverride === undefined) {
+    const resolved = await resolveContentsFromStore({
+      urls: urls ?? [],
+      providerId: provider.id,
+      config,
+      cwd: ctx.cwd,
+      options,
+      signal: signal ?? undefined,
+      onProgress,
+    });
+    return resolved.output;
+  }
+
+  const result = await executeOperationPlan(plan, options, {
+    cwd: ctx.cwd,
+    signal: signal ?? undefined,
+    onProgress,
+  });
+  if (isSearchResponse(result)) {
+    throw new Error(
+      `${provider.label} ${capability} returned an invalid result.`,
+    );
+  }
+  return result;
+}
+
 async function executeProviderTool({
   capability,
   config,
@@ -842,33 +1121,23 @@ async function executeProviderTool({
     provider.id,
     onUpdate,
   );
-  const providerContext = {
-    cwd: ctx.cwd,
-    signal: signal ?? undefined,
-    onProgress: progress.report,
-  };
-  const plan =
-    planOverride ??
-    buildProviderPlan(
-      provider,
-      providerConfig as ProviderConfigUnion,
-      buildOperationRequest(capability, {
-        urls,
-        query,
-        input,
-        options: stripLocalExecutionOptions(options),
-      }),
-    );
 
   let response: ProviderToolOutput;
   try {
-    const result = await executeOperationPlan(plan, options, providerContext);
-    if (isSearchResponse(result)) {
-      throw new Error(
-        `${provider.label} ${capability} returned an invalid result.`,
-      );
-    }
-    response = result;
+    response = await executeProviderOperation({
+      capability,
+      config,
+      provider,
+      providerConfig: providerConfig as ProviderConfigUnion,
+      ctx,
+      signal,
+      options,
+      urls,
+      query,
+      input,
+      onProgress: progress.report,
+      planOverride,
+    });
   } finally {
     progress.stop();
   }
@@ -1031,6 +1300,47 @@ function renderToolCallHeader(
   };
 }
 
+function renderQuestionCallHeader(
+  params: {
+    queries: string[];
+    provider?: ProviderId;
+  },
+  theme: Theme,
+): Component {
+  return {
+    invalidate() {},
+    render(width) {
+      const header = theme.fg("toolTitle", theme.bold("web_answer"));
+      const questions = getAnswerQueriesForDisplay(params.queries);
+      const lines: string[] = [];
+      const headerLine = truncateToWidth(header, width);
+      lines.push(
+        headerLine + " ".repeat(Math.max(0, width - visibleWidth(headerLine))),
+      );
+
+      for (const question of questions) {
+        const questionLine = truncateToWidth(
+          `  ${theme.fg("accent", truncateInline(cleanSingleLine(question), 120))}`,
+          width,
+        );
+        lines.push(
+          questionLine +
+            " ".repeat(Math.max(0, width - visibleWidth(questionLine))),
+        );
+      }
+
+      const detailLine = truncateToWidth(
+        `  ${theme.fg("muted", `provider=${params.provider ?? "auto"}`)}`,
+        width,
+      );
+      lines.push(
+        detailLine + " ".repeat(Math.max(0, width - visibleWidth(detailLine))),
+      );
+      return lines;
+    },
+  };
+}
+
 function renderProviderToolResult(
   result: {
     content?: Array<{ type: string; text?: string }>;
@@ -1041,10 +1351,14 @@ function renderProviderToolResult(
   isPartial: boolean,
   failureText: string,
   theme: Theme,
-): Text {
+  options: { hidePartial?: boolean } = {},
+): Text | undefined {
   const text = extractTextContent(result.content);
 
   if (isPartial) {
+    if (options.hidePartial === true) {
+      return undefined;
+    }
     return renderSimpleText(text ?? "Working…", theme, "warning");
   }
 
@@ -1057,13 +1371,33 @@ function renderProviderToolResult(
   }
 
   const details = result.details as ProviderToolDetails | undefined;
-  const summary =
-    details?.summary ??
-    getFirstLine(text) ??
-    `${details?.tool ?? "tool"} output available`;
+  const summary = renderCollapsedProviderToolSummary(details, text);
   let summaryText = theme.fg("success", summary);
   summaryText += theme.fg("muted", ` (${getExpandHint()})`);
   return new Text(summaryText, 0, 0);
+}
+
+function renderCollapsedProviderToolSummary(
+  details: ProviderToolDetails | undefined,
+  text: string | undefined,
+): string {
+  if (
+    details?.tool === "web_answer" &&
+    typeof details.queryCount === "number" &&
+    details.queryCount > 1
+  ) {
+    const failureSuffix =
+      details.failedQueryCount && details.failedQueryCount > 0
+        ? `, ${details.failedQueryCount} failed`
+        : "";
+    return `${details.queryCount} questions via ${details.provider}${failureSuffix}`;
+  }
+
+  return (
+    details?.summary ??
+    getFirstLine(text) ??
+    `${details?.tool ?? "tool"} output available`
+  );
 }
 
 interface ProviderToolMenuOption {
@@ -1626,6 +1960,16 @@ function resolveSearchQueries(queries: string[]): string[] {
   );
 }
 
+function resolveAnswerQueries(queries: string[]): string[] {
+  if (queries.length === 0) {
+    throw new Error("queries must contain at least one item.");
+  }
+
+  return queries.map((value, index) =>
+    normalizeSearchQuery(value, `queries[${index}]`),
+  );
+}
+
 function normalizeSearchQuery(value: string, fieldName: string): string {
   const normalized = value.trim();
   if (normalized.length === 0) {
@@ -1644,7 +1988,11 @@ function getSearchQueriesForDisplay(queries?: string[]): string[] {
     .filter((value) => value.length > 0);
 }
 
-function createSearchProgressReporter(
+function getAnswerQueriesForDisplay(queries: string[]): string[] {
+  return getSearchQueriesForDisplay(queries);
+}
+
+function createBatchProgressReporter(
   report: ((message: string) => void) | undefined,
   queries: string[],
   index: number,
@@ -1657,10 +2005,7 @@ function createSearchProgressReporter(
     return report;
   }
 
-  const label = `${index + 1}/${queries.length} ${formatQuotedPreview(
-    queries[index] ?? "",
-    40,
-  )}`;
+  const label = `${index + 1}/${queries.length}`;
   return (message: string) => {
     report(`${message} (${label})`);
   };
@@ -1710,10 +2055,9 @@ function renderCallHeader(
     render(width) {
       let header = theme.fg("toolTitle", theme.bold("web_search"));
       const queries = getSearchQueriesForDisplay(params.queries);
+      const showExpandedQueries = queries.length > 1;
       if (queries.length === 1) {
         header += ` ${theme.fg("accent", formatQuotedPreview(queries[0]))} `;
-      } else if (queries.length > 1) {
-        header += ` ${theme.fg("accent", `${queries.length} queries`)}`;
       }
 
       const lines: string[] = [];
@@ -1721,6 +2065,19 @@ function renderCallHeader(
       lines.push(
         headerLine + " ".repeat(Math.max(0, width - visibleWidth(headerLine))),
       );
+
+      if (showExpandedQueries) {
+        for (const query of queries) {
+          const queryLine = truncateToWidth(
+            `  ${theme.fg("accent", truncateInline(cleanSingleLine(query), 120))}`,
+            width,
+          );
+          lines.push(
+            queryLine +
+              " ".repeat(Math.max(0, width - visibleWidth(queryLine))),
+          );
+        }
+      }
 
       const detailParts = [
         `provider=${params.provider ?? "auto"}`,
@@ -1803,23 +2160,42 @@ function formatQuotedPreview(text: string, maxLength = 80): string {
   return `"${truncateInline(cleanSingleLine(text), maxLength)}"`;
 }
 
-function formatSearchResponses(outcomes: SearchQueryOutcome[]): string {
-  if (outcomes.length === 1) {
-    const outcome = outcomes[0];
-    if (outcome?.response) {
-      return formatSearchResponse(outcome.response);
-    }
-    return `Search failed: ${outcome?.error ?? "Unknown error."}`;
+function formatSearchResponses(
+  outcomes: SearchQueryOutcome[],
+  prefetch?: { prefetchId: string; provider: ProviderId; urlCount: number },
+): string {
+  const body =
+    outcomes.length === 1
+      ? formatSingleSearchOutcome(outcomes[0])
+      : outcomes
+          .map((outcome, index) => {
+            const section = outcome.response
+              ? formatSearchResponse(outcome.response)
+              : `Search failed: ${outcome.error ?? "Unknown error."}`;
+            return `Query ${index + 1}: ${formatQuotedPreview(outcome.query)}\n${section}`;
+          })
+          .join("\n\n");
+
+  if (!prefetch) {
+    return body;
   }
 
-  return outcomes
-    .map((outcome, index) => {
-      const body = outcome.response
-        ? formatSearchResponse(outcome.response)
-        : `Search failed: ${outcome.error ?? "Unknown error."}`;
-      return `Query ${index + 1}: ${formatQuotedPreview(outcome.query)}\n${body}`;
-    })
-    .join("\n\n");
+  return `${body}\n\nBackground contents prefetch started via ${prefetch.provider} for ${prefetch.urlCount} URL(s). Prefetch id: ${prefetch.prefetchId}`;
+}
+
+function formatSingleSearchOutcome(
+  outcome: SearchQueryOutcome | undefined,
+): string {
+  if (outcome?.response) {
+    return formatSearchResponse(outcome.response);
+  }
+  return `Search failed: ${outcome?.error ?? "Unknown error."}`;
+}
+
+function collectSearchResultUrls(outcomes: SearchQueryOutcome[]): string[] {
+  return outcomes.flatMap(
+    (outcome) => outcome.response?.results.map((result) => result.url) ?? [],
+  );
 }
 
 function formatSearchResponse(response: SearchResponse): string {
@@ -1882,6 +2258,7 @@ function truncateInline(text: string, maxLength: number): string {
 }
 
 export const __test__ = {
+  executeAnswerTool,
   executeProviderTool,
   executeSearchTool,
   extractTextContent,
@@ -1890,5 +2267,6 @@ export const __test__ = {
   getAvailableProviderIdsForCapability,
   getSyncedActiveTools,
   renderCallHeader,
+  renderQuestionCallHeader,
   renderCollapsedSearchSummary,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,7 @@ export default function webProvidersExtension(pi: ExtensionAPI) {
   });
 
   pi.on("session_start", async (_event, ctx) => {
-    await cleanupContentStore();
+    resetContentStore();
     await refreshManagedTools(pi, ctx.cwd, { addAvailable: true });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1052,9 +1052,10 @@ async function executeProviderOperation({
     );
 
   // Route through the content store only when the entire request can already
-  // be satisfied from an exact prefetched batch or from per-URL cached entries.
-  // Partial cache hits intentionally fall back to the provider's native batched
-  // contents endpoint to avoid fanning out into one request per missing URL.
+  // be satisfied from an exact cached batch entry or from reusable per-URL
+  // cached entries created by prefetch or earlier reads. Partial cache hits
+  // intentionally fall back to the provider's native batched contents endpoint
+  // to avoid fanning out into one request per missing URL.
   if (capability === "contents" && planOverride === undefined) {
     const useStore = await canResolveContentsFromStore({
       urls: urls ?? [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,6 @@ import {
   resolveContentsFromStore,
   startContentsPrefetch,
   stripSearchContentsPrefetchOptions,
-  tryServeContentsFromStore,
 } from "./prefetch-manager.js";
 import {
   getProviderConfigManifest,
@@ -1116,36 +1115,6 @@ async function executeProviderTool({
   planOverride?: ProviderOperationPlan<ProviderToolOutput>;
 }) {
   await cleanupContentStore();
-
-  // For contents: try to serve entirely from the local store before resolving
-  // a provider.  This lets pure cache hits succeed even when the provider that
-  // originally fetched the pages is later disabled or unavailable.
-  if (
-    capability === "contents" &&
-    planOverride === undefined &&
-    (urls?.length ?? 0) > 0
-  ) {
-    const cached = await tryServeContentsFromStore({
-      urls: urls ?? [],
-      explicitProvider,
-      config,
-      cwd: ctx.cwd,
-      options,
-      signal: signal ?? undefined,
-    });
-    if (cached) {
-      const text = await truncateAndSave(cached.text, capability);
-      return {
-        content: [{ type: "text" as const, text }],
-        details: {
-          tool: "web_contents",
-          provider: cached.provider,
-          summary: cached.summary,
-          itemCount: cached.itemCount,
-        } as ProviderToolDetails,
-      };
-    }
-  }
 
   const provider = resolveProviderForCapability(
     config,

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,10 +32,10 @@ import {
   stripLocalExecutionOptions,
 } from "./execution-policy.js";
 import {
+  canResolveContentsFromStore,
   cleanupContentStore,
   formatPrefetchStatusText,
   getPrefetchStatus,
-  hasAnyCachedContents,
   parseSearchContentsPrefetchOptions,
   resolveContentsFromStore,
   startContentsPrefetch,
@@ -1054,11 +1054,12 @@ async function executeProviderOperation({
       }),
     );
 
-  // Route through the content store only when at least one URL already has a
-  // cached (prefetched) entry.  This avoids adding implicit file-based caching
-  // overhead to regular web_contents calls that haven't been prefetched.
+  // Route through the content store only when the entire request can already
+  // be satisfied from an exact prefetched batch or from per-URL cached entries.
+  // Partial cache hits intentionally fall back to the provider's native batched
+  // contents endpoint to avoid fanning out into one request per missing URL.
   if (capability === "contents" && planOverride === undefined) {
-    const useStore = await hasAnyCachedContents({
+    const useStore = await canResolveContentsFromStore({
       urls: urls ?? [],
       providerId: provider.id,
       options,

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,12 +32,15 @@ import {
   stripLocalExecutionOptions,
 } from "./execution-policy.js";
 import {
+  cleanupContentStore,
   formatPrefetchStatusText,
   getPrefetchStatus,
+  hasAnyCachedContents,
   parseSearchContentsPrefetchOptions,
   resolveContentsFromStore,
   startContentsPrefetch,
   stripSearchContentsPrefetchOptions,
+  tryServeContentsFromStore,
 } from "./prefetch-manager.js";
 import {
   getProviderConfigManifest,
@@ -113,6 +116,8 @@ export default function webProvidersExtension(pi: ExtensionAPI) {
 
   pi.on("session_start", async (_event, ctx) => {
     await refreshManagedTools(pi, ctx.cwd, { addAvailable: true });
+    // Best-effort eviction of expired content-store entries on startup.
+    void cleanupContentStore();
   });
 
   pi.on("before_agent_start", async (_event, ctx) => {
@@ -1049,17 +1054,27 @@ async function executeProviderOperation({
       }),
     );
 
+  // Route through the content store only when at least one URL already has a
+  // cached (prefetched) entry.  This avoids adding implicit file-based caching
+  // overhead to regular web_contents calls that haven't been prefetched.
   if (capability === "contents" && planOverride === undefined) {
-    const resolved = await resolveContentsFromStore({
+    const useStore = await hasAnyCachedContents({
       urls: urls ?? [],
       providerId: provider.id,
-      config,
-      cwd: ctx.cwd,
       options,
-      signal: signal ?? undefined,
-      onProgress,
     });
-    return resolved.output;
+    if (useStore) {
+      const resolved = await resolveContentsFromStore({
+        urls: urls ?? [],
+        providerId: provider.id,
+        config,
+        cwd: ctx.cwd,
+        options,
+        signal: signal ?? undefined,
+        onProgress,
+      });
+      return resolved.output;
+    }
   }
 
   const result = await executeOperationPlan(plan, options, {
@@ -1105,6 +1120,36 @@ async function executeProviderTool({
   input?: string;
   planOverride?: ProviderOperationPlan<ProviderToolOutput>;
 }) {
+  // For contents: try to serve entirely from the local store before resolving
+  // a provider.  This lets pure cache hits succeed even when the provider that
+  // originally fetched the pages is later disabled or unavailable.
+  if (
+    capability === "contents" &&
+    planOverride === undefined &&
+    (urls?.length ?? 0) > 0
+  ) {
+    const cached = await tryServeContentsFromStore({
+      urls: urls ?? [],
+      explicitProvider,
+      config,
+      cwd: ctx.cwd,
+      options,
+      signal: signal ?? undefined,
+    });
+    if (cached) {
+      const text = await truncateAndSave(cached.text, capability);
+      return {
+        content: [{ type: "text" as const, text }],
+        details: {
+          tool: "web_contents",
+          provider: cached.provider,
+          summary: cached.summary,
+          itemCount: cached.itemCount,
+        } as ProviderToolDetails,
+      };
+    }
+  }
+
   const provider = resolveProviderForCapability(
     config,
     explicitProvider,

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import {
   formatPrefetchStatusText,
   getPrefetchStatus,
   parseSearchContentsPrefetchOptions,
+  resetContentStore,
   resolveContentsFromStore,
   startContentsPrefetch,
   stripSearchContentsPrefetchOptions,
@@ -1855,6 +1856,9 @@ class WebProvidersSettingsView implements Component {
     try {
       mutate(nextConfig);
       await writeConfigFile(nextConfig);
+      if (didContentsCacheInputsChange(this.config, nextConfig)) {
+        resetContentStore();
+      }
       this.config = nextConfig;
       this.tui.requestRender();
     } catch (error) {
@@ -1967,6 +1971,51 @@ function getResolvedProviderChoice(
 async function getPreferredProvider(cwd: string): Promise<ProviderId> {
   const current = await loadConfig();
   return getResolvedProviderChoice(current, cwd) ?? "codex";
+}
+
+function didContentsCacheInputsChange(
+  previous: WebProvidersConfig,
+  next: WebProvidersConfig,
+): boolean {
+  return (
+    stableStringify(getContentsCacheInputs(previous)) !==
+    stableStringify(getContentsCacheInputs(next))
+  );
+}
+
+function getContentsCacheInputs(config: WebProvidersConfig): JsonObject {
+  const providers: Record<string, unknown> = {};
+
+  for (const provider of PROVIDERS) {
+    if (!supportsProviderCapability(provider, "contents")) {
+      continue;
+    }
+    providers[provider.id] =
+      config.providers?.[
+        provider.id as keyof NonNullable<WebProvidersConfig["providers"]>
+      ] ?? null;
+  }
+
+  return { providers: providers as JsonObject };
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+
+  return `{${Object.keys(value)
+    .sort()
+    .map(
+      (key) =>
+        `${JSON.stringify(key)}:${stableStringify(
+          (value as Record<string, unknown>)[key],
+        )}`,
+    )
+    .join(",")}}`;
 }
 
 function summarizeStringValue(
@@ -2299,6 +2348,7 @@ function truncateInline(text: string, maxLength: number): string {
 }
 
 export const __test__ = {
+  didContentsCacheInputsChange,
   executeAnswerTool,
   executeProviderTool,
   executeSearchTool,

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ import {
   stripLocalExecutionOptions,
 } from "./execution-policy.js";
 import {
-  canResolveContentsFromStore,
+  cleanupContentStore,
   formatPrefetchStatusText,
   getPrefetchStatus,
   parseSearchContentsPrefetchOptions,
@@ -114,10 +114,12 @@ export default function webProvidersExtension(pi: ExtensionAPI) {
   });
 
   pi.on("session_start", async (_event, ctx) => {
+    await cleanupContentStore();
     await refreshManagedTools(pi, ctx.cwd, { addAvailable: true });
   });
 
   pi.on("before_agent_start", async (_event, ctx) => {
+    await cleanupContentStore();
     await refreshManagedTools(pi, ctx.cwd, { addAvailable: false });
   });
 }
@@ -692,6 +694,8 @@ async function executeSearchTool({
   queries: string[];
   planOverrides?: ProviderOperationPlan<SearchResponse>[];
 }) {
+  await cleanupContentStore();
+
   const provider = resolveProviderChoice(config, explicitProvider, ctx.cwd);
   const providerConfig = getEffectiveProviderConfig(config, provider.id);
   if (!providerConfig) {
@@ -1051,29 +1055,20 @@ async function executeProviderOperation({
       }),
     );
 
-  // Route through the content store only when the entire request can already
-  // be satisfied from an exact cached batch entry or from reusable per-URL
-  // cached entries created by prefetch or earlier reads. Partial cache hits
-  // intentionally fall back to the provider's native batched contents endpoint
-  // to avoid fanning out into one request per missing URL.
+  // Route all contents requests through the local content store so successful
+  // live reads become reusable cache entries. Exact cache hits are served
+  // immediately, and partial cache hits only fetch the missing or stale URLs.
   if (capability === "contents" && planOverride === undefined) {
-    const useStore = await canResolveContentsFromStore({
+    const resolved = await resolveContentsFromStore({
       urls: urls ?? [],
       providerId: provider.id,
+      config,
+      cwd: ctx.cwd,
       options,
+      signal: signal ?? undefined,
+      onProgress,
     });
-    if (useStore) {
-      const resolved = await resolveContentsFromStore({
-        urls: urls ?? [],
-        providerId: provider.id,
-        config,
-        cwd: ctx.cwd,
-        options,
-        signal: signal ?? undefined,
-        onProgress,
-      });
-      return resolved.output;
-    }
+    return resolved.output;
   }
 
   const result = await executeOperationPlan(plan, options, {
@@ -1119,6 +1114,8 @@ async function executeProviderTool({
   input?: string;
   planOverride?: ProviderOperationPlan<ProviderToolOutput>;
 }) {
+  await cleanupContentStore();
+
   // For contents: try to serve entirely from the local store before resolving
   // a provider.  This lets pure cache hits succeed even when the provider that
   // originally fetched the pages is later disabled or unavailable.

--- a/src/prefetch-manager.ts
+++ b/src/prefetch-manager.ts
@@ -69,6 +69,13 @@ interface StoredBatchContentsResult {
   fromCache: boolean;
 }
 
+interface StoredContentsMetadataEntry {
+  url: string;
+  text: string;
+  summary?: string;
+  itemCount?: number;
+}
+
 export interface PrefetchStartResult {
   prefetchId: string;
   provider: ProviderId;
@@ -553,97 +560,120 @@ export async function resolveContentsFromStore({
   signal?: AbortSignal;
   onProgress?: (message: string) => void;
 }): Promise<{ output: ProviderToolOutput; cachedCount: number }> {
-  if (await hasStoredBatchContents({ urls, providerId, options })) {
-    const batch = await ensureBatchContentsStored({
-      urls,
-      providerId,
-      config,
-      cwd,
-      options,
-      signal,
-      onProgress,
-    });
-    return {
-      output: {
-        provider: batch.value.provider,
-        text: batch.value.text,
-        summary:
-          batch.value.summary ??
-          `${batch.value.urls.length} URL(s) fetched via ${batch.value.provider}`,
-        itemCount: batch.value.itemCount ?? batch.value.urls.length,
-      },
-      cachedCount: batch.fromCache ? batch.value.urls.length : 0,
-    };
-  }
-
-  const settled = await Promise.allSettled(
-    urls.map((url) =>
-      ensureContentsStored({
-        url,
+  if (await canResolveContentsFromStore({ urls, providerId, options })) {
+    if (await hasStoredBatchContents({ urls, providerId, options })) {
+      const batch = await ensureBatchContentsStored({
+        urls,
         providerId,
         config,
         cwd,
         options,
         signal,
         onProgress,
-      }),
-    ),
-  );
+      });
+      return {
+        output: {
+          provider: batch.value.provider,
+          text: batch.value.text,
+          summary:
+            batch.value.summary ??
+            `${batch.value.urls.length} URL(s) fetched via ${batch.value.provider}`,
+          itemCount: batch.value.itemCount ?? batch.value.urls.length,
+        },
+        cachedCount: batch.fromCache ? batch.value.urls.length : 0,
+      };
+    }
 
-  const results = settled
-    .filter(
-      (result): result is PromiseFulfilledResult<StoredContentsResult> =>
-        result.status === "fulfilled",
-    )
-    .map((result) => result.value);
-  const failures = settled
-    .map((result, index) =>
-      result.status === "rejected"
-        ? {
-            url: urls[index] ?? "",
-            error:
-              result.reason instanceof Error
-                ? result.reason.message
-                : String(result.reason),
-          }
-        : undefined,
-    )
-    .filter((result): result is { url: string; error: string } =>
-      Boolean(result),
+    const settled = await Promise.allSettled(
+      urls.map((url) =>
+        ensureContentsStored({
+          url,
+          providerId,
+          config,
+          cwd,
+          options,
+          signal,
+          onProgress,
+        }),
+      ),
     );
 
-  if (results.length === 0 && failures.length > 0) {
-    throw new Error(
-      failures.length === 1
-        ? (failures[0]?.error ?? "web_contents failed.")
-        : `web_contents failed for all ${failures.length} URL(s): ${failures
-            .map(
-              (failure, index) =>
-                `${index + 1}. ${failure.url} — ${failure.error}`,
-            )
-            .join("; ")}`,
-    );
+    const results = settled
+      .filter(
+        (result): result is PromiseFulfilledResult<StoredContentsResult> =>
+          result.status === "fulfilled",
+      )
+      .map((result) => result.value);
+    const failures = settled
+      .map((result, index) =>
+        result.status === "rejected"
+          ? {
+              url: urls[index] ?? "",
+              error:
+                result.reason instanceof Error
+                  ? result.reason.message
+                  : String(result.reason),
+            }
+          : undefined,
+      )
+      .filter((result): result is { url: string; error: string } =>
+        Boolean(result),
+      );
+
+    if (results.length === 0 && failures.length > 0) {
+      throw new Error(
+        failures.length === 1
+          ? (failures[0]?.error ?? "web_contents failed.")
+          : `web_contents failed for all ${failures.length} URL(s): ${failures
+              .map(
+                (failure, index) =>
+                  `${index + 1}. ${failure.url} — ${failure.error}`,
+              )
+              .join("; ")}`,
+      );
+    }
+
+    const cachedCount = results.filter((r) => r.fromCache).length;
+    const provider = results[0]?.value.provider ?? providerId;
+    const textBlocks = results.map((r) => r.value.text.trim()).filter(Boolean);
+
+    for (const failure of failures) {
+      textBlocks.push(`Error: ${failure.url}\n   ${failure.error}`);
+    }
+
+    return {
+      output: {
+        provider,
+        text: textBlocks.join("\n\n").trim() || "No contents found.",
+        summary:
+          cachedCount > 0
+            ? `${results.length} of ${urls.length} URL(s) fetched via ${provider} (${cachedCount} cached)`
+            : `${results.length} of ${urls.length} URL(s) fetched via ${provider}`,
+        itemCount: results.length,
+      },
+      cachedCount,
+    };
   }
 
-  const cachedCount = results.filter((r) => r.fromCache).length;
-  const provider = results[0]?.value.provider ?? providerId;
-  const textBlocks = results.map((r) => r.value.text.trim()).filter(Boolean);
-
-  for (const failure of failures) {
-    textBlocks.push(`Error: ${failure.url}\n   ${failure.error}`);
-  }
-
+  const batch = await ensureBatchContentsStored({
+    urls,
+    providerId,
+    config,
+    cwd,
+    options,
+    signal,
+    onProgress,
+  });
   return {
     output: {
-      provider,
-      text: textBlocks.join("\n\n").trim() || "No contents found.",
+      provider: batch.value.provider,
+      text: batch.value.text,
       summary:
-        cachedCount > 0
-          ? `${results.length} of ${urls.length} URL(s) fetched via ${provider} (${cachedCount} cached)`
-          : `${results.length} of ${urls.length} URL(s) fetched via ${provider}`,
-      itemCount: results.length,
+        batch.value.summary ??
+        `${batch.value.urls.length} URL(s) fetched via ${batch.value.provider}`,
+      itemCount: batch.value.itemCount ?? batch.value.urls.length,
     },
-    cachedCount,
+    cachedCount: batch.fromCache ? batch.value.urls.length : 0,
   };
 }
 
@@ -847,6 +877,14 @@ async function ensureBatchContentsStored({
           optionsHash: hashOptions(options),
         },
       });
+      await storePerUrlContentsEntries({
+        entries: extractStoredContentsEntriesFromMetadata(result.metadata),
+        provider: result.provider,
+        options,
+        createdAt,
+        fetchedAt,
+        ttlMs,
+      });
       return { value: stored, fromCache: false };
     } catch (error) {
       await contentStore.put<JsonValue>({
@@ -994,6 +1032,78 @@ async function ensureContentsStored({
 
   inFlightContents.set(key, task);
   return await task;
+}
+
+async function storePerUrlContentsEntries({
+  entries,
+  provider,
+  options,
+  createdAt,
+  fetchedAt,
+  ttlMs,
+}: {
+  entries: StoredContentsMetadataEntry[];
+  provider: ProviderId;
+  options: JsonObject | undefined;
+  createdAt: number;
+  fetchedAt: number;
+  ttlMs: number;
+}): Promise<void> {
+  await Promise.all(
+    entries.map(async (entry) => {
+      const canonicalUrl = canonicalizeUrl(entry.url);
+      if (!/^https?:\/\//i.test(canonicalUrl)) {
+        return;
+      }
+
+      await contentStore.put<JsonValue>({
+        key: buildContentsStoreKey(canonicalUrl, provider, options),
+        kind: CONTENT_ENTRY_KIND,
+        status: "ready",
+        createdAt,
+        updatedAt: fetchedAt,
+        expiresAt: fetchedAt + ttlMs,
+        value: {
+          url: canonicalUrl,
+          provider,
+          text: entry.text,
+          summary: entry.summary,
+          itemCount: entry.itemCount,
+          fetchedAt,
+        } as unknown as JsonValue,
+        metadata: {
+          url: canonicalUrl,
+          provider,
+          optionsHash: hashOptions(options),
+        },
+      });
+    }),
+  );
+}
+
+function extractStoredContentsEntriesFromMetadata(
+  metadata: JsonObject | undefined,
+): StoredContentsMetadataEntry[] {
+  const rawEntries = metadata?.contentsEntries;
+  if (!Array.isArray(rawEntries)) {
+    return [];
+  }
+
+  return rawEntries.flatMap((entry) =>
+    isStoredContentsMetadataEntry(entry) ? [entry] : [],
+  );
+}
+
+function isStoredContentsMetadataEntry(
+  value: unknown,
+): value is StoredContentsMetadataEntry {
+  return (
+    isJsonObject(value) &&
+    typeof value.url === "string" &&
+    typeof value.text === "string" &&
+    (value.summary === undefined || typeof value.summary === "string") &&
+    (value.itemCount === undefined || typeof value.itemCount === "number")
+  );
 }
 
 function buildBatchContentsStoreKey(

--- a/src/prefetch-manager.ts
+++ b/src/prefetch-manager.ts
@@ -88,8 +88,26 @@ interface EnsureContentsArgs {
   onProgress?: (message: string) => void;
 }
 
+/** Result of ensuring a URL's contents are stored, with cache-hit metadata. */
+interface StoredContentsResult {
+  value: StoredContentsValue;
+  fromCache: boolean;
+}
+
 const contentStore = new FileContentStore();
-const inFlightContents = new Map<string, Promise<StoredContentsValue>>();
+const inFlightContents = new Map<string, Promise<StoredContentsResult>>();
+
+/**
+ * Remove expired entries from the content store.  Call this at session start
+ * or periodically to prevent unbounded cache growth.
+ */
+export async function cleanupContentStore(): Promise<void> {
+  try {
+    await contentStore.cleanup();
+  } catch {
+    // Best-effort: don't let cleanup failures disrupt the session.
+  }
+}
 
 export async function startContentsPrefetch({
   config,
@@ -162,12 +180,7 @@ export async function startContentsPrefetch({
       const failedCount = results.filter(
         (result) => result.status === "rejected",
       ).length;
-      const status =
-        failedCount === results.length
-          ? "failed"
-          : failedCount > 0
-            ? "ready"
-            : "ready";
+      const status = failedCount === results.length ? "failed" : "ready";
       await contentStore.put<JsonValue>({
         key: buildPrefetchJobStoreKey(prefetchId),
         kind: PREFETCH_JOB_KIND,
@@ -271,6 +284,126 @@ export async function getPrefetchStatus(
   };
 }
 
+/**
+ * Returns true when at least one of the given URLs has a valid (non-expired)
+ * entry in the content store. This is used to decide whether it's worth
+ * routing a `web_contents` call through the store rather than fetching
+ * directly from the provider.
+ */
+export async function hasAnyCachedContents({
+  urls,
+  providerId,
+  options,
+}: {
+  urls: string[];
+  providerId: ProviderId;
+  options: JsonObject | undefined;
+}): Promise<boolean> {
+  const now = Date.now();
+  for (const url of urls) {
+    const key = buildContentsStoreKey(url, providerId, options);
+
+    // Fast path: if there's an in-flight fetch for this URL the store is
+    // already handling it.
+    if (inFlightContents.has(key)) {
+      return true;
+    }
+
+    const entry = await contentStore.get(key);
+    if (
+      entry?.status === "ready" &&
+      isStoredContentsValue(entry.value) &&
+      !isExpired(entry, now)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Try to serve *all* requested URLs from the cache without needing a live
+ * provider.  Returns the assembled output when every URL is a cache hit, or
+ * `undefined` when at least one URL is missing.  This lets `web_contents`
+ * succeed even if the provider that originally fetched the pages is later
+ * disabled or unavailable.
+ *
+ * When `explicitProvider` is given, only that provider's cache entries are
+ * checked.  Otherwise all known providers are probed per URL.
+ */
+export async function tryServeContentsFromStore({
+  urls,
+  explicitProvider,
+  config: _config,
+  cwd: _cwd,
+  options,
+  signal: _signal,
+}: {
+  urls: string[];
+  explicitProvider: ProviderId | undefined;
+  config: WebProvidersConfig;
+  cwd: string;
+  options: JsonObject | undefined;
+  signal?: AbortSignal;
+}): Promise<ProviderToolOutput | undefined> {
+  if (urls.length === 0) {
+    return undefined;
+  }
+
+  const now = Date.now();
+  const providerCandidates: readonly ProviderId[] = explicitProvider
+    ? [explicitProvider]
+    : PROVIDER_IDS;
+
+  const hits: StoredContentsValue[] = [];
+
+  for (const url of urls) {
+    const hit = await findCachedEntry(url, providerCandidates, options, now);
+    if (!hit) {
+      // At least one URL is not cached — bail out.
+      return undefined;
+    }
+    hits.push(hit);
+  }
+
+  const provider = hits[0]?.provider ?? (explicitProvider as ProviderId);
+  const textBlocks = hits.map((h) => h.text.trim()).filter(Boolean);
+
+  return {
+    provider,
+    text: textBlocks.join("\n\n").trim() || "No contents found.",
+    summary: `${hits.length} of ${urls.length} URL(s) served from cache`,
+    itemCount: hits.length,
+  };
+}
+
+async function findCachedEntry(
+  url: string,
+  providerCandidates: readonly ProviderId[],
+  options: JsonObject | undefined,
+  now: number,
+): Promise<StoredContentsValue | undefined> {
+  for (const pid of providerCandidates) {
+    const key = buildContentsStoreKey(url, pid, options);
+
+    // Check in-flight promises first — if a prefetch is still running we
+    // can't serve synchronously, so treat it as a miss.
+    if (inFlightContents.has(key)) {
+      return undefined;
+    }
+
+    const entry = await contentStore.get<JsonValue>(key);
+    if (
+      entry?.status === "ready" &&
+      isStoredContentsValue(entry.value) &&
+      !isExpired(entry, now)
+    ) {
+      return entry.value;
+    }
+  }
+  return undefined;
+}
+
 export async function resolveContentsFromStore({
   urls,
   providerId,
@@ -302,9 +435,9 @@ export async function resolveContentsFromStore({
     ),
   );
 
-  const values = settled
+  const results = settled
     .filter(
-      (result): result is PromiseFulfilledResult<StoredContentsValue> =>
+      (result): result is PromiseFulfilledResult<StoredContentsResult> =>
         result.status === "fulfilled",
     )
     .map((result) => result.value);
@@ -324,7 +457,7 @@ export async function resolveContentsFromStore({
       Boolean(result),
     );
 
-  if (values.length === 0 && failures.length > 0) {
+  if (results.length === 0 && failures.length > 0) {
     throw new Error(
       failures.length === 1
         ? (failures[0]?.error ?? "web_contents failed.")
@@ -337,9 +470,9 @@ export async function resolveContentsFromStore({
     );
   }
 
-  const cachedCount = values.filter((entry) => entry.fetchedAt === 0).length;
-  const provider = values[0]?.provider ?? providerId;
-  const textBlocks = values.map((entry) => entry.text.trim()).filter(Boolean);
+  const cachedCount = results.filter((r) => r.fromCache).length;
+  const provider = results[0]?.value.provider ?? providerId;
+  const textBlocks = results.map((r) => r.value.text.trim()).filter(Boolean);
 
   for (const failure of failures) {
     textBlocks.push(`Error: ${failure.url}\n   ${failure.error}`);
@@ -351,9 +484,9 @@ export async function resolveContentsFromStore({
       text: textBlocks.join("\n\n").trim() || "No contents found.",
       summary:
         cachedCount > 0
-          ? `${values.length} of ${urls.length} URL(s) fetched via ${provider} (${cachedCount} cached)`
-          : `${values.length} of ${urls.length} URL(s) fetched via ${provider}`,
-      itemCount: values.length,
+          ? `${results.length} of ${urls.length} URL(s) fetched via ${provider} (${cachedCount} cached)`
+          : `${results.length} of ${urls.length} URL(s) fetched via ${provider}`,
+      itemCount: results.length,
     },
     cachedCount,
   };
@@ -446,7 +579,7 @@ async function ensureContentsStored({
   ttlMs = DEFAULT_CONTENT_TTL_MS,
   signal,
   onProgress,
-}: EnsureContentsArgs): Promise<StoredContentsValue> {
+}: EnsureContentsArgs): Promise<StoredContentsResult> {
   const key = buildContentsStoreKey(url, providerId, options);
   const existingInFlight = inFlightContents.get(key);
   if (existingInFlight) {
@@ -462,10 +595,7 @@ async function ensureContentsStored({
       isStoredContentsValue(existing.value) &&
       !isExpired(existing, now)
     ) {
-      return {
-        ...existing.value,
-        fetchedAt: 0,
-      };
+      return { value: existing.value, fromCache: true };
     }
 
     const provider = PROVIDER_MAP[providerId];
@@ -514,21 +644,22 @@ async function ensureContentsStored({
         );
       }
 
+      const now = Date.now();
       const stored: StoredContentsValue = {
         url: canonicalizeUrl(url),
         provider: result.provider,
         text: result.text,
         summary: result.summary,
         itemCount: result.itemCount,
-        fetchedAt: Date.now(),
+        fetchedAt: now,
       };
       await contentStore.put<JsonValue>({
         key,
         kind: CONTENT_ENTRY_KIND,
         status: "ready",
         createdAt,
-        updatedAt: stored.fetchedAt,
-        expiresAt: stored.fetchedAt + ttlMs,
+        updatedAt: now,
+        expiresAt: now + ttlMs,
         value: stored as unknown as JsonValue,
         metadata: {
           url: canonicalizeUrl(url),
@@ -536,7 +667,7 @@ async function ensureContentsStored({
           optionsHash: hashOptions(options),
         },
       });
-      return stored;
+      return { value: stored, fromCache: false };
     } catch (error) {
       await contentStore.put<JsonValue>({
         key,
@@ -587,12 +718,18 @@ function resolveContentsProvider(
   searchProviderId: ProviderId | undefined,
 ) {
   if (explicitProvider) {
-    return resolveProviderForCapability(
-      config,
-      explicitProvider,
-      cwd,
-      "contents",
-    );
+    try {
+      return resolveProviderForCapability(
+        config,
+        explicitProvider,
+        cwd,
+        "contents",
+      );
+    } catch {
+      // Explicit prefetch provider is unavailable — fall through so prefetch
+      // is silently skipped rather than sinking a successful search.
+      return undefined;
+    }
   }
 
   if (searchProviderId) {

--- a/src/prefetch-manager.ts
+++ b/src/prefetch-manager.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 import {
-  type ContentStore,
   type ContentStoreEntry,
   createStoreKey,
   hashKey,
@@ -16,16 +15,16 @@ import { PROVIDER_MAP } from "./providers/index.js";
 import type {
   JsonObject,
   JsonValue,
+  ProviderContentsMetadataEntry,
   ProviderId,
   ProviderToolOutput,
   WebProvidersConfig,
 } from "./types.js";
-import { PROVIDER_IDS } from "./types.js";
 
 const CONTENT_ENTRY_KIND = "web-contents";
 const CONTENT_BATCH_ENTRY_KIND = "web-contents-batch";
 const PREFETCH_JOB_KIND = "web-prefetch-job";
-const CONTENT_CACHE_VERSION = 1;
+const CONTENT_CACHE_VERSION = 2;
 const DEFAULT_CONTENT_TTL_MS = 30 * 60 * 1000;
 const DEFAULT_PREFETCH_MAX_URLS = 3;
 const MAX_PREFETCH_URLS = 5;
@@ -38,12 +37,18 @@ export interface SearchContentsPrefetchOptions {
   contentsOptions?: JsonObject;
 }
 
+interface StoredContentItem {
+  url?: string;
+  title?: string;
+  body: string;
+  summary?: string;
+  status?: "ready" | "failed";
+}
+
 interface StoredContentsValue {
   url: string;
   provider: ProviderId;
-  text: string;
-  summary?: string;
-  itemCount?: number;
+  item: StoredContentItem;
   fetchedAt: number;
 }
 
@@ -58,7 +63,7 @@ interface PrefetchJobValue {
 interface StoredBatchContentsValue {
   urls: string[];
   provider: ProviderId;
-  text: string;
+  items: StoredContentItem[];
   summary?: string;
   itemCount?: number;
   fetchedAt: number;
@@ -69,12 +74,7 @@ interface StoredBatchContentsResult {
   fromCache: boolean;
 }
 
-interface StoredContentsMetadataEntry {
-  url: string;
-  text: string;
-  summary?: string;
-  itemCount?: number;
-}
+interface StoredContentsMetadataEntry extends ProviderContentsMetadataEntry {}
 
 export interface PrefetchStartResult {
   prefetchId: string;
@@ -296,7 +296,7 @@ export async function getPrefetchStatus(
         return {
           url,
           status: "ready" as const,
-          text: entry.value.text,
+          text: renderStoredContentItem(entry.value.item),
           provider: entry.value.provider,
         };
       }
@@ -305,7 +305,7 @@ export async function getPrefetchStatus(
         return {
           url,
           status: "ready" as const,
-          text: entry.value.text,
+          text: renderStoredContentItems(entry.value.items),
           provider: entry.value.provider,
         };
       }
@@ -402,14 +402,8 @@ export async function canResolveContentsFromStore({
 }
 
 /**
- * Try to serve *all* requested URLs from the cache without needing a live
- * provider.  Returns the assembled output when every URL is a cache hit, or
- * `undefined` when at least one URL is missing.  This lets `web_contents`
- * succeed even if the provider that originally fetched the pages is later
- * disabled or unavailable.
- *
- * When `explicitProvider` is given, only that provider's cache entries are
- * checked.  Otherwise all known providers are probed per URL.
+ * Returns true when an exact multi-URL batch entry already exists for the
+ * resolved provider (or is currently in flight).
  */
 async function hasStoredBatchContents({
   urls,
@@ -431,116 +425,6 @@ async function hasStoredBatchContents({
     isStoredBatchContentsValue(entry.value) &&
     !isExpired(entry, Date.now())
   );
-}
-
-export async function tryServeContentsFromStore({
-  urls,
-  explicitProvider,
-  config: _config,
-  cwd: _cwd,
-  options,
-  signal: _signal,
-}: {
-  urls: string[];
-  explicitProvider: ProviderId | undefined;
-  config: WebProvidersConfig;
-  cwd: string;
-  options: JsonObject | undefined;
-  signal?: AbortSignal;
-}): Promise<ProviderToolOutput | undefined> {
-  if (urls.length === 0) {
-    return undefined;
-  }
-
-  const now = Date.now();
-  const providerCandidates: readonly ProviderId[] = explicitProvider
-    ? [explicitProvider]
-    : PROVIDER_IDS;
-
-  for (const pid of providerCandidates) {
-    const batch = await findCachedBatchEntry(urls, pid, options, now);
-    if (batch) {
-      return {
-        provider: batch.provider,
-        text: batch.text,
-        summary:
-          batch.summary ?? `${batch.urls.length} URL(s) served from cache`,
-        itemCount: batch.itemCount ?? batch.urls.length,
-      };
-    }
-  }
-
-  const hits: StoredContentsValue[] = [];
-
-  for (const url of urls) {
-    const hit = await findCachedEntry(url, providerCandidates, options, now);
-    if (!hit) {
-      // At least one URL is not cached — bail out.
-      return undefined;
-    }
-    hits.push(hit);
-  }
-
-  const provider = hits[0]?.provider ?? (explicitProvider as ProviderId);
-  const textBlocks = hits.map((h) => h.text.trim()).filter(Boolean);
-
-  return {
-    provider,
-    text: textBlocks.join("\n\n").trim() || "No contents found.",
-    summary: `${hits.length} of ${urls.length} URL(s) served from cache`,
-    itemCount: hits.length,
-  };
-}
-
-async function findCachedBatchEntry(
-  urls: string[],
-  providerId: ProviderId,
-  options: JsonObject | undefined,
-  now: number,
-): Promise<StoredBatchContentsValue | undefined> {
-  const key = buildBatchContentsStoreKey(urls, providerId, options);
-
-  if (inFlightBatchContents.has(key)) {
-    return undefined;
-  }
-
-  const entry = await contentStore.get<JsonValue>(key);
-  if (
-    entry?.status === "ready" &&
-    isStoredBatchContentsValue(entry.value) &&
-    !isExpired(entry, now)
-  ) {
-    return entry.value;
-  }
-
-  return undefined;
-}
-
-async function findCachedEntry(
-  url: string,
-  providerCandidates: readonly ProviderId[],
-  options: JsonObject | undefined,
-  now: number,
-): Promise<StoredContentsValue | undefined> {
-  for (const pid of providerCandidates) {
-    const key = buildContentsStoreKey(url, pid, options);
-
-    // Check in-flight promises first — if a prefetch is still running we
-    // can't serve synchronously, so treat it as a miss.
-    if (inFlightContents.has(key)) {
-      return undefined;
-    }
-
-    const entry = await contentStore.get<JsonValue>(key);
-    if (
-      entry?.status === "ready" &&
-      isStoredContentsValue(entry.value) &&
-      !isExpired(entry, now)
-    ) {
-      return entry.value;
-    }
-  }
-  return undefined;
 }
 
 export async function resolveContentsFromStore({
@@ -574,7 +458,9 @@ export async function resolveContentsFromStore({
       return {
         output: {
           provider: batch.value.provider,
-          text: batch.value.text,
+          text: renderStoredContentItems(
+            orderStoredContentItemsForRequest(batch.value.items, urls),
+          ),
           summary:
             batch.value.summary ??
             `${batch.value.urls.length} URL(s) fetched via ${batch.value.provider}`,
@@ -635,7 +521,10 @@ export async function resolveContentsFromStore({
 
     const cachedCount = results.filter((r) => r.fromCache).length;
     const provider = results[0]?.value.provider ?? providerId;
-    const textBlocks = results.map((r) => r.value.text.trim()).filter(Boolean);
+    const renderedItems = results.map((result) => result.value.item);
+    const textBlocks = [renderStoredContentItems(renderedItems)].filter(
+      Boolean,
+    );
 
     for (const failure of failures) {
       textBlocks.push(`Error: ${failure.url}\n   ${failure.error}`);
@@ -667,7 +556,9 @@ export async function resolveContentsFromStore({
   return {
     output: {
       provider: batch.value.provider,
-      text: batch.value.text,
+      text: renderStoredContentItems(
+        orderStoredContentItemsForRequest(batch.value.items, urls),
+      ),
       summary:
         batch.value.summary ??
         `${batch.value.urls.length} URL(s) fetched via ${batch.value.provider}`,
@@ -855,10 +746,16 @@ async function ensureBatchContentsStored({
       }
 
       const fetchedAt = Date.now();
+      const structuredEntries = extractStoredContentsEntriesFromMetadata(
+        result.metadata,
+      );
       const stored: StoredBatchContentsValue = {
         urls: normalizedUrls,
         provider: result.provider,
-        text: result.text,
+        items:
+          structuredEntries.length > 0
+            ? structuredEntries.map((entry) => toStoredContentItem(entry))
+            : [{ body: result.text }],
         summary: result.summary,
         itemCount: result.itemCount,
         fetchedAt,
@@ -878,7 +775,7 @@ async function ensureBatchContentsStored({
         },
       });
       await storePerUrlContentsEntries({
-        entries: extractStoredContentsEntriesFromMetadata(result.metadata),
+        entries: structuredEntries,
         provider: result.provider,
         options,
         createdAt,
@@ -986,12 +883,17 @@ async function ensureContentsStored({
       }
 
       const now = Date.now();
+      const canonicalUrl = canonicalizeUrl(url);
+      const structuredEntry = findStoredContentsEntry(
+        extractStoredContentsEntriesFromMetadata(result.metadata),
+        canonicalUrl,
+      );
       const stored: StoredContentsValue = {
-        url: canonicalizeUrl(url),
+        url: canonicalUrl,
         provider: result.provider,
-        text: result.text,
-        summary: result.summary,
-        itemCount: result.itemCount,
+        item: structuredEntry
+          ? toStoredContentItem(structuredEntry)
+          : { body: result.text },
         fetchedAt: now,
       };
       await contentStore.put<JsonValue>({
@@ -1003,7 +905,7 @@ async function ensureContentsStored({
         expiresAt: now + ttlMs,
         value: stored as unknown as JsonValue,
         metadata: {
-          url: canonicalizeUrl(url),
+          url: canonicalUrl,
           provider: result.provider,
           optionsHash: hashOptions(options),
         },
@@ -1052,7 +954,7 @@ async function storePerUrlContentsEntries({
   await Promise.all(
     entries.map(async (entry) => {
       const canonicalUrl = canonicalizeUrl(entry.url);
-      if (!/^https?:\/\//i.test(canonicalUrl)) {
+      if (entry.status === "failed" || !/^https?:\/\//i.test(canonicalUrl)) {
         return;
       }
 
@@ -1066,9 +968,7 @@ async function storePerUrlContentsEntries({
         value: {
           url: canonicalUrl,
           provider,
-          text: entry.text,
-          summary: entry.summary,
-          itemCount: entry.itemCount,
+          item: toStoredContentItem(entry),
           fetchedAt,
         } as unknown as JsonValue,
         metadata: {
@@ -1100,9 +1000,33 @@ function isStoredContentsMetadataEntry(
   return (
     isJsonObject(value) &&
     typeof value.url === "string" &&
-    typeof value.text === "string" &&
+    (value.title === undefined || typeof value.title === "string") &&
+    typeof value.body === "string" &&
     (value.summary === undefined || typeof value.summary === "string") &&
-    (value.itemCount === undefined || typeof value.itemCount === "number")
+    (value.status === undefined ||
+      value.status === "ready" ||
+      value.status === "failed")
+  );
+}
+
+function toStoredContentItem(
+  entry: StoredContentsMetadataEntry,
+): StoredContentItem {
+  return {
+    url: entry.url,
+    title: entry.title,
+    body: entry.body,
+    summary: entry.summary,
+    status: entry.status,
+  };
+}
+
+function findStoredContentsEntry(
+  entries: StoredContentsMetadataEntry[],
+  url: string,
+): StoredContentsMetadataEntry | undefined {
+  return entries.find(
+    (entry) => entry.status !== "failed" && canonicalizeUrl(entry.url) === url,
   );
 }
 
@@ -1240,6 +1164,93 @@ function formatUnknownError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function renderStoredContentItems(items: StoredContentItem[]): string {
+  if (items.length === 0) {
+    return "No contents found.";
+  }
+
+  const blocks = items.map((item, index) =>
+    renderStoredContentItem(item, index),
+  );
+  return blocks.join("\n\n").trim() || "No contents found.";
+}
+
+function orderStoredContentItemsForRequest(
+  items: StoredContentItem[],
+  urls: string[],
+): StoredContentItem[] {
+  const itemsByUrl = new Map<string, StoredContentItem[]>();
+  const extras: StoredContentItem[] = [];
+
+  for (const item of items) {
+    if (!item.url) {
+      extras.push(item);
+      continue;
+    }
+
+    const key = canonicalizeUrl(item.url);
+    const bucket = itemsByUrl.get(key);
+    if (bucket) {
+      bucket.push(item);
+    } else {
+      itemsByUrl.set(key, [item]);
+    }
+  }
+
+  if (itemsByUrl.size === 0) {
+    return items;
+  }
+
+  const ordered: StoredContentItem[] = [];
+  for (const url of urls) {
+    const key = canonicalizeUrl(url);
+    const bucket = itemsByUrl.get(key);
+    const next = bucket?.shift();
+    if (next) {
+      ordered.push(next);
+    }
+    if (bucket && bucket.length === 0) {
+      itemsByUrl.delete(key);
+    }
+  }
+
+  for (const bucket of itemsByUrl.values()) {
+    ordered.push(...bucket);
+  }
+
+  ordered.push(...extras);
+  return ordered;
+}
+
+function renderStoredContentItem(
+  item: StoredContentItem,
+  index?: number,
+): string {
+  const hasStructuredHeader = Boolean(item.title || item.url);
+  if (!hasStructuredHeader) {
+    return item.body.trim();
+  }
+
+  const heading =
+    item.status === "failed"
+      ? `Error: ${item.url ?? item.title ?? "Untitled"}`
+      : (item.title ?? item.url ?? "Untitled");
+  const lines = [
+    `${index === undefined ? "" : `${index + 1}. `}${heading}`.trim(),
+  ];
+
+  if (item.status !== "failed" && item.url && item.url !== heading) {
+    lines.push(`   ${item.url}`);
+  }
+  if (item.body.trim()) {
+    for (const line of item.body.trim().split("\n")) {
+      lines.push(`   ${line}`);
+    }
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
 function hashOptions(options: JsonObject | undefined): string {
   return hashKey(stableStringify(stripLocalExecutionOptions(options) ?? {}));
 }
@@ -1324,7 +1335,8 @@ function isStoredBatchContentsValue(
     Array.isArray(value.urls) &&
     value.urls.every((item) => typeof item === "string") &&
     isProviderId(value.provider) &&
-    typeof value.text === "string" &&
+    Array.isArray(value.items) &&
+    value.items.every((item) => isStoredContentItem(item)) &&
     typeof value.fetchedAt === "number"
   );
 }
@@ -1338,8 +1350,23 @@ function isStoredContentsValue(
   return (
     typeof value.url === "string" &&
     isProviderId(value.provider) &&
-    typeof value.text === "string" &&
+    isStoredContentItem(value.item) &&
     typeof value.fetchedAt === "number"
+  );
+}
+
+function isStoredContentItem(
+  value: unknown,
+): value is StoredContentItem & JsonObject {
+  return (
+    isJsonObject(value) &&
+    (value.url === undefined || typeof value.url === "string") &&
+    (value.title === undefined || typeof value.title === "string") &&
+    typeof value.body === "string" &&
+    (value.summary === undefined || typeof value.summary === "string") &&
+    (value.status === undefined ||
+      value.status === "ready" ||
+      value.status === "failed")
   );
 }
 

--- a/src/prefetch-manager.ts
+++ b/src/prefetch-manager.ts
@@ -161,12 +161,9 @@ export async function startContentsPrefetch({
 
   const ttlMs = clampTtlMs(options.ttlMs);
   const contentOptions = options.contentsOptions;
-  const batchKey = buildBatchContentsStoreKey(
-    selectedUrls,
-    provider.id,
-    contentOptions,
+  const contentKeys = selectedUrls.map((url) =>
+    buildContentsStoreKey(url, provider.id, contentOptions),
   );
-  const contentKeys = selectedUrls.map(() => batchKey);
   const prefetchId = randomUUID();
   const createdAt = Date.now();
 
@@ -186,20 +183,35 @@ export async function startContentsPrefetch({
     },
   });
 
-  const task = ensureBatchContentsStored({
-    urls: selectedUrls,
-    providerId: provider.id,
-    config,
-    cwd,
-    options: contentOptions,
-    ttlMs,
-    onProgress,
-  })
-    .then(async () => {
+  const task = Promise.allSettled(
+    selectedUrls.map((url) =>
+      ensureContentsStored({
+        url,
+        providerId: provider.id,
+        config,
+        cwd,
+        options: contentOptions,
+        ttlMs,
+        onProgress,
+      }),
+    ),
+  )
+    .then(async (results) => {
+      const failedResults = results.filter(
+        (result) => result.status === "rejected",
+      );
+      const failedUrlCount = failedResults.length;
+      const error =
+        failedResults.length === 0
+          ? undefined
+          : failedResults.length === 1
+            ? formatUnknownError(failedResults[0].reason)
+            : `${failedResults.length} URL(s) failed during prefetch.`;
+
       await contentStore.put<JsonValue>({
         key: buildPrefetchJobStoreKey(prefetchId),
         kind: PREFETCH_JOB_KIND,
-        status: "ready",
+        status: failedUrlCount === selectedUrls.length ? "failed" : "ready",
         createdAt,
         updatedAt: Date.now(),
         expiresAt: createdAt + ttlMs,
@@ -210,9 +222,10 @@ export async function startContentsPrefetch({
           contentKeys,
           createdAt,
         },
+        ...(error ? { error } : {}),
         metadata: {
           totalUrlCount: selectedUrls.length,
-          failedUrlCount: 0,
+          failedUrlCount,
         },
       });
     })
@@ -231,7 +244,7 @@ export async function startContentsPrefetch({
           contentKeys,
           createdAt,
         },
-        error: error instanceof Error ? error.message : String(error),
+        error: formatUnknownError(error),
         metadata: {
           totalUrlCount: selectedUrls.length,
           failedUrlCount: selectedUrls.length,
@@ -1111,6 +1124,10 @@ function clampTtlMs(value: number | undefined): number {
 
 function isExpired(entry: ContentStoreEntry, now: number): boolean {
   return entry.expiresAt !== undefined && entry.expiresAt <= now;
+}
+
+function formatUnknownError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function hashOptions(options: JsonObject | undefined): string {

--- a/src/prefetch-manager.ts
+++ b/src/prefetch-manager.ts
@@ -20,8 +20,10 @@ import type {
   ProviderToolOutput,
   WebProvidersConfig,
 } from "./types.js";
+import { PROVIDER_IDS } from "./types.js";
 
 const CONTENT_ENTRY_KIND = "web-contents";
+const CONTENT_BATCH_ENTRY_KIND = "web-contents-batch";
 const PREFETCH_JOB_KIND = "web-prefetch-job";
 const CONTENT_CACHE_VERSION = 1;
 const DEFAULT_CONTENT_TTL_MS = 30 * 60 * 1000;
@@ -51,6 +53,20 @@ interface PrefetchJobValue {
   urls: string[];
   contentKeys: string[];
   createdAt: number;
+}
+
+interface StoredBatchContentsValue {
+  urls: string[];
+  provider: ProviderId;
+  text: string;
+  summary?: string;
+  itemCount?: number;
+  fetchedAt: number;
+}
+
+interface StoredBatchContentsResult {
+  value: StoredBatchContentsValue;
+  fromCache: boolean;
 }
 
 export interface PrefetchStartResult {
@@ -96,6 +112,10 @@ interface StoredContentsResult {
 
 const contentStore = new FileContentStore();
 const inFlightContents = new Map<string, Promise<StoredContentsResult>>();
+const inFlightBatchContents = new Map<
+  string,
+  Promise<StoredBatchContentsResult>
+>();
 
 /**
  * Remove expired entries from the content store.  Call this at session start
@@ -141,9 +161,12 @@ export async function startContentsPrefetch({
 
   const ttlMs = clampTtlMs(options.ttlMs);
   const contentOptions = options.contentsOptions;
-  const contentKeys = selectedUrls.map((url) =>
-    buildContentsStoreKey(url, provider.id, contentOptions),
+  const batchKey = buildBatchContentsStoreKey(
+    selectedUrls,
+    provider.id,
+    contentOptions,
   );
+  const contentKeys = selectedUrls.map(() => batchKey);
   const prefetchId = randomUUID();
   const createdAt = Date.now();
 
@@ -163,28 +186,20 @@ export async function startContentsPrefetch({
     },
   });
 
-  const task = Promise.allSettled(
-    selectedUrls.map((url) =>
-      ensureContentsStored({
-        url,
-        providerId: provider.id,
-        config,
-        cwd,
-        options: contentOptions,
-        ttlMs,
-        onProgress,
-      }),
-    ),
-  )
-    .then(async (results) => {
-      const failedCount = results.filter(
-        (result) => result.status === "rejected",
-      ).length;
-      const status = failedCount === results.length ? "failed" : "ready";
+  const task = ensureBatchContentsStored({
+    urls: selectedUrls,
+    providerId: provider.id,
+    config,
+    cwd,
+    options: contentOptions,
+    ttlMs,
+    onProgress,
+  })
+    .then(async () => {
       await contentStore.put<JsonValue>({
         key: buildPrefetchJobStoreKey(prefetchId),
         kind: PREFETCH_JOB_KIND,
-        status,
+        status: "ready",
         createdAt,
         updatedAt: Date.now(),
         expiresAt: createdAt + ttlMs,
@@ -197,11 +212,32 @@ export async function startContentsPrefetch({
         },
         metadata: {
           totalUrlCount: selectedUrls.length,
-          failedUrlCount: failedCount,
+          failedUrlCount: 0,
         },
       });
     })
-    .catch(() => undefined);
+    .catch(async (error) => {
+      await contentStore.put<JsonValue>({
+        key: buildPrefetchJobStoreKey(prefetchId),
+        kind: PREFETCH_JOB_KIND,
+        status: "failed",
+        createdAt,
+        updatedAt: Date.now(),
+        expiresAt: createdAt + ttlMs,
+        value: {
+          prefetchId,
+          provider: provider.id,
+          urls: selectedUrls,
+          contentKeys,
+          createdAt,
+        },
+        error: error instanceof Error ? error.message : String(error),
+        metadata: {
+          totalUrlCount: selectedUrls.length,
+          failedUrlCount: selectedUrls.length,
+        },
+      });
+    });
 
   void task;
 
@@ -235,13 +271,24 @@ export async function getPrefetchStatus(
       };
     }
 
-    if (entry.status === "ready" && isStoredContentsValue(entry.value)) {
-      return {
-        url,
-        status: "ready" as const,
-        text: entry.value.text,
-        provider: entry.value.provider,
-      };
+    if (entry.status === "ready") {
+      if (isStoredContentsValue(entry.value)) {
+        return {
+          url,
+          status: "ready" as const,
+          text: entry.value.text,
+          provider: entry.value.provider,
+        };
+      }
+
+      if (isStoredBatchContentsValue(entry.value)) {
+        return {
+          url,
+          status: "ready" as const,
+          text: entry.value.text,
+          provider: entry.value.provider,
+        };
+      }
     }
 
     if (entry.status === "failed") {
@@ -285,12 +332,17 @@ export async function getPrefetchStatus(
 }
 
 /**
- * Returns true when at least one of the given URLs has a valid (non-expired)
- * entry in the content store. This is used to decide whether it's worth
- * routing a `web_contents` call through the store rather than fetching
- * directly from the provider.
+ * Returns true when the entire `web_contents` request can be satisfied from
+ * the store without triggering new per-URL fetches. We allow two cases:
+ *   1. an exact multi-URL batch entry already exists (or is currently in
+ *      flight), or
+ *   2. every requested URL already has an individual cached/in-flight entry.
+ *
+ * Partial cache hits intentionally return false so the caller can fall back to
+ * the provider's native batched contents endpoint instead of fanning out into
+ * one request per missing URL.
  */
-export async function hasAnyCachedContents({
+export async function canResolveContentsFromStore({
   urls,
   providerId,
   options,
@@ -299,14 +351,20 @@ export async function hasAnyCachedContents({
   providerId: ProviderId;
   options: JsonObject | undefined;
 }): Promise<boolean> {
+  if (urls.length === 0) {
+    return false;
+  }
+
+  if (await hasStoredBatchContents({ urls, providerId, options })) {
+    return true;
+  }
+
   const now = Date.now();
   for (const url of urls) {
     const key = buildContentsStoreKey(url, providerId, options);
 
-    // Fast path: if there's an in-flight fetch for this URL the store is
-    // already handling it.
     if (inFlightContents.has(key)) {
-      return true;
+      continue;
     }
 
     const entry = await contentStore.get(key);
@@ -315,10 +373,12 @@ export async function hasAnyCachedContents({
       isStoredContentsValue(entry.value) &&
       !isExpired(entry, now)
     ) {
-      return true;
+      continue;
     }
+
+    return false;
   }
-  return false;
+  return true;
 }
 
 /**
@@ -331,6 +391,28 @@ export async function hasAnyCachedContents({
  * When `explicitProvider` is given, only that provider's cache entries are
  * checked.  Otherwise all known providers are probed per URL.
  */
+async function hasStoredBatchContents({
+  urls,
+  providerId,
+  options,
+}: {
+  urls: string[];
+  providerId: ProviderId;
+  options: JsonObject | undefined;
+}): Promise<boolean> {
+  const key = buildBatchContentsStoreKey(urls, providerId, options);
+  if (inFlightBatchContents.has(key)) {
+    return true;
+  }
+
+  const entry = await contentStore.get<JsonValue>(key);
+  return (
+    entry?.status === "ready" &&
+    isStoredBatchContentsValue(entry.value) &&
+    !isExpired(entry, Date.now())
+  );
+}
+
 export async function tryServeContentsFromStore({
   urls,
   explicitProvider,
@@ -355,6 +437,19 @@ export async function tryServeContentsFromStore({
     ? [explicitProvider]
     : PROVIDER_IDS;
 
+  for (const pid of providerCandidates) {
+    const batch = await findCachedBatchEntry(urls, pid, options, now);
+    if (batch) {
+      return {
+        provider: batch.provider,
+        text: batch.text,
+        summary:
+          batch.summary ?? `${batch.urls.length} URL(s) served from cache`,
+        itemCount: batch.itemCount ?? batch.urls.length,
+      };
+    }
+  }
+
   const hits: StoredContentsValue[] = [];
 
   for (const url of urls) {
@@ -375,6 +470,30 @@ export async function tryServeContentsFromStore({
     summary: `${hits.length} of ${urls.length} URL(s) served from cache`,
     itemCount: hits.length,
   };
+}
+
+async function findCachedBatchEntry(
+  urls: string[],
+  providerId: ProviderId,
+  options: JsonObject | undefined,
+  now: number,
+): Promise<StoredBatchContentsValue | undefined> {
+  const key = buildBatchContentsStoreKey(urls, providerId, options);
+
+  if (inFlightBatchContents.has(key)) {
+    return undefined;
+  }
+
+  const entry = await contentStore.get<JsonValue>(key);
+  if (
+    entry?.status === "ready" &&
+    isStoredBatchContentsValue(entry.value) &&
+    !isExpired(entry, now)
+  ) {
+    return entry.value;
+  }
+
+  return undefined;
 }
 
 async function findCachedEntry(
@@ -421,6 +540,29 @@ export async function resolveContentsFromStore({
   signal?: AbortSignal;
   onProgress?: (message: string) => void;
 }): Promise<{ output: ProviderToolOutput; cachedCount: number }> {
+  if (await hasStoredBatchContents({ urls, providerId, options })) {
+    const batch = await ensureBatchContentsStored({
+      urls,
+      providerId,
+      config,
+      cwd,
+      options,
+      signal,
+      onProgress,
+    });
+    return {
+      output: {
+        provider: batch.value.provider,
+        text: batch.value.text,
+        summary:
+          batch.value.summary ??
+          `${batch.value.urls.length} URL(s) fetched via ${batch.value.provider}`,
+        itemCount: batch.value.itemCount ?? batch.value.urls.length,
+      },
+      cachedCount: batch.fromCache ? batch.value.urls.length : 0,
+    };
+  }
+
   const settled = await Promise.allSettled(
     urls.map((url) =>
       ensureContentsStored({
@@ -564,11 +706,149 @@ export function formatPrefetchStatusText(
 }
 
 export const __prefetchTest__ = {
+  buildBatchContentsStoreKey,
   buildContentsStoreKey,
   buildPrefetchJobStoreKey,
   selectPrefetchUrls,
   resolveContentsProvider,
 };
+
+async function ensureBatchContentsStored({
+  urls,
+  providerId,
+  config,
+  cwd,
+  options,
+  ttlMs = DEFAULT_CONTENT_TTL_MS,
+  signal,
+  onProgress,
+}: {
+  urls: string[];
+  providerId: ProviderId;
+  config: WebProvidersConfig;
+  cwd: string;
+  options: JsonObject | undefined;
+  ttlMs?: number;
+  signal?: AbortSignal;
+  onProgress?: (message: string) => void;
+}): Promise<StoredBatchContentsResult> {
+  const normalizedUrls = normalizeUrlSet(urls);
+  if (normalizedUrls.length === 0) {
+    throw new Error("At least one valid HTTP(S) URL is required.");
+  }
+
+  const key = buildBatchContentsStoreKey(normalizedUrls, providerId, options);
+  const existingInFlight = inFlightBatchContents.get(key);
+  if (existingInFlight) {
+    return await existingInFlight;
+  }
+
+  const task = (async () => {
+    const existing = await contentStore.get<JsonValue>(key);
+    const now = Date.now();
+
+    if (
+      existing?.status === "ready" &&
+      isStoredBatchContentsValue(existing.value) &&
+      !isExpired(existing, now)
+    ) {
+      return { value: existing.value, fromCache: true };
+    }
+
+    const provider = PROVIDER_MAP[providerId];
+    const providerConfig = getEffectiveProviderConfig(config, providerId);
+    if (!providerConfig) {
+      throw new Error(`Provider '${providerId}' is not configured.`);
+    }
+
+    const createdAt = now;
+    await contentStore.put<JsonValue>({
+      key,
+      kind: CONTENT_BATCH_ENTRY_KIND,
+      status: "pending",
+      createdAt,
+      updatedAt: createdAt,
+      expiresAt: createdAt + ttlMs,
+      metadata: {
+        urls: normalizedUrls as unknown as JsonValue,
+        provider: providerId,
+        optionsHash: hashOptions(options),
+      },
+    });
+
+    try {
+      const plan = provider.buildPlan(
+        {
+          capability: "contents",
+          urls: normalizedUrls,
+          options: stripLocalExecutionOptions(options),
+        },
+        providerConfig as never,
+      );
+      if (!plan) {
+        throw new Error(
+          `Provider '${providerId}' could not build a contents plan.`,
+        );
+      }
+      const result = await executeOperationPlan(plan, options, {
+        cwd,
+        signal,
+        onProgress,
+      });
+      if ("results" in result) {
+        throw new Error(
+          `${provider.label} contents returned an invalid result.`,
+        );
+      }
+
+      const fetchedAt = Date.now();
+      const stored: StoredBatchContentsValue = {
+        urls: normalizedUrls,
+        provider: result.provider,
+        text: result.text,
+        summary: result.summary,
+        itemCount: result.itemCount,
+        fetchedAt,
+      };
+      await contentStore.put<JsonValue>({
+        key,
+        kind: CONTENT_BATCH_ENTRY_KIND,
+        status: "ready",
+        createdAt,
+        updatedAt: fetchedAt,
+        expiresAt: fetchedAt + ttlMs,
+        value: stored as unknown as JsonValue,
+        metadata: {
+          urls: normalizedUrls as unknown as JsonValue,
+          provider: result.provider,
+          optionsHash: hashOptions(options),
+        },
+      });
+      return { value: stored, fromCache: false };
+    } catch (error) {
+      await contentStore.put<JsonValue>({
+        key,
+        kind: CONTENT_BATCH_ENTRY_KIND,
+        status: "failed",
+        createdAt,
+        updatedAt: Date.now(),
+        expiresAt: Date.now() + ttlMs,
+        error: error instanceof Error ? error.message : String(error),
+        metadata: {
+          urls: normalizedUrls as unknown as JsonValue,
+          provider: providerId,
+          optionsHash: hashOptions(options),
+        },
+      });
+      throw error;
+    } finally {
+      inFlightBatchContents.delete(key);
+    }
+  })();
+
+  inFlightBatchContents.set(key, task);
+  return await task;
+}
 
 async function ensureContentsStored({
   url,
@@ -693,6 +973,20 @@ async function ensureContentsStored({
   return await task;
 }
 
+function buildBatchContentsStoreKey(
+  urls: string[],
+  providerId: ProviderId,
+  options: JsonObject | undefined,
+): string {
+  return createStoreKey([
+    CONTENT_BATCH_ENTRY_KIND,
+    `v${CONTENT_CACHE_VERSION}`,
+    providerId,
+    hashKey(stableStringify(normalizeUrlSet(urls))),
+    hashOptions(options),
+  ]);
+}
+
 function buildContentsStoreKey(
   url: string,
   providerId: ProviderId,
@@ -760,6 +1054,12 @@ function canonicalizeUrl(url: string): string {
   } catch {
     return url.trim();
   }
+}
+
+function normalizeUrlSet(urls: string[]): string[] {
+  return [...new Set(urls.map((url) => canonicalizeUrl(url)).filter(Boolean))]
+    .filter((url) => /^https?:\/\//i.test(url))
+    .sort();
 }
 
 function selectPrefetchUrls(
@@ -874,6 +1174,21 @@ function isProviderId(value: unknown): value is ProviderId {
     value === "perplexity" ||
     value === "parallel" ||
     value === "valyu"
+  );
+}
+
+function isStoredBatchContentsValue(
+  value: unknown,
+): value is StoredBatchContentsValue & JsonObject {
+  if (!isJsonObject(value)) {
+    return false;
+  }
+  return (
+    Array.isArray(value.urls) &&
+    value.urls.every((item) => typeof item === "string") &&
+    isProviderId(value.provider) &&
+    typeof value.text === "string" &&
+    typeof value.fetchedAt === "number"
   );
 }
 

--- a/src/prefetch-manager.ts
+++ b/src/prefetch-manager.ts
@@ -118,11 +118,16 @@ interface StoredContentsResult {
   fromCache: boolean;
 }
 
+interface InFlightEntry<TValue> {
+  generation: number;
+  task: Promise<TValue>;
+}
+
 const contentStore = new MemoryContentStore();
-const inFlightContents = new Map<string, Promise<StoredContentsResult>>();
+const inFlightContents = new Map<string, InFlightEntry<StoredContentsResult>>();
 const inFlightBatchContents = new Map<
   string,
-  Promise<StoredBatchContentsResult>
+  InFlightEntry<StoredBatchContentsResult>
 >();
 let contentStoreGeneration = 0;
 
@@ -686,6 +691,18 @@ export const __prefetchTest__ = {
   resolveContentsProvider,
 };
 
+function deleteInFlightEntryIfCurrent<TValue>(
+  map: Map<string, InFlightEntry<TValue>>,
+  key: string,
+  generation: number,
+  task: Promise<TValue>,
+): void {
+  const current = map.get(key);
+  if (current?.generation === generation && current.task === task) {
+    map.delete(key);
+  }
+}
+
 async function ensureBatchContentsStored({
   urls,
   providerId,
@@ -715,10 +732,11 @@ async function ensureBatchContentsStored({
   const key = buildBatchContentsStoreKey(normalizedUrls, providerId, options);
   const existingInFlight = inFlightBatchContents.get(key);
   if (existingInFlight) {
-    return await existingInFlight;
+    return await existingInFlight.task;
   }
 
-  const task = (async () => {
+  let task!: Promise<StoredBatchContentsResult>;
+  task = (async () => {
     const existing = await contentStore.get<JsonValue>(key);
     const now = Date.now();
 
@@ -841,11 +859,16 @@ async function ensureBatchContentsStored({
       });
       throw error;
     } finally {
-      inFlightBatchContents.delete(key);
+      deleteInFlightEntryIfCurrent(
+        inFlightBatchContents,
+        key,
+        generation,
+        task,
+      );
     }
   })();
 
-  inFlightBatchContents.set(key, task);
+  inFlightBatchContents.set(key, { generation, task });
   return await task;
 }
 
@@ -863,10 +886,11 @@ async function ensureContentsStored({
   const key = buildContentsStoreKey(url, providerId, options);
   const existingInFlight = inFlightContents.get(key);
   if (existingInFlight) {
-    return await existingInFlight;
+    return await existingInFlight.task;
   }
 
-  const task = (async () => {
+  let task!: Promise<StoredContentsResult>;
+  task = (async () => {
     const existing = await contentStore.get<JsonValue>(key);
     const now = Date.now();
 
@@ -979,11 +1003,11 @@ async function ensureContentsStored({
       });
       throw error;
     } finally {
-      inFlightContents.delete(key);
+      deleteInFlightEntryIfCurrent(inFlightContents, key, generation, task);
     }
   })();
 
-  inFlightContents.set(key, task);
+  inFlightContents.set(key, { generation, task });
   return await task;
 }
 

--- a/src/prefetch-manager.ts
+++ b/src/prefetch-manager.ts
@@ -3,8 +3,8 @@ import {
   type ContentStore,
   type ContentStoreEntry,
   createStoreKey,
-  FileContentStore,
   hashKey,
+  MemoryContentStore,
 } from "./content-store.js";
 import { stripLocalExecutionOptions } from "./execution-policy.js";
 import {
@@ -110,7 +110,7 @@ interface StoredContentsResult {
   fromCache: boolean;
 }
 
-const contentStore = new FileContentStore();
+const contentStore = new MemoryContentStore();
 const inFlightContents = new Map<string, Promise<StoredContentsResult>>();
 const inFlightBatchContents = new Map<
   string,
@@ -703,6 +703,16 @@ export function formatPrefetchStatusText(
   }
 
   return lines.join("\n");
+}
+
+/**
+ * Reset all in-memory cache state. Intended for use in tests to isolate
+ * test cases from each other.
+ */
+export function resetContentStore(): void {
+  contentStore.clear();
+  inFlightContents.clear();
+  inFlightBatchContents.clear();
 }
 
 export const __prefetchTest__ = {

--- a/src/prefetch-manager.ts
+++ b/src/prefetch-manager.ts
@@ -385,15 +385,16 @@ export async function getPrefetchStatus(
 }
 
 /**
- * Returns true when the entire `web_contents` request can be satisfied from
- * the store without triggering new per-URL fetches. We allow two cases:
+ * Returns true when `web_contents` should route through the local store first.
+ * We prefer store-backed resolution when either:
  *   1. an exact multi-URL batch entry already exists (or is currently in
  *      flight), or
- *   2. every requested URL already has an individual cached/in-flight entry.
+ *   2. at least one requested URL already has an individual cached/in-flight
+ *      entry that we can reuse while fetching only the missing URLs.
  *
- * Partial cache hits intentionally return false so the caller can fall back to
- * the provider's native batched contents endpoint instead of fanning out into
- * one request per missing URL.
+ * When nothing is cached yet, callers can fall back to the provider's native
+ * batched contents endpoint to avoid fanning out a cold multi-URL request into
+ * one request per URL.
  */
 export async function canResolveContentsFromStore({
   urls,
@@ -417,7 +418,7 @@ export async function canResolveContentsFromStore({
     const key = buildContentsStoreKey(url, providerId, options);
 
     if (inFlightContents.has(key)) {
-      continue;
+      return true;
     }
 
     const entry = await contentStore.get(key);
@@ -426,12 +427,11 @@ export async function canResolveContentsFromStore({
       isStoredContentsValue(entry.value) &&
       !isExpired(entry, now)
     ) {
-      continue;
+      return true;
     }
-
-    return false;
   }
-  return true;
+
+  return false;
 }
 
 /**
@@ -569,7 +569,7 @@ export async function resolveContentsFromStore({
         text: textBlocks.join("\n\n").trim() || "No contents found.",
         summary:
           cachedCount > 0
-            ? `${results.length} of ${urls.length} URL(s) fetched via ${provider} (${cachedCount} cached)`
+            ? `${results.length} of ${urls.length} URL(s) resolved via ${provider} (${cachedCount} cached)`
             : `${results.length} of ${urls.length} URL(s) fetched via ${provider}`,
         itemCount: results.length,
       },

--- a/src/prefetch-manager.ts
+++ b/src/prefetch-manager.ts
@@ -1,0 +1,772 @@
+import { randomUUID } from "node:crypto";
+import {
+  type ContentStore,
+  type ContentStoreEntry,
+  createStoreKey,
+  FileContentStore,
+  hashKey,
+} from "./content-store.js";
+import { stripLocalExecutionOptions } from "./execution-policy.js";
+import {
+  getEffectiveProviderConfig,
+  resolveProviderForCapability,
+} from "./provider-resolution.js";
+import { executeOperationPlan } from "./provider-runtime.js";
+import { PROVIDER_MAP } from "./providers/index.js";
+import type {
+  JsonObject,
+  JsonValue,
+  ProviderId,
+  ProviderToolOutput,
+  WebProvidersConfig,
+} from "./types.js";
+
+const CONTENT_ENTRY_KIND = "web-contents";
+const PREFETCH_JOB_KIND = "web-prefetch-job";
+const CONTENT_CACHE_VERSION = 1;
+const DEFAULT_CONTENT_TTL_MS = 30 * 60 * 1000;
+const DEFAULT_PREFETCH_MAX_URLS = 3;
+const MAX_PREFETCH_URLS = 5;
+
+export interface SearchContentsPrefetchOptions {
+  enabled?: boolean;
+  maxUrls?: number;
+  provider?: ProviderId;
+  ttlMs?: number;
+  contentsOptions?: JsonObject;
+}
+
+interface StoredContentsValue {
+  url: string;
+  provider: ProviderId;
+  text: string;
+  summary?: string;
+  itemCount?: number;
+  fetchedAt: number;
+}
+
+interface PrefetchJobValue {
+  prefetchId: string;
+  provider: ProviderId;
+  urls: string[];
+  contentKeys: string[];
+  createdAt: number;
+}
+
+export interface PrefetchStartResult {
+  prefetchId: string;
+  provider: ProviderId;
+  urlCount: number;
+  queuedUrls: string[];
+}
+
+export interface PrefetchStatus {
+  prefetchId: string;
+  provider: ProviderId;
+  status: "pending" | "ready" | "failed";
+  totalUrlCount: number;
+  readyUrlCount: number;
+  failedUrlCount: number;
+  pendingUrlCount: number;
+  urls: Array<{
+    url: string;
+    status: "pending" | "ready" | "failed";
+    text?: string;
+    error?: string;
+    provider?: ProviderId;
+  }>;
+}
+
+interface EnsureContentsArgs {
+  url: string;
+  providerId: ProviderId;
+  config: WebProvidersConfig;
+  cwd: string;
+  options: JsonObject | undefined;
+  ttlMs?: number;
+  signal?: AbortSignal;
+  onProgress?: (message: string) => void;
+}
+
+const contentStore = new FileContentStore();
+const inFlightContents = new Map<string, Promise<StoredContentsValue>>();
+
+export async function startContentsPrefetch({
+  config,
+  cwd,
+  urls,
+  searchProviderId,
+  options,
+  onProgress,
+}: {
+  config: WebProvidersConfig;
+  cwd: string;
+  urls: string[];
+  searchProviderId?: ProviderId;
+  options: SearchContentsPrefetchOptions;
+  onProgress?: (message: string) => void;
+}): Promise<PrefetchStartResult | undefined> {
+  const selectedUrls = selectPrefetchUrls(urls, options.maxUrls);
+  if (selectedUrls.length === 0) {
+    return undefined;
+  }
+
+  const provider = resolveContentsProvider(
+    config,
+    cwd,
+    options.provider,
+    searchProviderId,
+  );
+  if (!provider) {
+    return undefined;
+  }
+
+  const ttlMs = clampTtlMs(options.ttlMs);
+  const contentOptions = options.contentsOptions;
+  const contentKeys = selectedUrls.map((url) =>
+    buildContentsStoreKey(url, provider.id, contentOptions),
+  );
+  const prefetchId = randomUUID();
+  const createdAt = Date.now();
+
+  await contentStore.put<JsonValue>({
+    key: buildPrefetchJobStoreKey(prefetchId),
+    kind: PREFETCH_JOB_KIND,
+    status: "pending",
+    createdAt,
+    updatedAt: createdAt,
+    expiresAt: createdAt + ttlMs,
+    value: {
+      prefetchId,
+      provider: provider.id,
+      urls: selectedUrls,
+      contentKeys,
+      createdAt,
+    },
+  });
+
+  const task = Promise.allSettled(
+    selectedUrls.map((url) =>
+      ensureContentsStored({
+        url,
+        providerId: provider.id,
+        config,
+        cwd,
+        options: contentOptions,
+        ttlMs,
+        onProgress,
+      }),
+    ),
+  )
+    .then(async (results) => {
+      const failedCount = results.filter(
+        (result) => result.status === "rejected",
+      ).length;
+      const status =
+        failedCount === results.length
+          ? "failed"
+          : failedCount > 0
+            ? "ready"
+            : "ready";
+      await contentStore.put<JsonValue>({
+        key: buildPrefetchJobStoreKey(prefetchId),
+        kind: PREFETCH_JOB_KIND,
+        status,
+        createdAt,
+        updatedAt: Date.now(),
+        expiresAt: createdAt + ttlMs,
+        value: {
+          prefetchId,
+          provider: provider.id,
+          urls: selectedUrls,
+          contentKeys,
+          createdAt,
+        },
+        metadata: {
+          totalUrlCount: selectedUrls.length,
+          failedUrlCount: failedCount,
+        },
+      });
+    })
+    .catch(() => undefined);
+
+  void task;
+
+  return {
+    prefetchId,
+    provider: provider.id,
+    urlCount: selectedUrls.length,
+    queuedUrls: selectedUrls,
+  };
+}
+
+export async function getPrefetchStatus(
+  prefetchId: string,
+): Promise<PrefetchStatus | undefined> {
+  const job = await contentStore.get<JsonValue>(
+    buildPrefetchJobStoreKey(prefetchId),
+  );
+  if (!job || !isPrefetchJobValue(job.value)) {
+    return undefined;
+  }
+
+  const entries = await Promise.all(
+    job.value.contentKeys.map((key) => contentStore.get<JsonValue>(key)),
+  );
+  const urlStates = job.value.urls.map((url, index) => {
+    const entry = entries[index];
+    if (!entry) {
+      return {
+        url,
+        status: "pending" as const,
+      };
+    }
+
+    if (entry.status === "ready" && isStoredContentsValue(entry.value)) {
+      return {
+        url,
+        status: "ready" as const,
+        text: entry.value.text,
+        provider: entry.value.provider,
+      };
+    }
+
+    if (entry.status === "failed") {
+      return {
+        url,
+        status: "failed" as const,
+        error: entry.error,
+      };
+    }
+
+    return {
+      url,
+      status: "pending" as const,
+    };
+  });
+
+  const readyUrlCount = urlStates.filter(
+    (entry) => entry.status === "ready",
+  ).length;
+  const failedUrlCount = urlStates.filter(
+    (entry) => entry.status === "failed",
+  ).length;
+  const pendingUrlCount = urlStates.length - readyUrlCount - failedUrlCount;
+  const status =
+    failedUrlCount === urlStates.length
+      ? "failed"
+      : pendingUrlCount > 0
+        ? "pending"
+        : "ready";
+
+  return {
+    prefetchId: job.value.prefetchId,
+    provider: job.value.provider,
+    status,
+    totalUrlCount: urlStates.length,
+    readyUrlCount,
+    failedUrlCount,
+    pendingUrlCount,
+    urls: urlStates,
+  };
+}
+
+export async function resolveContentsFromStore({
+  urls,
+  providerId,
+  config,
+  cwd,
+  options,
+  signal,
+  onProgress,
+}: {
+  urls: string[];
+  providerId: ProviderId;
+  config: WebProvidersConfig;
+  cwd: string;
+  options: JsonObject | undefined;
+  signal?: AbortSignal;
+  onProgress?: (message: string) => void;
+}): Promise<{ output: ProviderToolOutput; cachedCount: number }> {
+  const settled = await Promise.allSettled(
+    urls.map((url) =>
+      ensureContentsStored({
+        url,
+        providerId,
+        config,
+        cwd,
+        options,
+        signal,
+        onProgress,
+      }),
+    ),
+  );
+
+  const values = settled
+    .filter(
+      (result): result is PromiseFulfilledResult<StoredContentsValue> =>
+        result.status === "fulfilled",
+    )
+    .map((result) => result.value);
+  const failures = settled
+    .map((result, index) =>
+      result.status === "rejected"
+        ? {
+            url: urls[index] ?? "",
+            error:
+              result.reason instanceof Error
+                ? result.reason.message
+                : String(result.reason),
+          }
+        : undefined,
+    )
+    .filter((result): result is { url: string; error: string } =>
+      Boolean(result),
+    );
+
+  if (values.length === 0 && failures.length > 0) {
+    throw new Error(
+      failures.length === 1
+        ? (failures[0]?.error ?? "web_contents failed.")
+        : `web_contents failed for all ${failures.length} URL(s): ${failures
+            .map(
+              (failure, index) =>
+                `${index + 1}. ${failure.url} — ${failure.error}`,
+            )
+            .join("; ")}`,
+    );
+  }
+
+  const cachedCount = values.filter((entry) => entry.fetchedAt === 0).length;
+  const provider = values[0]?.provider ?? providerId;
+  const textBlocks = values.map((entry) => entry.text.trim()).filter(Boolean);
+
+  for (const failure of failures) {
+    textBlocks.push(`Error: ${failure.url}\n   ${failure.error}`);
+  }
+
+  return {
+    output: {
+      provider,
+      text: textBlocks.join("\n\n").trim() || "No contents found.",
+      summary:
+        cachedCount > 0
+          ? `${values.length} of ${urls.length} URL(s) fetched via ${provider} (${cachedCount} cached)`
+          : `${values.length} of ${urls.length} URL(s) fetched via ${provider}`,
+      itemCount: values.length,
+    },
+    cachedCount,
+  };
+}
+
+export function parseSearchContentsPrefetchOptions(
+  options: JsonObject | undefined,
+): SearchContentsPrefetchOptions | undefined {
+  const raw = options?.prefetch;
+  if (raw === undefined) {
+    return undefined;
+  }
+  if (!isJsonObject(raw)) {
+    throw new Error("prefetch must be an object.");
+  }
+
+  const enabled =
+    raw.enabled === undefined
+      ? true
+      : parseOptionalBoolean(raw.enabled, "enabled");
+  const maxUrls = parseOptionalPositiveInteger(raw.maxUrls, "maxUrls");
+  const provider = parseOptionalProviderId(raw.provider);
+  const ttlMs = parseOptionalPositiveInteger(raw.ttlMs, "ttlMs");
+  const contentsOptions =
+    raw.contentsOptions === undefined
+      ? undefined
+      : assertJsonObject(raw.contentsOptions, "prefetch.contentsOptions");
+
+  return {
+    enabled,
+    maxUrls,
+    provider,
+    ttlMs,
+    contentsOptions,
+  };
+}
+
+export function stripSearchContentsPrefetchOptions(
+  options: JsonObject | undefined,
+): JsonObject | undefined {
+  if (!options) {
+    return undefined;
+  }
+
+  const { prefetch: _prefetch, ...rest } = options;
+  return Object.keys(rest).length > 0 ? (rest as JsonObject) : undefined;
+}
+
+export function formatPrefetchStatusText(
+  status: PrefetchStatus,
+  includeContent = false,
+): string {
+  const lines = [
+    `Prefetch ${status.prefetchId}`,
+    `Provider: ${status.provider}`,
+    `Status: ${status.status}`,
+    `Ready: ${status.readyUrlCount}/${status.totalUrlCount}`,
+  ];
+
+  for (const [index, entry] of status.urls.entries()) {
+    lines.push("");
+    lines.push(`${index + 1}. ${entry.url}`);
+    lines.push(`   ${entry.status}`);
+    if (entry.error) {
+      lines.push(`   ${entry.error}`);
+    }
+    if (includeContent && entry.text) {
+      for (const line of entry.text.split("\n")) {
+        lines.push(`   ${line}`);
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export const __prefetchTest__ = {
+  buildContentsStoreKey,
+  buildPrefetchJobStoreKey,
+  selectPrefetchUrls,
+  resolveContentsProvider,
+};
+
+async function ensureContentsStored({
+  url,
+  providerId,
+  config,
+  cwd,
+  options,
+  ttlMs = DEFAULT_CONTENT_TTL_MS,
+  signal,
+  onProgress,
+}: EnsureContentsArgs): Promise<StoredContentsValue> {
+  const key = buildContentsStoreKey(url, providerId, options);
+  const existingInFlight = inFlightContents.get(key);
+  if (existingInFlight) {
+    return await existingInFlight;
+  }
+
+  const task = (async () => {
+    const existing = await contentStore.get<JsonValue>(key);
+    const now = Date.now();
+
+    if (
+      existing?.status === "ready" &&
+      isStoredContentsValue(existing.value) &&
+      !isExpired(existing, now)
+    ) {
+      return {
+        ...existing.value,
+        fetchedAt: 0,
+      };
+    }
+
+    const provider = PROVIDER_MAP[providerId];
+    const providerConfig = getEffectiveProviderConfig(config, providerId);
+    if (!providerConfig) {
+      throw new Error(`Provider '${providerId}' is not configured.`);
+    }
+
+    const createdAt = now;
+    await contentStore.put<JsonValue>({
+      key,
+      kind: CONTENT_ENTRY_KIND,
+      status: "pending",
+      createdAt,
+      updatedAt: createdAt,
+      expiresAt: createdAt + ttlMs,
+      metadata: {
+        url: canonicalizeUrl(url),
+        provider: providerId,
+        optionsHash: hashOptions(options),
+      },
+    });
+
+    try {
+      const plan = provider.buildPlan(
+        {
+          capability: "contents",
+          urls: [canonicalizeUrl(url)],
+          options: stripLocalExecutionOptions(options),
+        },
+        providerConfig as never,
+      );
+      if (!plan) {
+        throw new Error(
+          `Provider '${providerId}' could not build a contents plan.`,
+        );
+      }
+      const result = await executeOperationPlan(plan, options, {
+        cwd,
+        signal,
+        onProgress,
+      });
+      if ("results" in result) {
+        throw new Error(
+          `${provider.label} contents returned an invalid result.`,
+        );
+      }
+
+      const stored: StoredContentsValue = {
+        url: canonicalizeUrl(url),
+        provider: result.provider,
+        text: result.text,
+        summary: result.summary,
+        itemCount: result.itemCount,
+        fetchedAt: Date.now(),
+      };
+      await contentStore.put<JsonValue>({
+        key,
+        kind: CONTENT_ENTRY_KIND,
+        status: "ready",
+        createdAt,
+        updatedAt: stored.fetchedAt,
+        expiresAt: stored.fetchedAt + ttlMs,
+        value: stored as unknown as JsonValue,
+        metadata: {
+          url: canonicalizeUrl(url),
+          provider: result.provider,
+          optionsHash: hashOptions(options),
+        },
+      });
+      return stored;
+    } catch (error) {
+      await contentStore.put<JsonValue>({
+        key,
+        kind: CONTENT_ENTRY_KIND,
+        status: "failed",
+        createdAt,
+        updatedAt: Date.now(),
+        expiresAt: Date.now() + ttlMs,
+        error: error instanceof Error ? error.message : String(error),
+        metadata: {
+          url: canonicalizeUrl(url),
+          provider: providerId,
+          optionsHash: hashOptions(options),
+        },
+      });
+      throw error;
+    } finally {
+      inFlightContents.delete(key);
+    }
+  })();
+
+  inFlightContents.set(key, task);
+  return await task;
+}
+
+function buildContentsStoreKey(
+  url: string,
+  providerId: ProviderId,
+  options: JsonObject | undefined,
+): string {
+  return createStoreKey([
+    CONTENT_ENTRY_KIND,
+    `v${CONTENT_CACHE_VERSION}`,
+    providerId,
+    hashKey(canonicalizeUrl(url)),
+    hashOptions(options),
+  ]);
+}
+
+function buildPrefetchJobStoreKey(prefetchId: string): string {
+  return createStoreKey([PREFETCH_JOB_KIND, prefetchId]);
+}
+
+function resolveContentsProvider(
+  config: WebProvidersConfig,
+  cwd: string,
+  explicitProvider: ProviderId | undefined,
+  searchProviderId: ProviderId | undefined,
+) {
+  if (explicitProvider) {
+    return resolveProviderForCapability(
+      config,
+      explicitProvider,
+      cwd,
+      "contents",
+    );
+  }
+
+  if (searchProviderId) {
+    try {
+      return resolveProviderForCapability(
+        config,
+        searchProviderId,
+        cwd,
+        "contents",
+      );
+    } catch {
+      // Fall back to the configured contents provider below.
+    }
+  }
+
+  try {
+    return resolveProviderForCapability(config, undefined, cwd, "contents");
+  } catch {
+    return undefined;
+  }
+}
+
+function canonicalizeUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.hash = "";
+    return parsed.toString();
+  } catch {
+    return url.trim();
+  }
+}
+
+function selectPrefetchUrls(
+  urls: string[],
+  maxUrls: number | undefined,
+): string[] {
+  const selected: string[] = [];
+  const seen = new Set<string>();
+  const limit = clampPrefetchUrlCount(maxUrls);
+
+  for (const url of urls) {
+    const canonical = canonicalizeUrl(url);
+    if (!/^https?:\/\//i.test(canonical) || seen.has(canonical)) {
+      continue;
+    }
+    selected.push(canonical);
+    seen.add(canonical);
+    if (selected.length >= limit) {
+      break;
+    }
+  }
+
+  return selected;
+}
+
+function clampPrefetchUrlCount(value: number | undefined): number {
+  if (value === undefined) {
+    return DEFAULT_PREFETCH_MAX_URLS;
+  }
+  return Math.min(Math.max(Math.trunc(value), 1), MAX_PREFETCH_URLS);
+}
+
+function clampTtlMs(value: number | undefined): number {
+  if (value === undefined) {
+    return DEFAULT_CONTENT_TTL_MS;
+  }
+  return Math.max(1000, value);
+}
+
+function isExpired(entry: ContentStoreEntry, now: number): boolean {
+  return entry.expiresAt !== undefined && entry.expiresAt <= now;
+}
+
+function hashOptions(options: JsonObject | undefined): string {
+  return hashKey(stableStringify(stripLocalExecutionOptions(options) ?? {}));
+}
+
+function stableStringify(value: JsonValue): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+
+  return `{${Object.keys(value)
+    .sort()
+    .map(
+      (key) =>
+        `${JSON.stringify(key)}:${stableStringify(value[key] as JsonValue)}`,
+    )
+    .join(",")}}`;
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertJsonObject(value: unknown, field: string): JsonObject {
+  if (!isJsonObject(value)) {
+    throw new Error(`${field} must be an object.`);
+  }
+  return value;
+}
+
+function parseOptionalBoolean(value: unknown, field: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new Error(`prefetch.${field} must be a boolean.`);
+  }
+  return value;
+}
+
+function parseOptionalPositiveInteger(
+  value: unknown,
+  field: string,
+): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Number.isInteger(value) || Number(value) <= 0) {
+    throw new Error(`prefetch.${field} must be a positive integer.`);
+  }
+  return Number(value);
+}
+
+function parseOptionalProviderId(value: unknown): ProviderId | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (isProviderId(value)) {
+    return value;
+  }
+  throw new Error("prefetch.provider must be a valid provider id.");
+}
+
+function isProviderId(value: unknown): value is ProviderId {
+  return (
+    value === "claude" ||
+    value === "codex" ||
+    value === "exa" ||
+    value === "gemini" ||
+    value === "perplexity" ||
+    value === "parallel" ||
+    value === "valyu"
+  );
+}
+
+function isStoredContentsValue(
+  value: unknown,
+): value is StoredContentsValue & JsonObject {
+  if (!isJsonObject(value)) {
+    return false;
+  }
+  return (
+    typeof value.url === "string" &&
+    isProviderId(value.provider) &&
+    typeof value.text === "string" &&
+    typeof value.fetchedAt === "number"
+  );
+}
+
+function isPrefetchJobValue(
+  value: unknown,
+): value is PrefetchJobValue & JsonObject {
+  if (!isJsonObject(value)) {
+    return false;
+  }
+  return (
+    typeof value.prefetchId === "string" &&
+    isProviderId(value.provider) &&
+    Array.isArray(value.urls) &&
+    value.urls.every((item) => typeof item === "string") &&
+    Array.isArray(value.contentKeys) &&
+    value.contentKeys.every((item) => typeof item === "string") &&
+    typeof value.createdAt === "number"
+  );
+}

--- a/src/prefetch-manager.ts
+++ b/src/prefetch-manager.ts
@@ -109,6 +109,7 @@ interface EnsureContentsArgs {
   ttlMs?: number;
   signal?: AbortSignal;
   onProgress?: (message: string) => void;
+  generation?: number;
 }
 
 /** Result of ensuring a URL's contents are stored, with cache-hit metadata. */
@@ -123,6 +124,7 @@ const inFlightBatchContents = new Map<
   string,
   Promise<StoredBatchContentsResult>
 >();
+let contentStoreGeneration = 0;
 
 /**
  * Remove expired entries from the content store.  Call this at session start
@@ -134,6 +136,21 @@ export async function cleanupContentStore(): Promise<void> {
   } catch {
     // Best-effort: don't let cleanup failures disrupt the session.
   }
+}
+
+async function putContentStoreEntry<TValue extends JsonValue = JsonValue>({
+  entry,
+  generation,
+}: {
+  entry: ContentStoreEntry<TValue>;
+  generation: number;
+}): Promise<boolean> {
+  if (generation !== contentStoreGeneration) {
+    return false;
+  }
+
+  await contentStore.put(entry);
+  return true;
 }
 
 export async function startContentsPrefetch({
@@ -173,20 +190,24 @@ export async function startContentsPrefetch({
   );
   const prefetchId = randomUUID();
   const createdAt = Date.now();
+  const generation = contentStoreGeneration;
 
-  await contentStore.put<JsonValue>({
-    key: buildPrefetchJobStoreKey(prefetchId),
-    kind: PREFETCH_JOB_KIND,
-    status: "pending",
-    createdAt,
-    updatedAt: createdAt,
-    expiresAt: createdAt + ttlMs,
-    value: {
-      prefetchId,
-      provider: provider.id,
-      urls: selectedUrls,
-      contentKeys,
+  await putContentStoreEntry<JsonValue>({
+    generation,
+    entry: {
+      key: buildPrefetchJobStoreKey(prefetchId),
+      kind: PREFETCH_JOB_KIND,
+      status: "pending",
       createdAt,
+      updatedAt: createdAt,
+      expiresAt: createdAt + ttlMs,
+      value: {
+        prefetchId,
+        provider: provider.id,
+        urls: selectedUrls,
+        contentKeys,
+        createdAt,
+      },
     },
   });
 
@@ -200,6 +221,7 @@ export async function startContentsPrefetch({
         options: contentOptions,
         ttlMs,
         onProgress,
+        generation,
       }),
     ),
   )
@@ -215,46 +237,52 @@ export async function startContentsPrefetch({
             ? formatUnknownError(failedResults[0].reason)
             : `${failedResults.length} URL(s) failed during prefetch.`;
 
-      await contentStore.put<JsonValue>({
-        key: buildPrefetchJobStoreKey(prefetchId),
-        kind: PREFETCH_JOB_KIND,
-        status: failedUrlCount === selectedUrls.length ? "failed" : "ready",
-        createdAt,
-        updatedAt: Date.now(),
-        expiresAt: createdAt + ttlMs,
-        value: {
-          prefetchId,
-          provider: provider.id,
-          urls: selectedUrls,
-          contentKeys,
+      await putContentStoreEntry<JsonValue>({
+        generation,
+        entry: {
+          key: buildPrefetchJobStoreKey(prefetchId),
+          kind: PREFETCH_JOB_KIND,
+          status: failedUrlCount === selectedUrls.length ? "failed" : "ready",
           createdAt,
-        },
-        ...(error ? { error } : {}),
-        metadata: {
-          totalUrlCount: selectedUrls.length,
-          failedUrlCount,
+          updatedAt: Date.now(),
+          expiresAt: createdAt + ttlMs,
+          value: {
+            prefetchId,
+            provider: provider.id,
+            urls: selectedUrls,
+            contentKeys,
+            createdAt,
+          },
+          ...(error ? { error } : {}),
+          metadata: {
+            totalUrlCount: selectedUrls.length,
+            failedUrlCount,
+          },
         },
       });
     })
     .catch(async (error) => {
-      await contentStore.put<JsonValue>({
-        key: buildPrefetchJobStoreKey(prefetchId),
-        kind: PREFETCH_JOB_KIND,
-        status: "failed",
-        createdAt,
-        updatedAt: Date.now(),
-        expiresAt: createdAt + ttlMs,
-        value: {
-          prefetchId,
-          provider: provider.id,
-          urls: selectedUrls,
-          contentKeys,
+      await putContentStoreEntry<JsonValue>({
+        generation,
+        entry: {
+          key: buildPrefetchJobStoreKey(prefetchId),
+          kind: PREFETCH_JOB_KIND,
+          status: "failed",
           createdAt,
-        },
-        error: formatUnknownError(error),
-        metadata: {
-          totalUrlCount: selectedUrls.length,
-          failedUrlCount: selectedUrls.length,
+          updatedAt: Date.now(),
+          expiresAt: createdAt + ttlMs,
+          value: {
+            prefetchId,
+            provider: provider.id,
+            urls: selectedUrls,
+            contentKeys,
+            createdAt,
+          },
+          error: formatUnknownError(error),
+          metadata: {
+            totalUrlCount: selectedUrls.length,
+            failedUrlCount: selectedUrls.length,
+          },
         },
       });
     });
@@ -644,6 +672,7 @@ export function formatPrefetchStatusText(
  * test cases from each other.
  */
 export function resetContentStore(): void {
+  contentStoreGeneration += 1;
   contentStore.clear();
   inFlightContents.clear();
   inFlightBatchContents.clear();
@@ -666,6 +695,7 @@ async function ensureBatchContentsStored({
   ttlMs = DEFAULT_CONTENT_TTL_MS,
   signal,
   onProgress,
+  generation = contentStoreGeneration,
 }: {
   urls: string[];
   providerId: ProviderId;
@@ -675,6 +705,7 @@ async function ensureBatchContentsStored({
   ttlMs?: number;
   signal?: AbortSignal;
   onProgress?: (message: string) => void;
+  generation?: number;
 }): Promise<StoredBatchContentsResult> {
   const normalizedUrls = normalizeUrlSet(urls);
   if (normalizedUrls.length === 0) {
@@ -706,17 +737,20 @@ async function ensureBatchContentsStored({
     }
 
     const createdAt = now;
-    await contentStore.put<JsonValue>({
-      key,
-      kind: CONTENT_BATCH_ENTRY_KIND,
-      status: "pending",
-      createdAt,
-      updatedAt: createdAt,
-      expiresAt: createdAt + ttlMs,
-      metadata: {
-        urls: normalizedUrls as unknown as JsonValue,
-        provider: providerId,
-        optionsHash: hashOptions(options),
+    await putContentStoreEntry<JsonValue>({
+      generation,
+      entry: {
+        key,
+        kind: CONTENT_BATCH_ENTRY_KIND,
+        status: "pending",
+        createdAt,
+        updatedAt: createdAt,
+        expiresAt: createdAt + ttlMs,
+        metadata: {
+          urls: normalizedUrls as unknown as JsonValue,
+          provider: providerId,
+          optionsHash: hashOptions(options),
+        },
       },
     });
 
@@ -760,18 +794,21 @@ async function ensureBatchContentsStored({
         itemCount: result.itemCount,
         fetchedAt,
       };
-      await contentStore.put<JsonValue>({
-        key,
-        kind: CONTENT_BATCH_ENTRY_KIND,
-        status: "ready",
-        createdAt,
-        updatedAt: fetchedAt,
-        expiresAt: fetchedAt + ttlMs,
-        value: stored as unknown as JsonValue,
-        metadata: {
-          urls: normalizedUrls as unknown as JsonValue,
-          provider: result.provider,
-          optionsHash: hashOptions(options),
+      await putContentStoreEntry<JsonValue>({
+        generation,
+        entry: {
+          key,
+          kind: CONTENT_BATCH_ENTRY_KIND,
+          status: "ready",
+          createdAt,
+          updatedAt: fetchedAt,
+          expiresAt: fetchedAt + ttlMs,
+          value: stored as unknown as JsonValue,
+          metadata: {
+            urls: normalizedUrls as unknown as JsonValue,
+            provider: result.provider,
+            optionsHash: hashOptions(options),
+          },
         },
       });
       await storePerUrlContentsEntries({
@@ -781,21 +818,25 @@ async function ensureBatchContentsStored({
         createdAt,
         fetchedAt,
         ttlMs,
+        generation,
       });
       return { value: stored, fromCache: false };
     } catch (error) {
-      await contentStore.put<JsonValue>({
-        key,
-        kind: CONTENT_BATCH_ENTRY_KIND,
-        status: "failed",
-        createdAt,
-        updatedAt: Date.now(),
-        expiresAt: Date.now() + ttlMs,
-        error: error instanceof Error ? error.message : String(error),
-        metadata: {
-          urls: normalizedUrls as unknown as JsonValue,
-          provider: providerId,
-          optionsHash: hashOptions(options),
+      await putContentStoreEntry<JsonValue>({
+        generation,
+        entry: {
+          key,
+          kind: CONTENT_BATCH_ENTRY_KIND,
+          status: "failed",
+          createdAt,
+          updatedAt: Date.now(),
+          expiresAt: Date.now() + ttlMs,
+          error: error instanceof Error ? error.message : String(error),
+          metadata: {
+            urls: normalizedUrls as unknown as JsonValue,
+            provider: providerId,
+            optionsHash: hashOptions(options),
+          },
         },
       });
       throw error;
@@ -817,6 +858,7 @@ async function ensureContentsStored({
   ttlMs = DEFAULT_CONTENT_TTL_MS,
   signal,
   onProgress,
+  generation = contentStoreGeneration,
 }: EnsureContentsArgs): Promise<StoredContentsResult> {
   const key = buildContentsStoreKey(url, providerId, options);
   const existingInFlight = inFlightContents.get(key);
@@ -843,17 +885,20 @@ async function ensureContentsStored({
     }
 
     const createdAt = now;
-    await contentStore.put<JsonValue>({
-      key,
-      kind: CONTENT_ENTRY_KIND,
-      status: "pending",
-      createdAt,
-      updatedAt: createdAt,
-      expiresAt: createdAt + ttlMs,
-      metadata: {
-        url: canonicalizeUrl(url),
-        provider: providerId,
-        optionsHash: hashOptions(options),
+    await putContentStoreEntry<JsonValue>({
+      generation,
+      entry: {
+        key,
+        kind: CONTENT_ENTRY_KIND,
+        status: "pending",
+        createdAt,
+        updatedAt: createdAt,
+        expiresAt: createdAt + ttlMs,
+        metadata: {
+          url: canonicalizeUrl(url),
+          provider: providerId,
+          optionsHash: hashOptions(options),
+        },
       },
     });
 
@@ -896,34 +941,40 @@ async function ensureContentsStored({
           : { body: result.text },
         fetchedAt: now,
       };
-      await contentStore.put<JsonValue>({
-        key,
-        kind: CONTENT_ENTRY_KIND,
-        status: "ready",
-        createdAt,
-        updatedAt: now,
-        expiresAt: now + ttlMs,
-        value: stored as unknown as JsonValue,
-        metadata: {
-          url: canonicalUrl,
-          provider: result.provider,
-          optionsHash: hashOptions(options),
+      await putContentStoreEntry<JsonValue>({
+        generation,
+        entry: {
+          key,
+          kind: CONTENT_ENTRY_KIND,
+          status: "ready",
+          createdAt,
+          updatedAt: now,
+          expiresAt: now + ttlMs,
+          value: stored as unknown as JsonValue,
+          metadata: {
+            url: canonicalUrl,
+            provider: result.provider,
+            optionsHash: hashOptions(options),
+          },
         },
       });
       return { value: stored, fromCache: false };
     } catch (error) {
-      await contentStore.put<JsonValue>({
-        key,
-        kind: CONTENT_ENTRY_KIND,
-        status: "failed",
-        createdAt,
-        updatedAt: Date.now(),
-        expiresAt: Date.now() + ttlMs,
-        error: error instanceof Error ? error.message : String(error),
-        metadata: {
-          url: canonicalizeUrl(url),
-          provider: providerId,
-          optionsHash: hashOptions(options),
+      await putContentStoreEntry<JsonValue>({
+        generation,
+        entry: {
+          key,
+          kind: CONTENT_ENTRY_KIND,
+          status: "failed",
+          createdAt,
+          updatedAt: Date.now(),
+          expiresAt: Date.now() + ttlMs,
+          error: error instanceof Error ? error.message : String(error),
+          metadata: {
+            url: canonicalizeUrl(url),
+            provider: providerId,
+            optionsHash: hashOptions(options),
+          },
         },
       });
       throw error;
@@ -943,6 +994,7 @@ async function storePerUrlContentsEntries({
   createdAt,
   fetchedAt,
   ttlMs,
+  generation,
 }: {
   entries: StoredContentsMetadataEntry[];
   provider: ProviderId;
@@ -950,6 +1002,7 @@ async function storePerUrlContentsEntries({
   createdAt: number;
   fetchedAt: number;
   ttlMs: number;
+  generation: number;
 }): Promise<void> {
   await Promise.all(
     entries.map(async (entry) => {
@@ -958,23 +1011,26 @@ async function storePerUrlContentsEntries({
         return;
       }
 
-      await contentStore.put<JsonValue>({
-        key: buildContentsStoreKey(canonicalUrl, provider, options),
-        kind: CONTENT_ENTRY_KIND,
-        status: "ready",
-        createdAt,
-        updatedAt: fetchedAt,
-        expiresAt: fetchedAt + ttlMs,
-        value: {
-          url: canonicalUrl,
-          provider,
-          item: toStoredContentItem(entry),
-          fetchedAt,
-        } as unknown as JsonValue,
-        metadata: {
-          url: canonicalUrl,
-          provider,
-          optionsHash: hashOptions(options),
+      await putContentStoreEntry<JsonValue>({
+        generation,
+        entry: {
+          key: buildContentsStoreKey(canonicalUrl, provider, options),
+          kind: CONTENT_ENTRY_KIND,
+          status: "ready",
+          createdAt,
+          updatedAt: fetchedAt,
+          expiresAt: fetchedAt + ttlMs,
+          value: {
+            url: canonicalUrl,
+            provider,
+            item: toStoredContentItem(entry),
+            fetchedAt,
+          } as unknown as JsonValue,
+          metadata: {
+            url: canonicalUrl,
+            provider,
+            optionsHash: hashOptions(options),
+          },
         },
       });
     }),

--- a/src/providers/exa.ts
+++ b/src/providers/exa.ts
@@ -186,37 +186,55 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
     );
     const response = await client.getContents(urls, options as never);
 
+    const results = response.results ?? [];
     const lines: string[] = [];
-    for (const [index, result] of (response.results ?? []).entries()) {
-      lines.push(
-        `${index + 1}. ${String(result.title ?? result.url ?? "Untitled")}`,
-      );
-      lines.push(`   ${String(result.url ?? "")}`);
+    const contentsEntries = results
+      .map((result, index) => {
+        const entryLines = [
+          `${index + 1}. ${String(result.title ?? result.url ?? "Untitled")}`,
+          `   ${String(result.url ?? "")}`,
+        ];
 
-      const summary =
-        typeof result.summary === "string"
-          ? result.summary
-          : result.summary
-            ? formatJson(result.summary)
-            : undefined;
-      const text =
-        typeof result.text === "string"
-          ? result.text
-          : Array.isArray(result.highlights)
-            ? result.highlights.join(" ")
-            : "";
-      const body = trimSnippet(summary ?? text);
-      if (body) {
-        lines.push(`   ${body}`);
-      }
-      lines.push("");
-    }
+        const summary =
+          typeof result.summary === "string"
+            ? result.summary
+            : result.summary
+              ? formatJson(result.summary)
+              : undefined;
+        const text =
+          typeof result.text === "string"
+            ? result.text
+            : Array.isArray(result.highlights)
+              ? result.highlights.join(" ")
+              : "";
+        const body = trimSnippet(summary ?? text);
+        if (body) {
+          entryLines.push(`   ${body}`);
+        }
+
+        lines.push(...entryLines, "");
+
+        if (typeof result.url !== "string" || result.url.length === 0) {
+          return undefined;
+        }
+
+        return {
+          url: result.url,
+          text: entryLines.join("\n").trimEnd(),
+          summary: "1 content result via Exa",
+          itemCount: 1,
+        };
+      })
+      .filter((entry) => entry !== undefined);
 
     return {
       provider: this.id,
       text: lines.join("\n").trimEnd() || "No contents found.",
-      summary: `${response.results?.length ?? 0} content result(s) via Exa`,
-      itemCount: response.results?.length ?? 0,
+      summary: `${results.length} content result(s) via Exa`,
+      itemCount: results.length,
+      metadata: {
+        contentsEntries,
+      },
     };
   }
 

--- a/src/providers/exa.ts
+++ b/src/providers/exa.ts
@@ -8,6 +8,8 @@ import {
 } from "../provider-plans.js";
 import type {
   ExaProviderConfig,
+  JsonValue,
+  ProviderContentsMetadataEntry,
   ProviderContext,
   ProviderOperationRequest,
   ProviderResearchJob,
@@ -188,12 +190,11 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
 
     const results = response.results ?? [];
     const lines: string[] = [];
-    const contentsEntries = results
-      .map((result, index) => {
-        const entryLines = [
-          `${index + 1}. ${String(result.title ?? result.url ?? "Untitled")}`,
-          `   ${String(result.url ?? "")}`,
-        ];
+    const contentsEntries: ProviderContentsMetadataEntry[] = results.flatMap(
+      (result, index) => {
+        const title = String(result.title ?? result.url ?? "Untitled");
+        const url = String(result.url ?? "");
+        const entryLines = [`${index + 1}. ${title}`, `   ${url}`];
 
         const summary =
           typeof result.summary === "string"
@@ -214,18 +215,21 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
 
         lines.push(...entryLines, "");
 
-        if (typeof result.url !== "string" || result.url.length === 0) {
-          return undefined;
+        if (!url) {
+          return [];
         }
 
-        return {
-          url: result.url,
-          text: entryLines.join("\n").trimEnd(),
-          summary: "1 content result via Exa",
-          itemCount: 1,
-        };
-      })
-      .filter((entry) => entry !== undefined);
+        return [
+          {
+            url,
+            title,
+            body,
+            summary: "1 content result via Exa",
+            status: "ready",
+          },
+        ];
+      },
+    );
 
     return {
       provider: this.id,
@@ -233,7 +237,7 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
       summary: `${results.length} content result(s) via Exa`,
       itemCount: results.length,
       metadata: {
-        contentsEntries,
+        contentsEntries: contentsEntries as unknown as JsonValue,
       },
     };
   }

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -230,33 +230,36 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
       lines.push(text);
     }
 
-    const failures = metadata.filter(
+    const retrievalFailures = metadata.filter(
       (entry) =>
         entry.status !== "URL_RETRIEVAL_STATUS_SUCCESS" &&
         entry.status !== undefined,
     );
-    if (failures.length > 0) {
+    if (retrievalFailures.length > 0) {
       if (lines.length > 0) {
         lines.push("");
       }
       lines.push("Retrieval issues:");
-      for (const failure of failures) {
+      for (const failure of retrievalFailures) {
         lines.push(`- ${failure.url}: ${failure.status}`);
       }
     }
 
-    const successCount =
-      metadata.length > 0
-        ? metadata.filter(
-            (entry) =>
-              entry.status === "URL_RETRIEVAL_STATUS_SUCCESS" ||
-              entry.status === undefined,
-          ).length
-        : successfulEntries.length > 0
-          ? successfulEntries.length
-          : text
-            ? 1
-            : 0;
+    const contentFailures = getGeminiContentFailures(
+      contentsEntries,
+      retrievalFailures,
+    );
+    if (contentFailures.length > 0) {
+      if (lines.length > 0) {
+        lines.push("");
+      }
+      lines.push("Content issues:");
+      for (const failure of contentFailures) {
+        lines.push(`- ${failure.url}: ${failure.body}`);
+      }
+    }
+
+    const successCount = successfulEntries.length;
 
     return {
       provider: this.id,
@@ -572,8 +575,8 @@ function buildGeminiContentsEntries(
         }))
       : buildFallbackGeminiContentsEntries(text, urls, metadata);
 
-  const failureEntries = metadata.flatMap<ProviderContentsMetadataEntry>(
-    (entry) =>
+  const retrievalFailureEntries =
+    metadata.flatMap<ProviderContentsMetadataEntry>((entry) =>
       entry.status !== undefined &&
       entry.status !== "URL_RETRIEVAL_STATUS_SUCCESS" &&
       !hasGeminiContentsEntryForUrl(readyEntries, entry.url)
@@ -586,9 +589,23 @@ function buildGeminiContentsEntries(
             },
           ]
         : [],
+    );
+  const formatFailureEntries = metadata.flatMap<ProviderContentsMetadataEntry>(
+    (entry) =>
+      isGeminiMetadataSuccess(entry) &&
+      !hasGeminiContentsEntryForUrl(readyEntries, entry.url)
+        ? [
+            {
+              url: entry.url,
+              title: entry.url,
+              body: "Gemini returned content for this URL in an unexpected format.",
+              status: "failed",
+            },
+          ]
+        : [],
   );
 
-  return [...readyEntries, ...failureEntries];
+  return [...readyEntries, ...retrievalFailureEntries, ...formatFailureEntries];
 }
 
 function parseGeminiContentsBlocks(
@@ -673,7 +690,7 @@ function buildFallbackGeminiContentsEntries(
   const fallbackUrl =
     successfulMetadata.length === 1
       ? successfulMetadata[0]?.url
-      : urls.length === 1 && successfulMetadata.length === 0
+      : urls.length === 1 && metadata.length === 0
         ? urls[0]
         : undefined;
 
@@ -702,6 +719,29 @@ function extractGeminiContentsTitle(text: string): string | undefined {
   }
 
   return firstLine.replace(/^#+\s*/, "").trim() || undefined;
+}
+
+function isGeminiMetadataSuccess(entry: {
+  status: string | undefined;
+}): boolean {
+  return (
+    entry.status === "URL_RETRIEVAL_STATUS_SUCCESS" ||
+    entry.status === undefined
+  );
+}
+
+function getGeminiContentFailures(
+  entries: ProviderContentsMetadataEntry[],
+  retrievalFailures: Array<{ url: string; status: string | undefined }>,
+): ProviderContentsMetadataEntry[] {
+  const retrievalFailureUrls = new Set(
+    retrievalFailures.map((entry) => normalizeGeminiUrl(entry.url)),
+  );
+  return entries.filter(
+    (entry) =>
+      entry.status === "failed" &&
+      !retrievalFailureUrls.has(normalizeGeminiUrl(entry.url)),
+  );
 }
 
 function hasGeminiContentsEntryForUrl(

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -657,6 +657,8 @@ async function createSearchInteraction(
   }
 }
 
+// TODO: Remove this suppression when @google/genai provides a way to silence
+// the experimental-interactions warning natively.
 const GEMINI_INTERACTIONS_WARNING =
   /GoogleGenAI\.interactions: Interactions usage is experimental and may change in future versions\.?/;
 let geminiWarningSuppressionDepth = 0;

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -327,10 +327,12 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
     context: ProviderContext,
   ): Promise<ProviderResearchPollResult> {
     const ai = this.createClient(config);
-    const interaction = await ai.interactions.get(
-      id,
-      undefined,
-      buildGeminiRequestOptions(context.signal),
+    const interaction = await runWithoutGeminiInteractionsWarning(() =>
+      ai.interactions.get(
+        id,
+        undefined,
+        buildGeminiRequestOptions(context.signal),
+      ),
     );
 
     if (interaction.status === "completed") {
@@ -632,9 +634,8 @@ async function createSearchInteraction(
   };
 
   try {
-    return await ai.interactions.create(
-      forcedRequest,
-      buildGeminiRequestOptions(signal),
+    return await runWithoutGeminiInteractionsWarning(() =>
+      ai.interactions.create(forcedRequest, buildGeminiRequestOptions(signal)),
     );
   } catch (error) {
     if (!isBuiltInToolChoiceError(error)) {
@@ -642,16 +643,103 @@ async function createSearchInteraction(
     }
 
     const fallbackGenerationConfig = stripToolChoice(request.generation_config);
-    return ai.interactions.create(
-      {
-        ...request,
-        ...(fallbackGenerationConfig
-          ? { generation_config: fallbackGenerationConfig }
-          : {}),
-      },
-      buildGeminiRequestOptions(signal),
+    return runWithoutGeminiInteractionsWarning(() =>
+      ai.interactions.create(
+        {
+          ...request,
+          ...(fallbackGenerationConfig
+            ? { generation_config: fallbackGenerationConfig }
+            : {}),
+        },
+        buildGeminiRequestOptions(signal),
+      ),
     );
   }
+}
+
+const GEMINI_INTERACTIONS_WARNING =
+  /GoogleGenAI\.interactions: Interactions usage is experimental and may change in future versions\.?/;
+let geminiWarningSuppressionDepth = 0;
+let originalGeminiConsoleWarn: typeof console.warn | undefined;
+let originalGeminiStderrWrite: typeof process.stderr.write | undefined;
+
+async function runWithoutGeminiInteractionsWarning<T>(
+  operation: () => Promise<T>,
+): Promise<T> {
+  installGeminiWarningSuppression();
+  try {
+    return await operation();
+  } finally {
+    uninstallGeminiWarningSuppression();
+  }
+}
+
+function installGeminiWarningSuppression(): void {
+  geminiWarningSuppressionDepth += 1;
+  if (geminiWarningSuppressionDepth !== 1) {
+    return;
+  }
+
+  originalGeminiConsoleWarn = console.warn.bind(console);
+  console.warn = (...args: unknown[]) => {
+    if (matchesGeminiInteractionsWarning(args)) {
+      return;
+    }
+    originalGeminiConsoleWarn?.(...args);
+  };
+
+  originalGeminiStderrWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = ((chunk: unknown, ...args: unknown[]) => {
+    if (matchesGeminiInteractionsWarning([chunk])) {
+      const callback = args.find(
+        (arg): arg is (error?: Error | null) => void =>
+          typeof arg === "function",
+      );
+      callback?.(null);
+      return true;
+    }
+    return (
+      originalGeminiStderrWrite?.(
+        chunk as never,
+        ...(args as Parameters<typeof process.stderr.write>[1][]),
+      ) ?? true
+    );
+  }) as typeof process.stderr.write;
+}
+
+function uninstallGeminiWarningSuppression(): void {
+  geminiWarningSuppressionDepth = Math.max(
+    0,
+    geminiWarningSuppressionDepth - 1,
+  );
+  if (geminiWarningSuppressionDepth !== 0) {
+    return;
+  }
+
+  if (originalGeminiConsoleWarn) {
+    console.warn = originalGeminiConsoleWarn;
+    originalGeminiConsoleWarn = undefined;
+  }
+  if (originalGeminiStderrWrite) {
+    process.stderr.write = originalGeminiStderrWrite;
+    originalGeminiStderrWrite = undefined;
+  }
+}
+
+function matchesGeminiInteractionsWarning(parts: unknown[]): boolean {
+  const text = parts
+    .map((part) => {
+      if (typeof part === "string") {
+        return part;
+      }
+      if (part instanceof Uint8Array) {
+        return Buffer.from(part).toString("utf8");
+      }
+      return "";
+    })
+    .join(" ");
+
+  return GEMINI_INTERACTIONS_WARNING.test(text);
 }
 
 function isBuiltInToolChoiceError(error: unknown): boolean {

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -11,6 +11,8 @@ import {
 import type {
   GeminiProviderConfig,
   JsonObject,
+  JsonValue,
+  ProviderContentsMetadataEntry,
   ProviderContext,
   ProviderOperationRequest,
   ProviderResearchJob,
@@ -201,9 +203,10 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
       defaultModel: native?.contentsModel ?? DEFAULT_CONTENTS_MODEL,
       prompt:
         `Extract the main textual content from each of the following URLs. ` +
-        `For each URL, return the page title followed by the cleaned body text. ` +
-        `Preserve the original structure (headings, paragraphs, lists) but remove ` +
-        `navigation, ads, and boilerplate.\n\n${urlList}`,
+        `For every successfully retrieved URL, return exactly one block in this format:\n` +
+        `[[[URL]]]\n<resolved URL>\n[[[TITLE]]]\n<title>\n[[[BODY]]]\n<cleaned body text>\n[[[END]]]\n\n` +
+        `Only include successfully retrieved URLs. Preserve headings, paragraphs, and lists in BODY, ` +
+        `but remove navigation, ads, and boilerplate. Do not add any text outside these blocks.\n\n${urlList}`,
       options,
       toolConfig: { urlContext: {} },
     });
@@ -215,38 +218,54 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
 
     const text = response.text?.trim() || "";
     const metadata = extractUrlContextMetadata(response.candidates);
+    const contentsEntries = buildGeminiContentsEntries(text, urls, metadata);
     const lines: string[] = [];
 
-    if (text) {
+    const successfulEntries = contentsEntries.filter(
+      (entry) => entry.status !== "failed",
+    );
+    if (successfulEntries.length > 0) {
+      lines.push(renderGeminiContentsEntries(successfulEntries));
+    } else if (text) {
       lines.push(text);
     }
 
-    if (metadata.length > 0) {
-      const failures = metadata.filter(
-        (entry) =>
-          entry.status !== "URL_RETRIEVAL_STATUS_SUCCESS" &&
-          entry.status !== undefined,
-      );
-      if (failures.length > 0) {
+    const failures = metadata.filter(
+      (entry) =>
+        entry.status !== "URL_RETRIEVAL_STATUS_SUCCESS" &&
+        entry.status !== undefined,
+    );
+    if (failures.length > 0) {
+      if (lines.length > 0) {
         lines.push("");
-        lines.push("Retrieval issues:");
-        for (const failure of failures) {
-          lines.push(`- ${failure.url}: ${failure.status}`);
-        }
+      }
+      lines.push("Retrieval issues:");
+      for (const failure of failures) {
+        lines.push(`- ${failure.url}: ${failure.status}`);
       }
     }
 
-    const successCount = metadata.filter(
-      (entry) =>
-        entry.status === "URL_RETRIEVAL_STATUS_SUCCESS" ||
-        entry.status === undefined,
-    ).length;
+    const successCount =
+      metadata.length > 0
+        ? metadata.filter(
+            (entry) =>
+              entry.status === "URL_RETRIEVAL_STATUS_SUCCESS" ||
+              entry.status === undefined,
+          ).length
+        : successfulEntries.length > 0
+          ? successfulEntries.length
+          : text
+            ? 1
+            : 0;
 
     return {
       provider: this.id,
       text: lines.join("\n").trimEnd() || "No contents extracted.",
       summary: `${successCount} of ${urls.length} URL(s) extracted via Gemini`,
       itemCount: successCount,
+      metadata: {
+        contentsEntries: contentsEntries as unknown as JsonValue,
+      },
     };
   }
 
@@ -535,6 +554,191 @@ function extractUrlContextMetadata(
   }
 
   return results;
+}
+
+function buildGeminiContentsEntries(
+  text: string,
+  urls: string[],
+  metadata: Array<{ url: string; status: string | undefined }>,
+): ProviderContentsMetadataEntry[] {
+  const parsedEntries = parseGeminiContentsBlocks(text);
+  const orderedReadyEntries = orderGeminiContentsEntries(parsedEntries, urls);
+  const readyEntries =
+    orderedReadyEntries.length > 0
+      ? orderedReadyEntries.map((entry) => ({
+          ...entry,
+          summary: "1 content result via Gemini",
+          status: "ready" as const,
+        }))
+      : buildFallbackGeminiContentsEntries(text, urls, metadata);
+
+  const failureEntries = metadata.flatMap<ProviderContentsMetadataEntry>(
+    (entry) =>
+      entry.status !== undefined &&
+      entry.status !== "URL_RETRIEVAL_STATUS_SUCCESS" &&
+      !hasGeminiContentsEntryForUrl(readyEntries, entry.url)
+        ? [
+            {
+              url: entry.url,
+              title: entry.url,
+              body: entry.status,
+              status: "failed",
+            },
+          ]
+        : [],
+  );
+
+  return [...readyEntries, ...failureEntries];
+}
+
+function parseGeminiContentsBlocks(
+  text: string,
+): Array<{ url: string; title?: string; body: string }> {
+  const normalized = text.replace(/\r\n/g, "\n");
+  const blocks: Array<{ url: string; title?: string; body: string }> = [];
+  const pattern =
+    /\[\[\[URL\]\]\]\s*\n([^\n]+)\n\[\[\[TITLE\]\]\]\s*\n([^\n]*)\n\[\[\[BODY\]\]\]\s*\n([\s\S]*?)\n\[\[\[END\]\]\]/g;
+
+  for (const match of normalized.matchAll(pattern)) {
+    const url = match[1]?.trim();
+    const title = match[2]?.trim();
+    const body = match[3]?.trim();
+    if (!url || !body) {
+      continue;
+    }
+
+    blocks.push({
+      url,
+      ...(title ? { title } : {}),
+      body,
+    });
+  }
+
+  return blocks;
+}
+
+function orderGeminiContentsEntries<T extends { url: string }>(
+  entries: T[],
+  urls: string[],
+): T[] {
+  if (entries.length <= 1) {
+    return entries;
+  }
+
+  const entriesByUrl = new Map<string, T[]>();
+  for (const entry of entries) {
+    const key = normalizeGeminiUrl(entry.url);
+    const bucket = entriesByUrl.get(key);
+    if (bucket) {
+      bucket.push(entry);
+    } else {
+      entriesByUrl.set(key, [entry]);
+    }
+  }
+
+  const ordered: T[] = [];
+  for (const url of urls) {
+    const key = normalizeGeminiUrl(url);
+    const bucket = entriesByUrl.get(key);
+    const next = bucket?.shift();
+    if (next) {
+      ordered.push(next);
+    }
+    if (bucket && bucket.length === 0) {
+      entriesByUrl.delete(key);
+    }
+  }
+
+  for (const bucket of entriesByUrl.values()) {
+    ordered.push(...bucket);
+  }
+
+  return ordered;
+}
+
+function buildFallbackGeminiContentsEntries(
+  text: string,
+  urls: string[],
+  metadata: Array<{ url: string; status: string | undefined }>,
+): ProviderContentsMetadataEntry[] {
+  if (!text) {
+    return [];
+  }
+
+  const successfulMetadata = metadata.filter(
+    (entry) =>
+      entry.status === "URL_RETRIEVAL_STATUS_SUCCESS" ||
+      entry.status === undefined,
+  );
+  const fallbackUrl =
+    successfulMetadata.length === 1
+      ? successfulMetadata[0]?.url
+      : urls.length === 1 && successfulMetadata.length === 0
+        ? urls[0]
+        : undefined;
+
+  if (!fallbackUrl) {
+    return [];
+  }
+
+  return [
+    {
+      url: fallbackUrl,
+      title: extractGeminiContentsTitle(text),
+      body: text,
+      summary: "1 content result via Gemini",
+      status: "ready",
+    },
+  ];
+}
+
+function extractGeminiContentsTitle(text: string): string | undefined {
+  const firstLine = text
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  if (!firstLine) {
+    return undefined;
+  }
+
+  return firstLine.replace(/^#+\s*/, "").trim() || undefined;
+}
+
+function hasGeminiContentsEntryForUrl(
+  entries: ProviderContentsMetadataEntry[],
+  url: string,
+): boolean {
+  const normalized = normalizeGeminiUrl(url);
+  return entries.some((entry) => normalizeGeminiUrl(entry.url) === normalized);
+}
+
+function normalizeGeminiUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.hash = "";
+    return parsed.toString();
+  } catch {
+    return url.trim();
+  }
+}
+
+function renderGeminiContentsEntries(
+  entries: ProviderContentsMetadataEntry[],
+): string {
+  return entries
+    .map((entry, index) => {
+      const heading = entry.title ?? entry.url;
+      const lines = [`${index + 1}. ${heading}`];
+      if (entry.url && entry.url !== heading) {
+        lines.push(`   ${entry.url}`);
+      }
+      for (const line of entry.body.trim().split("\n")) {
+        lines.push(`   ${line}`);
+      }
+      return lines.join("\n");
+    })
+    .join("\n\n")
+    .trim();
 }
 
 function formatInteractionOutputs(outputs: unknown): string {

--- a/src/providers/parallel.ts
+++ b/src/providers/parallel.ts
@@ -143,17 +143,26 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
     );
 
     const lines: string[] = [];
-    for (const [index, result] of response.results.entries()) {
-      lines.push(`${index + 1}. ${result.title ?? result.url}`);
-      lines.push(`   ${result.url}`);
+    const contentsEntries = response.results.map((result, index) => {
+      const entryLines = [
+        `${index + 1}. ${result.title ?? result.url}`,
+        `   ${result.url}`,
+      ];
 
       const text = result.excerpts?.join(" ") ?? result.full_content ?? "";
       const snippet = trimSnippet(text);
       if (snippet) {
-        lines.push(`   ${snippet}`);
+        entryLines.push(`   ${snippet}`);
       }
-      lines.push("");
-    }
+
+      lines.push(...entryLines, "");
+      return {
+        url: result.url,
+        text: entryLines.join("\n").trimEnd(),
+        summary: "1 content result via Parallel",
+        itemCount: 1,
+      };
+    });
 
     for (const error of response.errors) {
       lines.push(`Error: ${error.url}`);
@@ -170,6 +179,9 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
       text: lines.join("\n").trimEnd() || "No contents found.",
       summary: `${itemCount} content result(s) via Parallel`,
       itemCount,
+      metadata: {
+        contentsEntries,
+      },
     };
   }
 

--- a/src/providers/parallel.ts
+++ b/src/providers/parallel.ts
@@ -4,7 +4,9 @@ import { stripLocalExecutionOptions } from "../execution-policy.js";
 import { createDefaultRequestPolicy } from "../execution-policy-defaults.js";
 import { createSilentForegroundPlan } from "../provider-plans.js";
 import type {
+  JsonValue,
   ParallelProviderConfig,
+  ProviderContentsMetadataEntry,
   ProviderContext,
   ProviderOperationRequest,
   ProviderStatus,
@@ -143,34 +145,44 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
     );
 
     const lines: string[] = [];
-    const contentsEntries = response.results.map((result, index) => {
-      const entryLines = [
-        `${index + 1}. ${result.title ?? result.url}`,
-        `   ${result.url}`,
-      ];
+    const contentsEntries: ProviderContentsMetadataEntry[] =
+      response.results.map((result, index) => {
+        const title = result.title ?? result.url;
+        const entryLines = [`${index + 1}. ${title}`, `   ${result.url}`];
 
-      const text = result.excerpts?.join(" ") ?? result.full_content ?? "";
-      const snippet = trimSnippet(text);
-      if (snippet) {
-        entryLines.push(`   ${snippet}`);
-      }
+        const text = result.excerpts?.join(" ") ?? result.full_content ?? "";
+        const body = trimSnippet(text);
+        if (body) {
+          entryLines.push(`   ${body}`);
+        }
 
-      lines.push(...entryLines, "");
-      return {
-        url: result.url,
-        text: entryLines.join("\n").trimEnd(),
-        summary: "1 content result via Parallel",
-        itemCount: 1,
-      };
-    });
+        lines.push(...entryLines, "");
+        return {
+          url: result.url,
+          title,
+          body,
+          summary: "1 content result via Parallel",
+          status: "ready",
+        };
+      });
 
     for (const error of response.errors) {
-      lines.push(`Error: ${error.url}`);
-      lines.push(`   ${error.error_type}`);
+      const detailLines = [error.error_type];
       if (error.content) {
-        lines.push(`   ${trimSnippet(error.content)}`);
+        detailLines.push(trimSnippet(error.content));
+      }
+
+      lines.push(`Error: ${error.url}`);
+      for (const line of detailLines) {
+        lines.push(`   ${line}`);
       }
       lines.push("");
+      contentsEntries.push({
+        url: error.url,
+        title: error.url,
+        body: detailLines.join("\n"),
+        status: "failed",
+      });
     }
 
     const itemCount = response.results.length;
@@ -180,7 +192,7 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
       summary: `${itemCount} content result(s) via Parallel`,
       itemCount,
       metadata: {
-        contentsEntries,
+        contentsEntries: contentsEntries as unknown as JsonValue,
       },
     };
   }

--- a/src/providers/valyu.ts
+++ b/src/providers/valyu.ts
@@ -195,11 +195,15 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
 
     const results = finalResponse.results ?? [];
     const lines: string[] = [];
-    for (const [index, result] of results.entries()) {
-      lines.push(`${index + 1}. ${result.url}`);
-      if (result.status === "failed") {
-        lines.push(`   Failed: ${result.error}`);
-      } else {
+    const contentsEntries = results
+      .map((result, index) => {
+        const entryLines = [`${index + 1}. ${result.url}`];
+        if (result.status === "failed") {
+          entryLines.push(`   Failed: ${result.error}`);
+          lines.push(...entryLines, "");
+          return undefined;
+        }
+
         const snippet =
           typeof result.summary === "string"
             ? result.summary
@@ -210,18 +214,27 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
                 ? String(result.content)
                 : formatJson(result.content);
         if (result.title) {
-          lines.push(`   ${result.title}`);
+          entryLines.push(`   ${result.title}`);
         }
-        lines.push(`   ${trimSnippet(snippet)}`);
-      }
-      lines.push("");
-    }
+        entryLines.push(`   ${trimSnippet(snippet)}`);
+        lines.push(...entryLines, "");
+        return {
+          url: result.url,
+          text: entryLines.join("\n").trimEnd(),
+          summary: "1 content result via Valyu",
+          itemCount: 1,
+        };
+      })
+      .filter((entry) => entry !== undefined);
 
     return {
       provider: this.id,
       text: lines.join("\n").trimEnd() || "No contents found.",
       summary: `${results.length} content result(s) via Valyu`,
       itemCount: results.length,
+      metadata: {
+        contentsEntries,
+      },
     };
   }
 

--- a/src/providers/valyu.ts
+++ b/src/providers/valyu.ts
@@ -7,6 +7,8 @@ import {
   createSilentForegroundPlan,
 } from "../provider-plans.js";
 import type {
+  JsonValue,
+  ProviderContentsMetadataEntry,
   ProviderContext,
   ProviderOperationRequest,
   ProviderResearchJob,
@@ -195,13 +197,20 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
 
     const results = finalResponse.results ?? [];
     const lines: string[] = [];
-    const contentsEntries = results
-      .map((result, index) => {
+    const contentsEntries: ProviderContentsMetadataEntry[] =
+      results.flatMap<ProviderContentsMetadataEntry>((result, index) => {
         const entryLines = [`${index + 1}. ${result.url}`];
         if (result.status === "failed") {
           entryLines.push(`   Failed: ${result.error}`);
           lines.push(...entryLines, "");
-          return undefined;
+          return [
+            {
+              url: result.url,
+              title: result.url,
+              body: `Failed: ${result.error}`,
+              status: "failed",
+            },
+          ];
         }
 
         const snippet =
@@ -213,19 +222,22 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
                   typeof result.content === "number"
                 ? String(result.content)
                 : formatJson(result.content);
+        const body = trimSnippet(snippet);
         if (result.title) {
           entryLines.push(`   ${result.title}`);
         }
-        entryLines.push(`   ${trimSnippet(snippet)}`);
+        entryLines.push(`   ${body}`);
         lines.push(...entryLines, "");
-        return {
-          url: result.url,
-          text: entryLines.join("\n").trimEnd(),
-          summary: "1 content result via Valyu",
-          itemCount: 1,
-        };
-      })
-      .filter((entry) => entry !== undefined);
+        return [
+          {
+            url: result.url,
+            title: result.title,
+            body,
+            summary: "1 content result via Valyu",
+            status: "ready",
+          },
+        ];
+      });
 
     return {
       provider: this.id,
@@ -233,7 +245,7 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
       summary: `${results.length} content result(s) via Valyu`,
       itemCount: results.length,
       metadata: {
-        contentsEntries,
+        contentsEntries: contentsEntries as unknown as JsonValue,
       },
     };
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,7 @@ export interface ProviderToolOutput {
   text: string;
   summary?: string;
   itemCount?: number;
+  metadata?: JsonObject;
 }
 
 export interface ProviderResearchJob {

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,14 @@ export interface SearchResponse {
   results: SearchResult[];
 }
 
+export interface ProviderContentsMetadataEntry {
+  url: string;
+  title?: string;
+  body: string;
+  summary?: string;
+  status?: "ready" | "failed";
+}
+
 export interface ProviderToolOutput {
   provider: ProviderId;
   text: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,8 @@ export interface ProviderToolDetails {
   provider: ProviderId;
   summary?: string;
   itemCount?: number;
+  queryCount?: number;
+  failedQueryCount?: number;
 }
 
 export interface ClaudeProviderNativeConfig {

--- a/test/gemini-provider.test.ts
+++ b/test/gemini-provider.test.ts
@@ -515,6 +515,74 @@ describe("GeminiProvider contents", () => {
     });
   });
 
+  it("marks successfully retrieved URLs as failed when Gemini returns only a partial structured response", async () => {
+    const generateContent = vi.fn().mockResolvedValue({
+      text: [
+        "[[[URL]]]",
+        "https://example.com/a",
+        "[[[TITLE]]]",
+        "Page A",
+        "[[[BODY]]]",
+        "Content from the first URL.",
+        "[[[END]]]",
+        "",
+        "https://example.com/b",
+        "Page B",
+        "Content from the second URL.",
+      ].join("\n"),
+      candidates: [
+        {
+          urlContextMetadata: {
+            urlMetadata: [
+              {
+                retrievedUrl: "https://example.com/a",
+                urlRetrievalStatus: "URL_RETRIEVAL_STATUS_SUCCESS",
+              },
+              {
+                retrievedUrl: "https://example.com/b",
+                urlRetrievalStatus: "URL_RETRIEVAL_STATUS_SUCCESS",
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const provider = createProvider({ models: { generateContent } });
+    const response = await provider.contents(
+      ["https://example.com/a", "https://example.com/b"],
+      undefined,
+      createConfig(),
+      createContext(),
+    );
+
+    expect(response.text).toContain("1. Page A");
+    expect(response.text).toContain("Content from the first URL.");
+    expect(response.text).toContain("Content issues:");
+    expect(response.text).toContain(
+      "https://example.com/b: Gemini returned content for this URL in an unexpected format.",
+    );
+    expect(response.summary).toBe("1 of 2 URL(s) extracted via Gemini");
+    expect(response.itemCount).toBe(1);
+    expect(response.metadata).toEqual({
+      contentsEntries: [
+        {
+          url: "https://example.com/a",
+          title: "Page A",
+          body: "Content from the first URL.",
+          summary: "1 content result via Gemini",
+          status: "ready",
+        },
+        {
+          url: "https://example.com/b",
+          title: "https://example.com/b",
+          body: "Gemini returned content for this URL in an unexpected format.",
+          status: "failed",
+        },
+      ],
+    });
+  });
+
   it("uses custom contentsModel from config", async () => {
     const generateContent = vi.fn().mockResolvedValue({
       text: "Extracted content.",

--- a/test/gemini-provider.test.ts
+++ b/test/gemini-provider.test.ts
@@ -428,7 +428,23 @@ describe("GeminiProvider contents", () => {
 
   it("handles multiple URLs with mixed retrieval statuses", async () => {
     const generateContent = vi.fn().mockResolvedValue({
-      text: "Content from the first URL.",
+      text: [
+        "[[[URL]]]",
+        "https://example.com/a",
+        "[[[TITLE]]]",
+        "Page A",
+        "[[[BODY]]]",
+        "Content from the first URL.",
+        "[[[END]]]",
+        "",
+        "[[[URL]]]",
+        "https://example.com/c",
+        "[[[TITLE]]]",
+        "Page C",
+        "[[[BODY]]]",
+        "Content from the third URL.",
+        "[[[END]]]",
+      ].join("\n"),
       candidates: [
         {
           urlContextMetadata: {
@@ -463,13 +479,40 @@ describe("GeminiProvider contents", () => {
       createContext(),
     );
 
+    expect(response.text).toContain("1. Page A");
     expect(response.text).toContain("Content from the first URL.");
+    expect(response.text).toContain("2. Page C");
+    expect(response.text).toContain("Content from the third URL.");
     expect(response.text).toContain("Retrieval issues:");
     expect(response.text).toContain(
       "https://example.com/b: URL_RETRIEVAL_STATUS_ERROR",
     );
     expect(response.summary).toBe("2 of 3 URL(s) extracted via Gemini");
     expect(response.itemCount).toBe(2);
+    expect(response.metadata).toEqual({
+      contentsEntries: [
+        {
+          url: "https://example.com/a",
+          title: "Page A",
+          body: "Content from the first URL.",
+          summary: "1 content result via Gemini",
+          status: "ready",
+        },
+        {
+          url: "https://example.com/c",
+          title: "Page C",
+          body: "Content from the third URL.",
+          summary: "1 content result via Gemini",
+          status: "ready",
+        },
+        {
+          url: "https://example.com/b",
+          title: "https://example.com/b",
+          body: "URL_RETRIEVAL_STATUS_ERROR",
+          status: "failed",
+        },
+      ],
+    });
   });
 
   it("uses custom contentsModel from config", async () => {

--- a/test/provider-tool-output.test.ts
+++ b/test/provider-tool-output.test.ts
@@ -249,6 +249,236 @@ describe("provider tool output", () => {
     ).rejects.toThrow("queries must contain at least one item.");
   });
 
+  it("groups multi-query answer output into per-question sections", async () => {
+    const config: WebProvidersConfig = {
+      version: 1,
+      providers: {
+        gemini: {
+          enabled: true,
+          apiKey: "literal-key",
+        },
+      },
+    };
+
+    const result = await __test__.executeAnswerTool({
+      config,
+      explicitProvider: "gemini",
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: undefined,
+      queries: [
+        "What are common Tenzir use cases?",
+        "How does Tenzir help with SIEM migration?",
+      ],
+      planOverrides: [
+        {
+          capability: "answer",
+          providerId: "gemini",
+          providerLabel: "Gemini",
+          deliveryMode: "silent-foreground",
+          execute: async () => ({
+            provider: "gemini",
+            text: "Tenzir is used for detection engineering and security data pipelines.",
+            summary: "Answer via Gemini with 2 source(s)",
+          }),
+        },
+        {
+          capability: "answer",
+          providerId: "gemini",
+          providerLabel: "Gemini",
+          deliveryMode: "silent-foreground",
+          execute: async () => ({
+            provider: "gemini",
+            text: "Tenzir can reduce SIEM costs during migration by reshaping and routing data.",
+            summary: "Answer via Gemini with 3 source(s)",
+          }),
+        },
+      ],
+    });
+
+    expect(result.content[0]?.text).toContain(
+      'Question 1: "What are common Tenzir use cases?"',
+    );
+    expect(result.content[0]?.text).toContain(
+      "Tenzir is used for detection engineering and security data pipelines.",
+    );
+    expect(result.content[0]?.text).toContain(
+      'Question 2: "How does Tenzir help with SIEM migration?"',
+    );
+    expect(result.content[0]?.text).toContain(
+      "Tenzir can reduce SIEM costs during migration by reshaping and routing data.",
+    );
+    expect(result.details).toEqual({
+      tool: "web_answer",
+      provider: "gemini",
+      summary: undefined,
+      itemCount: undefined,
+      queryCount: 2,
+      failedQueryCount: 0,
+    });
+  });
+
+  it("preserves successful answers when one query in a batch fails", async () => {
+    const config: WebProvidersConfig = {
+      version: 1,
+      providers: {
+        gemini: {
+          enabled: true,
+          apiKey: "literal-key",
+        },
+      },
+    };
+
+    const result = await __test__.executeAnswerTool({
+      config,
+      explicitProvider: "gemini",
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: undefined,
+      queries: [
+        "What are common Tenzir use cases?",
+        "How does Tenzir help with SIEM migration?",
+      ],
+      planOverrides: [
+        {
+          capability: "answer",
+          providerId: "gemini",
+          providerLabel: "Gemini",
+          deliveryMode: "silent-foreground",
+          execute: async () => ({
+            provider: "gemini",
+            text: "Tenzir is used for detection engineering and security data pipelines.",
+            summary: "Answer via Gemini with 2 source(s)",
+          }),
+        },
+        {
+          capability: "answer",
+          providerId: "gemini",
+          providerLabel: "Gemini",
+          deliveryMode: "silent-foreground",
+          execute: async () => {
+            throw new Error("rate limited");
+          },
+        },
+      ],
+    });
+
+    expect(result.content[0]?.text).toContain(
+      'Question 1: "What are common Tenzir use cases?"',
+    );
+    expect(result.content[0]?.text).toContain(
+      'Question 2: "How does Tenzir help with SIEM migration?"',
+    );
+    expect(result.content[0]?.text).toContain("Answer failed: rate limited");
+    expect(result.details).toEqual({
+      tool: "web_answer",
+      provider: "gemini",
+      summary: undefined,
+      itemCount: undefined,
+      queryCount: 2,
+      failedQueryCount: 1,
+    });
+  });
+
+  it("fails the answer batch when every query fails", async () => {
+    const config: WebProvidersConfig = {
+      version: 1,
+      providers: {
+        gemini: {
+          enabled: true,
+          apiKey: "literal-key",
+        },
+      },
+    };
+
+    await expect(
+      __test__.executeAnswerTool({
+        config,
+        explicitProvider: "gemini",
+        ctx: { cwd: process.cwd() },
+        signal: undefined,
+        onUpdate: undefined,
+        options: undefined,
+        queries: [
+          "What are common Tenzir use cases?",
+          "How does Tenzir help with SIEM migration?",
+        ],
+        planOverrides: [
+          {
+            capability: "answer",
+            providerId: "gemini",
+            providerLabel: "Gemini",
+            deliveryMode: "silent-foreground",
+            execute: async () => {
+              throw new Error("timeout");
+            },
+          },
+          {
+            capability: "answer",
+            providerId: "gemini",
+            providerLabel: "Gemini",
+            deliveryMode: "silent-foreground",
+            execute: async () => {
+              throw new Error("rate limited");
+            },
+          },
+        ],
+      }),
+    ).rejects.toThrow(
+      'All 2 web_answer queries failed: 1. "What are common Tenzir use cases?" — timeout; 2. "How does Tenzir help with SIEM migratio…" — rate limited',
+    );
+  });
+
+  it("supports a single-question batch for web_answer", async () => {
+    const config: WebProvidersConfig = {
+      version: 1,
+      providers: {
+        gemini: {
+          enabled: true,
+          apiKey: "literal-key",
+        },
+      },
+    };
+
+    const result = await __test__.executeAnswerTool({
+      config,
+      explicitProvider: "gemini",
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: undefined,
+      queries: ["What are common Tenzir use cases?"],
+      planOverrides: [
+        {
+          capability: "answer",
+          providerId: "gemini",
+          providerLabel: "Gemini",
+          deliveryMode: "silent-foreground",
+          execute: async () => ({
+            provider: "gemini",
+            text: "Tenzir is used for detection engineering and SIEM migration.",
+            summary: "Answer via Gemini with 2 source(s)",
+            itemCount: 2,
+          }),
+        },
+      ],
+    });
+
+    expect(result.content[0]?.text).toBe(
+      "Tenzir is used for detection engineering and SIEM migration.",
+    );
+    expect(result.details).toEqual({
+      tool: "web_answer",
+      provider: "gemini",
+      summary: "Answer via Gemini with 2 source(s)",
+      itemCount: 2,
+      queryCount: 1,
+      failedQueryCount: 0,
+    });
+  });
+
   it("truncates oversized non-search output and saves the full response", async () => {
     const config: WebProvidersConfig = {
       version: 1,
@@ -574,6 +804,9 @@ describe("provider tool output", () => {
   it("describes supported local execution controls in tool option help", () => {
     expect(__test__.describeOptionsField("contents", ["exa"])).toBe(
       "Provider-specific extraction options. Local execution controls: requestTimeoutMs, retryCount, retryDelayMs.",
+    );
+    expect(__test__.describeOptionsField("search", ["exa"])).toBe(
+      "Provider-specific search options. Local execution controls: requestTimeoutMs, retryCount, retryDelayMs. Local orchestration options may include prefetch={ enabled, maxUrls, provider, ttlMs, contentsOptions }.",
     );
     expect(
       __test__.describeOptionsField("research", [

--- a/test/rendering.test.ts
+++ b/test/rendering.test.ts
@@ -40,7 +40,7 @@ describe("web_search renderer", () => {
     );
   });
 
-  it("shows a compact multi-query call header", () => {
+  it("shows each query on its own line for multi-query search calls", () => {
     const rendered = renderComponentText(
       __test__.renderCallHeader(
         {
@@ -53,7 +53,11 @@ describe("web_search renderer", () => {
       120,
     );
 
-    expect(rendered).toContain("web_search 3 queries");
+    expect(rendered).toContain("web_search");
+    expect(rendered).toContain("  exa sdk");
+    expect(rendered).toContain("  exa pricing");
+    expect(rendered).toContain("  exa api");
+    expect(rendered).not.toContain("3 queries");
     expect(rendered).toContain("provider=exa maxResults=4");
   });
 
@@ -116,6 +120,49 @@ describe("web_search renderer", () => {
 
     expect(summary).toContain("3 queries, 4 results via exa, 1 failed");
     expect(summary).toContain("to expand");
+  });
+});
+
+describe("web_answer renderer", () => {
+  it("renders a single question on its own line below the tool name", () => {
+    const rendered = renderComponentText(
+      __test__.renderQuestionCallHeader(
+        {
+          queries: ["What are common Tenzir use cases?"],
+          provider: "gemini",
+        },
+        createTheme(),
+      ),
+      120,
+    );
+
+    expect(rendered).toContain("web_answer");
+    expect(rendered).toContain("  What are common Tenzir use cases?");
+    expect(rendered).toContain("provider=gemini");
+    expect(rendered).not.toContain(
+      'web_answer "What are common Tenzir use cases?"',
+    );
+  });
+
+  it("renders multiple questions on separate lines", () => {
+    const rendered = renderComponentText(
+      __test__.renderQuestionCallHeader(
+        {
+          queries: [
+            "What are common Tenzir use cases?",
+            "How does Tenzir help with SIEM migration?",
+          ],
+          provider: "gemini",
+        },
+        createTheme(),
+      ),
+      120,
+    );
+
+    expect(rendered).toContain("web_answer");
+    expect(rendered).toContain("  What are common Tenzir use cases?");
+    expect(rendered).toContain("  How does Tenzir help with SIEM migration?");
+    expect(rendered).toContain("provider=gemini");
   });
 });
 

--- a/test/search-prefetch.test.ts
+++ b/test/search-prefetch.test.ts
@@ -1,0 +1,144 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { exaCtorMock, exaSearchMock, exaGetContentsMock } = vi.hoisted(() => ({
+  exaCtorMock: vi.fn(),
+  exaSearchMock: vi.fn(),
+  exaGetContentsMock: vi.fn(),
+}));
+
+vi.mock("exa-js", () => ({
+  Exa: exaCtorMock.mockImplementation(function MockExa() {
+    return {
+      search: exaSearchMock,
+      getContents: exaGetContentsMock,
+      answer: vi.fn(),
+      research: {
+        create: vi.fn(),
+        get: vi.fn(),
+      },
+    };
+  }),
+}));
+
+const originalHome = process.env.HOME;
+const cleanupDirs: string[] = [];
+
+beforeEach(() => {
+  const home = mkdtempSync(join(tmpdir(), "pi-web-providers-prefetch-home-"));
+  cleanupDirs.push(home);
+  process.env.HOME = home;
+});
+
+afterEach(() => {
+  exaCtorMock.mockClear();
+  exaSearchMock.mockReset();
+  exaGetContentsMock.mockReset();
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
+  while (cleanupDirs.length > 0) {
+    const dir = cleanupDirs.pop();
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("search contents prefetch", () => {
+  it("starts background contents prefetching and reuses the cached results in web_contents", async () => {
+    const { __test__ } = await import("../src/index.js");
+    const { getPrefetchStatus } = await import("../src/prefetch-manager.js");
+    const config = {
+      version: 1,
+      providers: {
+        exa: {
+          enabled: true,
+          apiKey: "literal-key",
+        },
+      },
+    } as const;
+
+    exaSearchMock.mockResolvedValue({
+      results: [
+        {
+          title: "Exa SDK",
+          url: "https://exa.ai/sdk",
+          text: "SDK docs",
+        },
+        {
+          title: "Exa Pricing",
+          url: "https://exa.ai/pricing",
+          text: "Pricing docs",
+        },
+      ],
+    });
+    exaGetContentsMock.mockImplementation(async (urls: string[]) => ({
+      results: urls.map((url) => ({
+        title: url === "https://exa.ai/sdk" ? "Exa SDK" : "Exa Pricing",
+        url,
+        text: `Fetched body for ${url}`,
+      })),
+    }));
+
+    const searchResult = await __test__.executeSearchTool({
+      config,
+      explicitProvider: "exa",
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: {
+        prefetch: {
+          enabled: true,
+          maxUrls: 2,
+        },
+      },
+      maxResults: 2,
+      queries: ["exa docs"],
+    });
+
+    const searchText = searchResult.content[0]?.text ?? "";
+    expect(searchText).toContain("1. Exa SDK");
+    expect(searchText).toContain(
+      "Background contents prefetch started via exa for 2 URL(s). Prefetch id:",
+    );
+    const prefetchId =
+      searchText.match(/Prefetch id: ([\w-]+)/)?.[1] ?? "missing";
+    expect(prefetchId).not.toBe("missing");
+    expect(exaSearchMock).toHaveBeenCalledWith("exa docs", {
+      numResults: 2,
+    });
+
+    const contentsResult = await __test__.executeProviderTool({
+      capability: "contents",
+      config,
+      explicitProvider: "exa",
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: undefined,
+      urls: ["https://exa.ai/sdk", "https://exa.ai/pricing"],
+    });
+
+    expect(exaGetContentsMock).toHaveBeenCalledTimes(2);
+    expect(contentsResult.content[0]?.text).toContain(
+      "Fetched body for https://exa.ai/sdk",
+    );
+    expect(contentsResult.content[0]?.text).toContain(
+      "Fetched body for https://exa.ai/pricing",
+    );
+
+    const status = await getPrefetchStatus(prefetchId);
+    expect(status).toMatchObject({
+      prefetchId,
+      provider: "exa",
+      readyUrlCount: 2,
+      totalUrlCount: 2,
+      status: "ready",
+    });
+  });
+});

--- a/test/search-prefetch.test.ts
+++ b/test/search-prefetch.test.ts
@@ -1,6 +1,3 @@
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { exaCtorMock, exaSearchMock, exaGetContentsMock } = vi.hoisted(() => ({
@@ -23,30 +20,20 @@ vi.mock("exa-js", () => ({
   }),
 }));
 
-const originalHome = process.env.HOME;
-const cleanupDirs: string[] = [];
-
-beforeEach(() => {
-  const home = mkdtempSync(join(tmpdir(), "pi-web-providers-prefetch-home-"));
-  cleanupDirs.push(home);
-  process.env.HOME = home;
-});
-
-afterEach(() => {
+beforeEach(async () => {
   exaCtorMock.mockClear();
   exaSearchMock.mockReset();
   exaGetContentsMock.mockReset();
-  if (originalHome === undefined) {
-    delete process.env.HOME;
-  } else {
-    process.env.HOME = originalHome;
-  }
-  while (cleanupDirs.length > 0) {
-    const dir = cleanupDirs.pop();
-    if (dir) {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  }
+  const { resetContentStore } = await import("../src/prefetch-manager.js");
+  resetContentStore();
+});
+
+afterEach(async () => {
+  exaCtorMock.mockClear();
+  exaSearchMock.mockReset();
+  exaGetContentsMock.mockReset();
+  const { resetContentStore } = await import("../src/prefetch-manager.js");
+  resetContentStore();
 });
 
 describe("search contents prefetch", () => {
@@ -113,14 +100,10 @@ describe("search contents prefetch", () => {
       numResults: 2,
     });
 
-    // The prefetch is fire-and-forget: at this point the in-flight batch
-    // promise exists but hasn't completed yet, so no getContents calls have
-    // fired.
-    expect(exaGetContentsMock.mock.calls.length).toBe(0);
-
     // The first explicit web_contents call piggybacks on the in-flight batch
-    // prefetch promise, so the provider still receives a single batched
-    // contents request for both URLs.
+    // prefetch promise (or reuses the cached result if the prefetch already
+    // completed), so the provider receives at most a single batched contents
+    // request for both URLs.
     const contentsResult = await __test__.executeProviderTool({
       capability: "contents",
       config,

--- a/test/search-prefetch.test.ts
+++ b/test/search-prefetch.test.ts
@@ -232,7 +232,7 @@ describe("search contents prefetch", () => {
     );
   });
 
-  it("reuses earlier live reads without refetching the same URLs", async () => {
+  it("reuses earlier live reads without refetching and re-renders them in the current request order", async () => {
     const { __test__ } = await import("../src/index.js");
     const config = {
       version: 1,
@@ -278,12 +278,14 @@ describe("search contents prefetch", () => {
     expect(exaGetContentsMock.mock.calls).toEqual([
       [["https://exa.ai/pricing", "https://exa.ai/sdk"], undefined],
     ]);
-    expect(cachedResult.content[0]?.text).toContain(
-      "Fetched body for https://exa.ai/sdk",
+    const cachedText = cachedResult.content[0]?.text ?? "";
+    expect(cachedText).toContain("1. Exa Pricing");
+    expect(cachedText).toContain("2. Exa SDK");
+    expect(cachedText.indexOf("1. Exa Pricing")).toBeLessThan(
+      cachedText.indexOf("2. Exa SDK"),
     );
-    expect(cachedResult.content[0]?.text).toContain(
-      "Fetched body for https://exa.ai/pricing",
-    );
+    expect(cachedText).toContain("Fetched body for https://exa.ai/sdk");
+    expect(cachedText).toContain("Fetched body for https://exa.ai/pricing");
   });
 
   it("cleans up expired cache entries automatically on the next tool call", async () => {

--- a/test/search-prefetch.test.ts
+++ b/test/search-prefetch.test.ts
@@ -50,7 +50,7 @@ afterEach(() => {
 });
 
 describe("search contents prefetch", () => {
-  it("starts background contents prefetching and reuses the cached results in web_contents", async () => {
+  it("starts background contents prefetching, reuses the cached batch, and works without an explicit provider", async () => {
     const { __test__ } = await import("../src/index.js");
     const { getPrefetchStatus } = await import("../src/prefetch-manager.js");
     const config = {
@@ -113,13 +113,14 @@ describe("search contents prefetch", () => {
       numResults: 2,
     });
 
-    // The prefetch is fire-and-forget: at this point the in-flight promises
-    // exist but haven't completed yet, so no getContents calls have fired.
+    // The prefetch is fire-and-forget: at this point the in-flight batch
+    // promise exists but hasn't completed yet, so no getContents calls have
+    // fired.
     expect(exaGetContentsMock.mock.calls.length).toBe(0);
 
-    // The first explicit web_contents call piggbacks on the in-flight
-    // prefetch promises (via ensureContentsStored dedup), which triggers
-    // exactly 2 getContents calls — one per URL.
+    // The first explicit web_contents call piggybacks on the in-flight batch
+    // prefetch promise, so the provider still receives a single batched
+    // contents request for both URLs.
     const contentsResult = await __test__.executeProviderTool({
       capability: "contents",
       config,
@@ -131,7 +132,11 @@ describe("search contents prefetch", () => {
       urls: ["https://exa.ai/sdk", "https://exa.ai/pricing"],
     });
 
-    expect(exaGetContentsMock).toHaveBeenCalledTimes(2);
+    expect(exaGetContentsMock).toHaveBeenCalledTimes(1);
+    expect(exaGetContentsMock).toHaveBeenCalledWith(
+      ["https://exa.ai/pricing", "https://exa.ai/sdk"],
+      undefined,
+    );
     expect(contentsResult.content[0]?.text).toContain(
       "Fetched body for https://exa.ai/sdk",
     );
@@ -139,9 +144,68 @@ describe("search contents prefetch", () => {
       "Fetched body for https://exa.ai/pricing",
     );
 
-    // A second web_contents call should reuse the now-cached entries and
-    // make zero additional provider fetches.
+    // A second web_contents call should reuse the now-cached batch even when
+    // no explicit provider is supplied.
     const cachedResult = await __test__.executeProviderTool({
+      capability: "contents",
+      config,
+      explicitProvider: undefined,
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: undefined,
+      urls: ["https://exa.ai/sdk", "https://exa.ai/pricing"],
+    });
+
+    expect(exaGetContentsMock).toHaveBeenCalledTimes(1); // unchanged
+    expect(cachedResult.content[0]?.text).toContain(
+      "Fetched body for https://exa.ai/sdk",
+    );
+
+    await vi.waitFor(async () => {
+      const status = await getPrefetchStatus(prefetchId);
+      expect(status).toMatchObject({
+        prefetchId,
+        provider: "exa",
+        readyUrlCount: 2,
+        totalUrlCount: 2,
+        status: "ready",
+      });
+    });
+  });
+
+  it("falls back to a single provider batch when only part of the request is cached", async () => {
+    const { __test__ } = await import("../src/index.js");
+    const config = {
+      version: 1,
+      providers: {
+        exa: {
+          enabled: true,
+          apiKey: "literal-key",
+        },
+      },
+    } as const;
+
+    exaGetContentsMock.mockImplementation(async (urls: string[]) => ({
+      results: urls.map((url) => ({
+        title: url === "https://exa.ai/sdk" ? "Exa SDK" : "Exa Pricing",
+        url,
+        text: `Fetched body for ${url}`,
+      })),
+    }));
+
+    await __test__.executeProviderTool({
+      capability: "contents",
+      config,
+      explicitProvider: "exa",
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: undefined,
+      urls: ["https://exa.ai/sdk"],
+    });
+
+    await __test__.executeProviderTool({
       capability: "contents",
       config,
       explicitProvider: "exa",
@@ -152,18 +216,14 @@ describe("search contents prefetch", () => {
       urls: ["https://exa.ai/sdk", "https://exa.ai/pricing"],
     });
 
-    expect(exaGetContentsMock).toHaveBeenCalledTimes(2); // unchanged
-    expect(cachedResult.content[0]?.text).toContain(
-      "Fetched body for https://exa.ai/sdk",
-    );
-
-    const status = await getPrefetchStatus(prefetchId);
-    expect(status).toMatchObject({
-      prefetchId,
-      provider: "exa",
-      readyUrlCount: 2,
-      totalUrlCount: 2,
-      status: "ready",
-    });
+    expect(exaGetContentsMock).toHaveBeenCalledTimes(2);
+    expect(exaGetContentsMock.mock.calls[0]).toEqual([
+      ["https://exa.ai/sdk"],
+      undefined,
+    ]);
+    expect(exaGetContentsMock.mock.calls[1]).toEqual([
+      ["https://exa.ai/sdk", "https://exa.ai/pricing"],
+      undefined,
+    ]);
   });
 });

--- a/test/search-prefetch.test.ts
+++ b/test/search-prefetch.test.ts
@@ -173,7 +173,7 @@ describe("search contents prefetch", () => {
     });
   });
 
-  it("falls back to one native batched contents fetch when a multi-URL request is only partially cached", async () => {
+  it("reuses partial cache hits and fetches only the missing URLs", async () => {
     const { __test__ } = await import("../src/index.js");
     const config = {
       version: 1,
@@ -221,7 +221,7 @@ describe("search contents prefetch", () => {
       undefined,
     ]);
     expect(exaGetContentsMock.mock.calls[1]).toEqual([
-      ["https://exa.ai/pricing", "https://exa.ai/sdk"],
+      ["https://exa.ai/pricing"],
       undefined,
     ]);
     expect(result.content[0]?.text).toContain(

--- a/test/search-prefetch.test.ts
+++ b/test/search-prefetch.test.ts
@@ -37,7 +37,7 @@ afterEach(async () => {
 });
 
 describe("search contents prefetch", () => {
-  it("starts background contents prefetching, reuses the cached batch, and works without an explicit provider", async () => {
+  it("starts background contents prefetching, reuses prefetched per-URL entries, and works without an explicit provider", async () => {
     const { __test__ } = await import("../src/index.js");
     const { getPrefetchStatus } = await import("../src/prefetch-manager.js");
     const config = {
@@ -100,10 +100,9 @@ describe("search contents prefetch", () => {
       numResults: 2,
     });
 
-    // The first explicit web_contents call piggybacks on the in-flight batch
-    // prefetch promise (or reuses the cached result if the prefetch already
-    // completed), so the provider receives at most a single batched contents
-    // request for both URLs.
+    // The first explicit web_contents call should piggyback on the in-flight
+    // per-URL prefetch work (or reuse the cached entries if prefetch already
+    // completed), so it does not trigger any additional provider calls.
     const contentsResult = await __test__.executeProviderTool({
       capability: "contents",
       config,
@@ -115,11 +114,11 @@ describe("search contents prefetch", () => {
       urls: ["https://exa.ai/sdk", "https://exa.ai/pricing"],
     });
 
-    expect(exaGetContentsMock).toHaveBeenCalledTimes(1);
-    expect(exaGetContentsMock).toHaveBeenCalledWith(
-      ["https://exa.ai/pricing", "https://exa.ai/sdk"],
-      undefined,
-    );
+    expect(exaGetContentsMock).toHaveBeenCalledTimes(2);
+    expect(exaGetContentsMock.mock.calls).toEqual([
+      [["https://exa.ai/sdk"], undefined],
+      [["https://exa.ai/pricing"], undefined],
+    ]);
     expect(contentsResult.content[0]?.text).toContain(
       "Fetched body for https://exa.ai/sdk",
     );
@@ -127,8 +126,8 @@ describe("search contents prefetch", () => {
       "Fetched body for https://exa.ai/pricing",
     );
 
-    // A second web_contents call should reuse the now-cached batch even when
-    // no explicit provider is supplied.
+    // A second web_contents call should be able to reuse a prefetched subset
+    // even when no explicit provider is supplied.
     const cachedResult = await __test__.executeProviderTool({
       capability: "contents",
       config,
@@ -137,12 +136,15 @@ describe("search contents prefetch", () => {
       signal: undefined,
       onUpdate: undefined,
       options: undefined,
-      urls: ["https://exa.ai/sdk", "https://exa.ai/pricing"],
+      urls: ["https://exa.ai/sdk"],
     });
 
-    expect(exaGetContentsMock).toHaveBeenCalledTimes(1); // unchanged
+    expect(exaGetContentsMock).toHaveBeenCalledTimes(2); // unchanged
     expect(cachedResult.content[0]?.text).toContain(
       "Fetched body for https://exa.ai/sdk",
+    );
+    expect(cachedResult.content[0]?.text).not.toContain(
+      "Fetched body for https://exa.ai/pricing",
     );
 
     await vi.waitFor(async () => {
@@ -154,6 +156,20 @@ describe("search contents prefetch", () => {
         totalUrlCount: 2,
         status: "ready",
       });
+      expect(status?.urls).toEqual([
+        expect.objectContaining({
+          url: "https://exa.ai/sdk",
+          status: "ready",
+          text: expect.stringContaining("Fetched body for https://exa.ai/sdk"),
+        }),
+        expect.objectContaining({
+          url: "https://exa.ai/pricing",
+          status: "ready",
+          text: expect.stringContaining(
+            "Fetched body for https://exa.ai/pricing",
+          ),
+        }),
+      ]);
     });
   });
 

--- a/test/search-prefetch.test.ts
+++ b/test/search-prefetch.test.ts
@@ -113,6 +113,13 @@ describe("search contents prefetch", () => {
       numResults: 2,
     });
 
+    // The prefetch is fire-and-forget: at this point the in-flight promises
+    // exist but haven't completed yet, so no getContents calls have fired.
+    expect(exaGetContentsMock.mock.calls.length).toBe(0);
+
+    // The first explicit web_contents call piggbacks on the in-flight
+    // prefetch promises (via ensureContentsStored dedup), which triggers
+    // exactly 2 getContents calls — one per URL.
     const contentsResult = await __test__.executeProviderTool({
       capability: "contents",
       config,
@@ -130,6 +137,24 @@ describe("search contents prefetch", () => {
     );
     expect(contentsResult.content[0]?.text).toContain(
       "Fetched body for https://exa.ai/pricing",
+    );
+
+    // A second web_contents call should reuse the now-cached entries and
+    // make zero additional provider fetches.
+    const cachedResult = await __test__.executeProviderTool({
+      capability: "contents",
+      config,
+      explicitProvider: "exa",
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: undefined,
+      urls: ["https://exa.ai/sdk", "https://exa.ai/pricing"],
+    });
+
+    expect(exaGetContentsMock).toHaveBeenCalledTimes(2); // unchanged
+    expect(cachedResult.content[0]?.text).toContain(
+      "Fetched body for https://exa.ai/sdk",
     );
 
     const status = await getPrefetchStatus(prefetchId);

--- a/test/search-prefetch.test.ts
+++ b/test/search-prefetch.test.ts
@@ -173,7 +173,7 @@ describe("search contents prefetch", () => {
     });
   });
 
-  it("falls back to a single provider batch when only part of the request is cached", async () => {
+  it("fetches only missing URLs when part of the request is already cached", async () => {
     const { __test__ } = await import("../src/index.js");
     const config = {
       version: 1,
@@ -204,7 +204,7 @@ describe("search contents prefetch", () => {
       urls: ["https://exa.ai/sdk"],
     });
 
-    await __test__.executeProviderTool({
+    const result = await __test__.executeProviderTool({
       capability: "contents",
       config,
       explicitProvider: "exa",
@@ -221,8 +221,147 @@ describe("search contents prefetch", () => {
       undefined,
     ]);
     expect(exaGetContentsMock.mock.calls[1]).toEqual([
-      ["https://exa.ai/sdk", "https://exa.ai/pricing"],
+      ["https://exa.ai/pricing"],
       undefined,
     ]);
+    expect(result.content[0]?.text).toContain(
+      "Fetched body for https://exa.ai/sdk",
+    );
+    expect(result.content[0]?.text).toContain(
+      "Fetched body for https://exa.ai/pricing",
+    );
+  });
+
+  it("reuses earlier live reads without refetching the same URLs", async () => {
+    const { __test__ } = await import("../src/index.js");
+    const config = {
+      version: 1,
+      providers: {
+        exa: {
+          enabled: true,
+          apiKey: "literal-key",
+        },
+      },
+    } as const;
+
+    exaGetContentsMock.mockImplementation(async (urls: string[]) => ({
+      results: urls.map((url) => ({
+        title: url === "https://exa.ai/sdk" ? "Exa SDK" : "Exa Pricing",
+        url,
+        text: `Fetched body for ${url}`,
+      })),
+    }));
+
+    await __test__.executeProviderTool({
+      capability: "contents",
+      config,
+      explicitProvider: "exa",
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: undefined,
+      urls: ["https://exa.ai/sdk", "https://exa.ai/pricing"],
+    });
+
+    const cachedResult = await __test__.executeProviderTool({
+      capability: "contents",
+      config,
+      explicitProvider: undefined,
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: undefined,
+      urls: ["https://exa.ai/pricing", "https://exa.ai/sdk"],
+    });
+
+    expect(exaGetContentsMock).toHaveBeenCalledTimes(2);
+    expect(exaGetContentsMock.mock.calls).toEqual([
+      [["https://exa.ai/sdk"], undefined],
+      [["https://exa.ai/pricing"], undefined],
+    ]);
+    expect(cachedResult.content[0]?.text).toContain(
+      "Fetched body for https://exa.ai/sdk",
+    );
+    expect(cachedResult.content[0]?.text).toContain(
+      "Fetched body for https://exa.ai/pricing",
+    );
+  });
+
+  it("cleans up expired cache entries automatically on the next tool call", async () => {
+    vi.useFakeTimers();
+    try {
+      const { __test__ } = await import("../src/index.js");
+      const { getPrefetchStatus } = await import("../src/prefetch-manager.js");
+      const config = {
+        version: 1,
+        providers: {
+          exa: {
+            enabled: true,
+            apiKey: "literal-key",
+          },
+        },
+      } as const;
+
+      exaSearchMock.mockResolvedValue({
+        results: [
+          {
+            title: "Exa SDK",
+            url: "https://exa.ai/sdk",
+            text: "SDK docs",
+          },
+        ],
+      });
+      exaGetContentsMock.mockImplementation(async (urls: string[]) => ({
+        results: urls.map((url) => ({
+          title: "Exa SDK",
+          url,
+          text: `Fetched body for ${url}`,
+        })),
+      }));
+
+      const searchResult = await __test__.executeSearchTool({
+        config,
+        explicitProvider: "exa",
+        ctx: { cwd: process.cwd() },
+        signal: undefined,
+        onUpdate: undefined,
+        options: {
+          prefetch: {
+            enabled: true,
+            maxUrls: 1,
+            ttlMs: 1000,
+          },
+        },
+        maxResults: 1,
+        queries: ["exa docs"],
+      });
+
+      const prefetchId =
+        (searchResult.content[0]?.text ?? "").match(
+          /Prefetch id: ([\w-]+)/,
+        )?.[1] ?? "missing";
+      expect(prefetchId).not.toBe("missing");
+
+      await vi.waitFor(async () => {
+        expect((await getPrefetchStatus(prefetchId))?.status).toBe("ready");
+      });
+
+      vi.advanceTimersByTime(1001);
+
+      await __test__.executeProviderTool({
+        capability: "contents",
+        config,
+        explicitProvider: "exa",
+        ctx: { cwd: process.cwd() },
+        signal: undefined,
+        onUpdate: undefined,
+        options: undefined,
+        urls: ["https://exa.ai/pricing"],
+      });
+
+      expect(await getPrefetchStatus(prefetchId)).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/test/search-prefetch.test.ts
+++ b/test/search-prefetch.test.ts
@@ -173,7 +173,7 @@ describe("search contents prefetch", () => {
     });
   });
 
-  it("fetches only missing URLs when part of the request is already cached", async () => {
+  it("falls back to one native batched contents fetch when a multi-URL request is only partially cached", async () => {
     const { __test__ } = await import("../src/index.js");
     const config = {
       version: 1,
@@ -221,7 +221,7 @@ describe("search contents prefetch", () => {
       undefined,
     ]);
     expect(exaGetContentsMock.mock.calls[1]).toEqual([
-      ["https://exa.ai/pricing"],
+      ["https://exa.ai/pricing", "https://exa.ai/sdk"],
       undefined,
     ]);
     expect(result.content[0]?.text).toContain(
@@ -274,10 +274,9 @@ describe("search contents prefetch", () => {
       urls: ["https://exa.ai/pricing", "https://exa.ai/sdk"],
     });
 
-    expect(exaGetContentsMock).toHaveBeenCalledTimes(2);
+    expect(exaGetContentsMock).toHaveBeenCalledTimes(1);
     expect(exaGetContentsMock.mock.calls).toEqual([
-      [["https://exa.ai/sdk"], undefined],
-      [["https://exa.ai/pricing"], undefined],
+      [["https://exa.ai/pricing", "https://exa.ai/sdk"], undefined],
     ]);
     expect(cachedResult.content[0]?.text).toContain(
       "Fetched body for https://exa.ai/sdk",

--- a/test/session-cache-reset.test.ts
+++ b/test/session-cache-reset.test.ts
@@ -222,4 +222,144 @@ describe("session cache reset", () => {
 
     expect(exaGetContentsMock).toHaveBeenCalledTimes(2);
   });
+
+  it("keeps deduplicating replacement in-flight requests after session start", async () => {
+    const { default: webProvidersExtension, __test__ } = await import(
+      "../src/index.js"
+    );
+
+    const handlers = new Map<string, Function>();
+    webProvidersExtension({
+      registerTool() {},
+      registerCommand() {},
+      on(event: string, handler: Function) {
+        handlers.set(event, handler);
+      },
+      getActiveTools() {
+        return [];
+      },
+      setActiveTools() {},
+    } as unknown as ExtensionAPI);
+
+    const config = {
+      version: 1,
+      providers: {
+        exa: {
+          enabled: true,
+          apiKey: "literal-key",
+        },
+      },
+    } as const;
+
+    let resolveFirstCall:
+      | ((value: {
+          results: Array<{ title: string; url: string; text: string }>;
+        }) => void)
+      | undefined;
+    let resolveSecondCall:
+      | ((value: {
+          results: Array<{ title: string; url: string; text: string }>;
+        }) => void)
+      | undefined;
+    const firstCall = new Promise<{
+      results: Array<{ title: string; url: string; text: string }>;
+    }>((resolve) => {
+      resolveFirstCall = resolve;
+    });
+    const secondCall = new Promise<{
+      results: Array<{ title: string; url: string; text: string }>;
+    }>((resolve) => {
+      resolveSecondCall = resolve;
+    });
+
+    exaGetContentsMock
+      .mockImplementationOnce(() => firstCall)
+      .mockImplementationOnce(() => secondCall);
+
+    const firstRequest = __test__.executeProviderTool({
+      capability: "contents",
+      config,
+      explicitProvider: "exa",
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: undefined,
+      urls: ["https://exa.ai/sdk"],
+    });
+
+    await vi.waitFor(() => {
+      expect(exaGetContentsMock).toHaveBeenCalledTimes(1);
+    });
+
+    const sessionStart = handlers.get("session_start");
+    expect(sessionStart).toBeTypeOf("function");
+    await sessionStart?.({}, { cwd: process.cwd() });
+
+    const secondRequest = __test__.executeProviderTool({
+      capability: "contents",
+      config,
+      explicitProvider: "exa",
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: undefined,
+      urls: ["https://exa.ai/sdk"],
+    });
+
+    await vi.waitFor(() => {
+      expect(exaGetContentsMock).toHaveBeenCalledTimes(2);
+    });
+
+    resolveFirstCall?.({
+      results: [
+        {
+          title: "Exa SDK",
+          url: "https://exa.ai/sdk",
+          text: "Stale body from the previous session",
+        },
+      ],
+    });
+    await firstRequest;
+
+    const thirdRequest = __test__.executeProviderTool({
+      capability: "contents",
+      config,
+      explicitProvider: "exa",
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: undefined,
+      urls: ["https://exa.ai/sdk"],
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(exaGetContentsMock).toHaveBeenCalledTimes(2);
+
+    resolveSecondCall?.({
+      results: [
+        {
+          title: "Exa SDK",
+          url: "https://exa.ai/sdk",
+          text: "Fresh body from the current session",
+        },
+      ],
+    });
+
+    await expect(secondRequest).resolves.toMatchObject({
+      content: [
+        {
+          type: "text",
+          text: expect.stringContaining("Fresh body from the current session"),
+        },
+      ],
+    });
+    await expect(thirdRequest).resolves.toMatchObject({
+      content: [
+        {
+          type: "text",
+          text: expect.stringContaining("Fresh body from the current session"),
+        },
+      ],
+    });
+  });
 });

--- a/test/session-cache-reset.test.ts
+++ b/test/session-cache-reset.test.ts
@@ -121,4 +121,105 @@ describe("session cache reset", () => {
 
     expect(exaGetContentsMock).toHaveBeenCalledTimes(2);
   });
+
+  it("does not let an in-flight contents request repopulate the cache after session start", async () => {
+    const { default: webProvidersExtension, __test__ } = await import(
+      "../src/index.js"
+    );
+
+    const handlers = new Map<string, Function>();
+    webProvidersExtension({
+      registerTool() {},
+      registerCommand() {},
+      on(event: string, handler: Function) {
+        handlers.set(event, handler);
+      },
+      getActiveTools() {
+        return [];
+      },
+      setActiveTools() {},
+    } as unknown as ExtensionAPI);
+
+    const config = {
+      version: 1,
+      providers: {
+        exa: {
+          enabled: true,
+          apiKey: "literal-key",
+        },
+      },
+    } as const;
+
+    let resolveFirstCall:
+      | ((value: {
+          results: Array<{ title: string; url: string; text: string }>;
+        }) => void)
+      | undefined;
+    const firstCall = new Promise<{
+      results: Array<{ title: string; url: string; text: string }>;
+    }>((resolve) => {
+      resolveFirstCall = resolve;
+    });
+
+    exaGetContentsMock
+      .mockImplementationOnce(() => firstCall)
+      .mockImplementationOnce(async (urls: string[]) => ({
+        results: urls.map((url) => ({
+          title: "Exa SDK",
+          url,
+          text: `Fresh body for ${url}`,
+        })),
+      }));
+
+    const inFlightRequest = __test__.executeProviderTool({
+      capability: "contents",
+      config,
+      explicitProvider: "exa",
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: undefined,
+      urls: ["https://exa.ai/sdk"],
+    });
+
+    await vi.waitFor(() => {
+      expect(exaGetContentsMock).toHaveBeenCalledTimes(1);
+    });
+
+    const sessionStart = handlers.get("session_start");
+    expect(sessionStart).toBeTypeOf("function");
+    await sessionStart?.({}, { cwd: process.cwd() });
+
+    resolveFirstCall?.({
+      results: [
+        {
+          title: "Exa SDK",
+          url: "https://exa.ai/sdk",
+          text: "Stale body from the previous session",
+        },
+      ],
+    });
+
+    await expect(inFlightRequest).resolves.toMatchObject({
+      content: [
+        {
+          type: "text",
+          text: expect.stringContaining("Stale body from the previous session"),
+        },
+      ],
+    });
+
+    await __test__.executeProviderTool({
+      capability: "contents",
+      config,
+      explicitProvider: "exa",
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: undefined,
+      urls: ["https://exa.ai/sdk"],
+    });
+
+    expect(exaGetContentsMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/test/session-cache-reset.test.ts
+++ b/test/session-cache-reset.test.ts
@@ -1,0 +1,124 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { exaCtorMock, exaGetContentsMock } = vi.hoisted(() => ({
+  exaCtorMock: vi.fn(),
+  exaGetContentsMock: vi.fn(),
+}));
+
+vi.mock("exa-js", () => ({
+  Exa: exaCtorMock.mockImplementation(function MockExa() {
+    return {
+      search: vi.fn(),
+      getContents: exaGetContentsMock,
+      answer: vi.fn(),
+      research: {
+        create: vi.fn(),
+        get: vi.fn(),
+      },
+    };
+  }),
+}));
+
+const originalHome = process.env.HOME;
+const cleanupDirs: string[] = [];
+
+beforeEach(async () => {
+  const home = mkdtempSync(join(tmpdir(), "pi-web-providers-home-"));
+  cleanupDirs.push(home);
+  process.env.HOME = home;
+  exaCtorMock.mockClear();
+  exaGetContentsMock.mockReset();
+  const { resetContentStore } = await import("../src/prefetch-manager.js");
+  resetContentStore();
+});
+
+afterEach(async () => {
+  exaCtorMock.mockClear();
+  exaGetContentsMock.mockReset();
+  const { resetContentStore } = await import("../src/prefetch-manager.js");
+  resetContentStore();
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
+  while (cleanupDirs.length > 0) {
+    const dir = cleanupDirs.pop();
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("session cache reset", () => {
+  it("clears the in-memory contents cache on session start", async () => {
+    const { default: webProvidersExtension, __test__ } = await import(
+      "../src/index.js"
+    );
+
+    const handlers = new Map<string, Function>();
+    webProvidersExtension({
+      registerTool() {},
+      registerCommand() {},
+      on(event: string, handler: Function) {
+        handlers.set(event, handler);
+      },
+      getActiveTools() {
+        return [];
+      },
+      setActiveTools() {},
+    } as unknown as ExtensionAPI);
+
+    const config = {
+      version: 1,
+      providers: {
+        exa: {
+          enabled: true,
+          apiKey: "literal-key",
+        },
+      },
+    } as const;
+
+    exaGetContentsMock.mockImplementation(async (urls: string[]) => ({
+      results: urls.map((url) => ({
+        title: "Exa SDK",
+        url,
+        text: `Fetched body for ${url}`,
+      })),
+    }));
+
+    await __test__.executeProviderTool({
+      capability: "contents",
+      config,
+      explicitProvider: "exa",
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: undefined,
+      urls: ["https://exa.ai/sdk"],
+    });
+
+    expect(exaGetContentsMock).toHaveBeenCalledTimes(1);
+
+    const sessionStart = handlers.get("session_start");
+    expect(sessionStart).toBeTypeOf("function");
+    await sessionStart?.({}, { cwd: process.cwd() });
+
+    await __test__.executeProviderTool({
+      capability: "contents",
+      config,
+      explicitProvider: "exa",
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: undefined,
+      urls: ["https://exa.ai/sdk"],
+    });
+
+    expect(exaGetContentsMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/tool-availability.test.ts
+++ b/test/tool-availability.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, Theme } from "@mariozechner/pi-coding-agent";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { execFileSyncMock } = vi.hoisted(() => ({
@@ -57,6 +57,7 @@ describe("managed tool availability", () => {
       name: string;
       description: string;
       parameters?: { properties?: Record<string, unknown> };
+      renderResult?: (...args: any[]) => unknown;
     }> = [];
 
     webProvidersExtension({
@@ -88,8 +89,10 @@ describe("managed tool availability", () => {
     );
     expect(webContents?.description).not.toContain("web_search");
     expect(webAnswer?.description).toBe(
-      "Answer a question using web-grounded evidence.",
+      "Answer one or more questions using web-grounded evidence (up to 10 per call).",
     );
+    expect(webAnswer?.parameters?.properties).not.toHaveProperty("query");
+    expect(webAnswer?.parameters?.properties).toHaveProperty("queries");
     expect(webResearch?.description).toBe(
       "Investigate a topic across web sources and produce a longer report.",
     );
@@ -245,6 +248,56 @@ describe("managed tool availability", () => {
     expect(Array.from(activeTools)).toEqual(["web_search"]);
   });
 
+  it("suppresses noisy partial foreground tool text in the pending tool box", () => {
+    process.env.EXA_API_KEY = "test-key";
+
+    const tools: Array<{
+      name: string;
+      description: string;
+      parameters?: { properties?: Record<string, unknown> };
+      renderResult?: (...args: any[]) => unknown;
+    }> = [];
+
+    webProvidersExtension({
+      registerTool(tool: {
+        name: string;
+        description: string;
+        renderResult?: (...args: any[]) => unknown;
+      }) {
+        tools.push(tool);
+      },
+      registerCommand() {},
+      on() {},
+      getActiveTools() {
+        return [];
+      },
+      setActiveTools() {},
+    } as unknown as ExtensionAPI);
+
+    const webSearch = tools.find((tool) => tool.name === "web_search");
+    const webContents = tools.find((tool) => tool.name === "web_contents");
+
+    const partialSearchRender = webSearch?.renderResult?.(
+      {
+        content: [{ type: "text", text: "Searching Exa for: exa sdk" }],
+      },
+      { expanded: false, isPartial: true },
+      createTheme(),
+    );
+    const partialContentsRender = webContents?.renderResult?.(
+      {
+        content: [
+          { type: "text", text: "Fetching contents from Exa for 2 URL(s)" },
+        ],
+      },
+      { expanded: false, isPartial: true },
+      createTheme(),
+    );
+
+    expect(partialSearchRender).toBeUndefined();
+    expect(partialContentsRender).toBeUndefined();
+  });
+
   it("surfaces Perplexity overrides when Perplexity is available", () => {
     process.env.PERPLEXITY_API_KEY = "test-key";
 
@@ -274,6 +327,13 @@ describe("managed tool availability", () => {
     ).toEqual(["perplexity"]);
   });
 });
+
+function createTheme(): Theme {
+  return {
+    fg: (_color: string, text: string) => text,
+    bold: (text: string) => text,
+  } as unknown as Theme;
+}
 
 function mockClaudeAvailable(): void {
   execFileSyncMock.mockImplementation((_command, args: string[]) => {

--- a/test/tool-availability.test.ts
+++ b/test/tool-availability.test.ts
@@ -298,6 +298,70 @@ describe("managed tool availability", () => {
     expect(partialContentsRender).toBeUndefined();
   });
 
+  it("clears the contents cache when saved contents-capable provider settings change", () => {
+    const previous: WebProvidersConfig = {
+      version: 1,
+      providers: {
+        exa: {
+          enabled: true,
+          apiKey: "EXA_API_KEY",
+          native: {
+            type: "auto",
+            contents: {
+              text: true,
+            },
+          },
+        },
+      },
+    };
+
+    const next: WebProvidersConfig = {
+      version: 1,
+      providers: {
+        exa: {
+          enabled: true,
+          apiKey: "EXA_API_KEY",
+          native: {
+            type: "auto",
+            contents: {
+              text: false,
+            },
+          },
+        },
+      },
+    };
+
+    expect(__test__.didContentsCacheInputsChange(previous, next)).toBe(true);
+  });
+
+  it("keeps the contents cache when only non-contents providers change", () => {
+    const previous: WebProvidersConfig = {
+      version: 1,
+      providers: {
+        codex: {
+          enabled: true,
+          native: {
+            webSearchEnabled: true,
+          },
+        },
+      },
+    };
+
+    const next: WebProvidersConfig = {
+      version: 1,
+      providers: {
+        codex: {
+          enabled: true,
+          native: {
+            webSearchEnabled: false,
+          },
+        },
+      },
+    };
+
+    expect(__test__.didContentsCacheInputsChange(previous, next)).toBe(false);
+  });
+
   it("surfaces Perplexity overrides when Perplexity is available", () => {
     process.env.PERPLEXITY_API_KEY = "test-key";
 


### PR DESCRIPTION
`web_search` gains background page prefetching via `options.prefetch`, and `web_contents` reuses cached or in-flight pages so concurrent requests for the same URL are never double-fetched.

### Review

- The in-flight deduplication logic in `ensureContentsStored` / `ensureBatchContentsStored` — both use a per-key `inFlightContents` / `inFlightBatchContents` map that coalesces concurrent callers onto a single provider request.
- Session-start cache invalidation via `contentStoreGeneration` — ensures stale entries from a previous session never leak into the new one, even if an old in-flight request resolves after the reset.
- Partial cache-hit path in `resolveContentsFromStore` — only missing URLs are fetched; the rest are served from the store.

### Details

<details>
<summary>⁉️ Motivation</summary>

A common agent pattern is `web_search` → `web_contents` for the top results. Without prefetching, the agent waits for search results, then makes a second round-trip for page extraction. With prefetch enabled, the extraction starts in the background as soon as search results arrive, and the subsequent `web_contents` call either piggybacks on the in-flight work or gets an instant cache hit.

</details>

<details>
<summary>🧪 Testing</summary>

- `test/search-prefetch.test.ts` — prefetch lifecycle, partial cache reuse, TTL expiry cleanup
- `test/session-cache-reset.test.ts` — cache invalidation on session start, in-flight deduplication across sessions
- All 117 tests pass

</details>

<details>
<summary>📌 References</summary>

New files: `src/prefetch-manager.ts`, `src/content-store.ts`

</details>