### PR TITLE
Replace single active-provider model with per-tool provider mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ off entirely.
   turn it off entirely
 - **Multiple providers** — Claude, Codex, Exa, Gemini, Perplexity, Parallel,
   Valyu
-- **One config command** (`/web-providers`) with separate sections for provider
-  settings and tool-to-provider mappings
+- **One config command** (`/web-providers`) with separate sections for tool
+  routing, shared generic settings, and provider-specific settings
 - **Batched search and answers** — run several related queries in a single
   `web_search` or `web_answer` call and get grouped results back in one response
 - **Async contents prefetch** — optionally start background `web_contents`
@@ -41,8 +41,9 @@ Run:
 ```
 
 This edits the global config file `~/.pi/agent/web-providers.json`. The flow is
-split into two parts: select a tool to configure its routing and tool-specific
-settings, or select a provider to edit its provider-native settings.
+split into three parts: select a tool to configure its routing and tool-specific
+settings, adjust shared generic execution settings, or select a provider to edit
+its provider-native settings.
 
 ## 🔧 Tools
 
@@ -71,10 +72,10 @@ set. `/web-providers` can also persist default search prefetch settings under
 
 Read and extract the main contents of one or more web pages.
 
-| Parameter  | Type     | Default  | Description                          |
-| ---------- | -------- | -------- | ------------------------------------ |
-| `urls`     | string[] | required | One or more URLs to extract          |
-| `options`  | object   | —        | Provider-specific extraction options |
+| Parameter | Type     | Default  | Description                          |
+| --------- | -------- | -------- | ------------------------------------ |
+| `urls`    | string[] | required | One or more URLs to extract          |
+| `options` | object   | —        | Provider-specific extraction options |
 
 `web_contents` reuses any matching cached pages already present in the local
 content store—whether they came from prefetch or an earlier read—and only
@@ -84,10 +85,10 @@ fetches missing or stale URLs.
 
 Answer one or more questions using web-grounded evidence.
 
-| Parameter  | Type     | Default  | Description                                          |
-| ---------- | -------- | -------- | ---------------------------------------------------- |
-| `queries`  | string[] | required | One or more questions to answer in one call (max 10) |
-| `options`  | object   | —        | Provider-specific options                            |
+| Parameter | Type     | Default  | Description                                          |
+| --------- | -------- | -------- | ---------------------------------------------------- |
+| `queries` | string[] | required | One or more questions to answer in one call (max 10) |
+| `options` | object   | —        | Provider-specific options                            |
 
 Responses are grouped into per-question sections when more than one question is provided.
 
@@ -95,10 +96,10 @@ Responses are grouped into per-question sections when more than one question is 
 
 Investigate a topic across web sources and produce a longer report.
 
-| Parameter  | Type   | Default  | Description                |
-| ---------- | ------ | -------- | -------------------------- |
-| `input`    | string | required | Research brief or question |
-| `options`  | object | —        | Provider-specific options  |
+| Parameter | Type   | Default  | Description                |
+| --------- | ------ | -------- | -------------------------- |
+| `input`   | string | required | Research brief or question |
+| `options` | object | —        | Provider-specific options  |
 
 `options` are provider-native and provider-specific. Equivalent concepts can use
 different field names across SDKs—for example Perplexity uses `country`, Exa

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ summarises capabilities and authentication:
 | **Claude**     |   ✓    |          |   ✓    |          | Local Claude Code auth |
 | **Codex**      |   ✓    |          |        |          | Local Codex CLI auth   |
 | **Exa**        |   ✓    |    ✓     |   ✓    |    ✓     | `EXA_API_KEY`          |
-| **Gemini**     |   ✓    |    ✓     |   ✓    |    ✓     | `GOOGLE_API_KEY`       |
+| **Gemini**     |   ✓    |          |   ✓    |    ✓     | `GOOGLE_API_KEY`       |
 | **Perplexity** |   ✓    |          |   ✓    |    ✓     | `PERPLEXITY_API_KEY`   |
 | **Parallel**   |   ✓    |    ✓     |        |          | `PARALLEL_API_KEY`     |
 | **Valyu**      |   ✓    |    ✓     |   ✓    |    ✓     | `VALYU_API_KEY`        |
@@ -191,10 +191,9 @@ summarises capabilities and authentication:
 <summary><strong>Gemini</strong></summary>
 
 - SDK: `@google/genai`
-- Search, contents, and answer run in **silent foreground** mode
+- Search and answer run in **silent foreground** mode
 - Research runs in **background research** mode and supports `resumeId`
-- Google Search grounding for answers and URL Context extraction for page
-  contents
+- Google Search grounding for answers
 - Deep-research agents via Google's Gemini API
 - Supports provider-native request options such as `model`, `config`,
   `generation_config`, and `agent_config` depending on the tool

--- a/README.md
+++ b/README.md
@@ -12,19 +12,12 @@ off entirely.
 
 ## ✨ Features
 
-- **Per-tool provider routing** — map each managed tool to its own provider or
-  turn it off entirely
 - **Multiple providers** — Claude, Codex, Exa, Gemini, Perplexity, Parallel,
   Valyu
-- **One config command** (`/web-providers`) with separate sections for tool
-  routing, shared generic settings, and provider-specific settings
 - **Batched search and answers** — run several related queries in a single
   `web_search` or `web_answer` call and get grouped results back in one response
 - **Async contents prefetch** — optionally start background `web_contents`
   extraction from `web_search` results and reuse the cached pages later
-- **Timeout and retry controls** — configurable request timeouts, retries,
-  research polling, deadlines, and resumable background jobs
-- **Truncated output with temp-file spillover** for large results
 
 ## 📦 Install
 
@@ -40,18 +33,33 @@ Run:
 /web-providers
 ```
 
-This edits the global config file `~/.pi/agent/web-providers.json`. The flow is
-split into three parts: select a tool to configure its routing and tool-specific
-settings, adjust shared generic execution settings, or select a provider to edit
-its provider-native settings.
+This edits the global config file `~/.pi/agent/web-providers.json`. The
+settings UI mirrors the three sections below: tools, providers, and generic
+settings.
 
-## 🔧 Tools
+Each tool can be routed to any compatible provider:
 
-Which tools are registered depends on the configured tool mapping. A tool is
-only exposed when it is mapped to a compatible provider and that provider is
-currently available.
+| Provider       | search | contents | answer | research | Auth                   |
+| -------------- | :----: | :------: | :----: | :------: | ---------------------- |
+| **Claude**     |   ✔    |          |   ✔    |          | Local Claude Code auth |
+| **Codex**      |   ✔    |          |        |          | Local Codex CLI auth   |
+| **Exa**        |   ✔    |    ✔     |   ✔    |    ✔     | `EXA_API_KEY`          |
+| **Gemini**     |   ✔    |          |   ✔    |    ✔     | `GOOGLE_API_KEY`       |
+| **Perplexity** |   ✔    |          |   ✔    |    ✔     | `PERPLEXITY_API_KEY`   |
+| **Parallel**   |   ✔    |    ✔     |        |          | `PARALLEL_API_KEY`     |
+| **Valyu**      |   ✔    |    ✔     |   ✔    |    ✔     | `VALYU_API_KEY`        |
 
-### `web_search`
+See [`example-config.json`](example-config.json) for a full default
+configuration.
+
+### Tools
+
+Each managed tool maps to one provider id or `null` for off under the top-level
+`tools` key. A tool is only exposed when it is mapped to a compatible provider
+and that provider is currently available. Tool-specific settings live under
+`toolSettings`; today this covers `toolSettings.search.prefetch`.
+
+#### `web_search`
 
 Find likely sources on the public web for up to 10 queries in a single call
 and return titles, URLs, and snippets grouped by query.
@@ -68,7 +76,7 @@ starts a background page-extraction workflow only when `prefetch.provider` is
 set. `/web-providers` can also persist default search prefetch settings under
 `toolSettings.search.prefetch`.
 
-### `web_contents`
+#### `web_contents`
 
 Read and extract the main contents of one or more web pages.
 
@@ -81,7 +89,7 @@ Read and extract the main contents of one or more web pages.
 content store—whether they came from prefetch or an earlier read—and only
 fetches missing or stale URLs.
 
-### `web_answer`
+#### `web_answer`
 
 Answer one or more questions using web-grounded evidence.
 
@@ -92,7 +100,7 @@ Answer one or more questions using web-grounded evidence.
 
 Responses are grouped into per-question sections when more than one question is provided.
 
-### `web_research`
+#### `web_research`
 
 Investigate a topic across web sources and produce a longer report.
 
@@ -130,20 +138,15 @@ Providers deliver results in one of three modes:
 
 </details>
 
-## 🔌 Providers
+### Providers
 
-Every provider is a thin adapter around an official SDK. The table below
-summarises capabilities and authentication:
-
-| Provider       | search | contents | answer | research | Auth                   |
-| -------------- | :----: | :------: | :----: | :------: | ---------------------- |
-| **Claude**     |   ✓    |          |   ✓    |          | Local Claude Code auth |
-| **Codex**      |   ✓    |          |        |          | Local Codex CLI auth   |
-| **Exa**        |   ✓    |    ✓     |   ✓    |    ✓     | `EXA_API_KEY`          |
-| **Gemini**     |   ✓    |          |   ✓    |    ✓     | `GOOGLE_API_KEY`       |
-| **Perplexity** |   ✓    |          |   ✓    |    ✓     | `PERPLEXITY_API_KEY`   |
-| **Parallel**   |   ✓    |    ✓     |        |          | `PARALLEL_API_KEY`     |
-| **Valyu**      |   ✓    |    ✓     |   ✓    |    ✓     | `VALYU_API_KEY`        |
+Every provider is a thin adapter around an official SDK. Each provider has an
+`enabled` toggle that controls whether it is eligible for tool mappings.
+Provider config is split into `native` settings (forwarded to the SDK) and
+`policy` settings (local overrides that take precedence over generic settings);
+legacy `defaults` blocks are still accepted when reading. Secret-like values
+can be literal strings, environment variable names (e.g., `EXA_API_KEY`), or
+shell commands prefixed with `!`.
 
 <details>
 <summary><strong>Claude</strong></summary>
@@ -231,23 +234,19 @@ summarises capabilities and authentication:
 
 </details>
 
-## 📝 Config Notes
+### Generic settings
 
-- `/web-providers` stores provider settings under `providers` and per-tool
-  routing under a top-level `tools` block
-- Tool-local settings live under `toolSettings`; today this is used for
-  `toolSettings.search.prefetch`
-- Each managed tool maps to one provider id or `null` for off
-- Provider config is split into `native` settings (forwarded to the SDK) and
-  `policy` settings (enforced by the extension runtime); legacy `defaults`
-  blocks are still accepted when reading
-- Tools with no mapping, incompatible mappings, or unavailable mapped providers
-  are hidden from the agent
-- Secret-like values can be literal strings, environment variable names (e.g.,
-  `EXA_API_KEY`), or shell commands prefixed with `!`
+The `genericSettings` block sets shared execution defaults that apply to all
+providers unless overridden in a provider's `policy` block:
 
-See [`example-config.json`](example-config.json) for a full default
-configuration (kept in sync via CI).
+| Field                              | Default    | Description                                    |
+| ---------------------------------- | ---------- | ---------------------------------------------- |
+| `requestTimeoutMs`                 | `30000`    | Maximum time for a single provider request     |
+| `retryCount`                       | `3`        | Retries for transient failures                 |
+| `retryDelayMs`                     | `2000`     | Initial delay before retrying                  |
+| `researchPollIntervalMs`           | `3000`     | How often to poll long-running research jobs   |
+| `researchTimeoutMs`                | `21600000` | Overall deadline for research before returning |
+| `researchMaxConsecutivePollErrors` | `3`        | Consecutive poll failures before stopping      |
 
 ## 🛠️ Development
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,23 @@
 # 🌍 pi-web-providers
 
 A _meta_ web extension for [pi](https://pi.dev) that routes search, content
-extraction, answers, and research through configurable providers.
+extraction, answers, and research through configurable per-tool providers.
 
 ## Why?
 
-Most web extensions hard-wire a single backend. **pi-web-providers** dispatches
-every request to a **configurable provider** instead, so you can swap backends,
-compare results, or tap into capabilities—like deep research—that only certain
-providers offer. The tool surface adapts automatically: only tools supported by
-your active provider are exposed to the agent.
+Most web extensions hard-wire a single backend. **pi-web-providers** lets you
+mix and match providers per tool instead, so `web_search`, `web_contents`,
+`web_answer`, and `web_research` can each use a different backend or be turned
+off entirely.
 
 ## ✨ Features
 
-- **Provider-driven tool surface** — tools are registered based on what the
-  active provider actually supports, not a fixed list
+- **Per-tool provider routing** — map each managed tool to its own provider or
+  turn it off entirely
 - **Multiple providers** — Claude, Codex, Exa, Gemini, Perplexity, Parallel,
   Valyu
-- **One config command** (`/web-providers`) with a TUI that adapts to the
-  selected provider
-- **Transparent fallback** — search falls back to Codex when no provider is
-  explicitly enabled and the local CLI is installed and authenticated
-- **Per-provider tool toggles** — disable individual capabilities without
-  switching providers
+- **One config command** (`/web-providers`) with separate sections for provider
+  settings and tool-to-provider mappings
 - **Batched search and answers** — run several related queries in a single
   `web_search` or `web_answer` call and get grouped results back in one response
 - **Async contents prefetch** — optionally start background `web_contents`
@@ -46,13 +41,14 @@ Run:
 ```
 
 This edits the global config file `~/.pi/agent/web-providers.json`. The flow is
-provider-first: pick the active provider, then configure its tool toggles and
-settings.
+split into two parts: select a provider to edit its settings, then map each
+managed tool to one compatible provider or `off`.
 
 ## 🔧 Tools
 
-Which tools are registered depends on the active provider's capabilities. If no
-provider supports a given capability, the corresponding tool is never exposed.
+Which tools are registered depends on the configured tool mapping. A tool is
+only exposed when it is mapped to a compatible provider and that provider is
+currently available.
 
 ### `web_search`
 
@@ -64,7 +60,6 @@ and return titles, URLs, and snippets grouped by query.
 | `queries`    | string[] | required | One or more search queries to run (max 10)                           |
 | `maxResults` | integer  | `5`      | Result count per query, clamped to `1–20`                            |
 | `options`    | object   | —        | Provider-specific search options plus local `prefetch` orchestration |
-| `provider`   | string   | auto     | Optional provider override                                           |
 
 `web_search.options.prefetch` is local-only and not forwarded into the provider
 SDK. It accepts `enabled`, `maxUrls`, `provider`, `ttlMs`, and
@@ -79,7 +74,6 @@ Read and extract the main contents of one or more web pages.
 | ---------- | -------- | -------- | ------------------------------------ |
 | `urls`     | string[] | required | One or more URLs to extract          |
 | `options`  | object   | —        | Provider-specific extraction options |
-| `provider` | string   | auto     | Optional provider override           |
 
 `web_contents` reuses any matching cached pages already present in the local
 content store—whether they came from prefetch or an earlier read—and only
@@ -93,7 +87,6 @@ Answer one or more questions using web-grounded evidence.
 | ---------- | -------- | -------- | ---------------------------------------------------- |
 | `queries`  | string[] | required | One or more questions to answer in one call (max 10) |
 | `options`  | object   | —        | Provider-specific options                            |
-| `provider` | string   | auto     | Optional provider override                           |
 
 Responses are grouped into per-question sections when more than one question is provided.
 
@@ -105,7 +98,6 @@ Investigate a topic across web sources and produce a longer report.
 | ---------- | ------ | -------- | -------------------------- |
 | `input`    | string | required | Research brief or question |
 | `options`  | object | —        | Provider-specific options  |
-| `provider` | string | auto     | Optional provider override |
 
 `options` are provider-native and provider-specific. Equivalent concepts can use
 different field names across SDKs—for example Perplexity uses `country`, Exa
@@ -239,14 +231,14 @@ summarises capabilities and authentication:
 
 ## 📝 Config Notes
 
-- `/web-providers` keeps exactly one provider active (`enabled: true`) and
-  disables the rest
-- Each provider can enable or disable individual tools through a `tools` block
+- `/web-providers` stores provider settings under `providers` and per-tool
+  routing under a top-level `tools` block
+- Each managed tool maps to one provider id or `null` for off
 - Provider config is split into `native` settings (forwarded to the SDK) and
   `policy` settings (enforced by the extension runtime); legacy `defaults`
   blocks are still accepted when reading
-- If no provider is explicitly enabled for search, the extension falls back to
-  Codex when the local CLI is installed and authenticated
+- Tools with no mapping, incompatible mappings, or unavailable mapped providers
+  are hidden from the agent
 - Secret-like values can be literal strings, environment variable names (e.g.,
   `EXA_API_KEY`), or shell commands prefixed with `!`
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Run:
 ```
 
 This edits the global config file `~/.pi/agent/web-providers.json`. The flow is
-split into two parts: select a provider to edit its settings, then map each
-managed tool to one compatible provider or `off`.
+split into two parts: select a tool to configure its routing and tool-specific
+settings, or select a provider to edit its provider-native settings.
 
 ## 🔧 Tools
 
@@ -62,9 +62,10 @@ and return titles, URLs, and snippets grouped by query.
 | `options`    | object   | —        | Provider-specific search options plus local `prefetch` orchestration |
 
 `web_search.options.prefetch` is local-only and not forwarded into the provider
-SDK. It accepts `enabled`, `maxUrls`, `provider`, `ttlMs`, and
-`contentsOptions`, and starts a background page-extraction workflow that writes
-results into the local content store.
+SDK. It accepts `provider`, `maxUrls`, `ttlMs`, and `contentsOptions`, and
+starts a background page-extraction workflow only when `prefetch.provider` is
+set. `/web-providers` can also persist default search prefetch settings under
+`toolSettings.search.prefetch`.
 
 ### `web_contents`
 
@@ -233,6 +234,8 @@ summarises capabilities and authentication:
 
 - `/web-providers` stores provider settings under `providers` and per-tool
   routing under a top-level `tools` block
+- Tool-local settings live under `toolSettings`; today this is used for
+  `toolSettings.search.prefetch`
 - Each managed tool maps to one provider id or `null` for off
 - Provider config is split into `native` settings (forwarded to the SDK) and
   `policy` settings (enforced by the extension runtime); legacy `defaults`

--- a/changelog/unreleased/per-tool-provider-mapping-replaces-single-active-provider-model.md
+++ b/changelog/unreleased/per-tool-provider-mapping-replaces-single-active-provider-model.md
@@ -17,7 +17,6 @@ Before:
 
 ```json
 {
-  "version": 1,
   "providers": {
     "exa": {
       "enabled": true,
@@ -48,6 +47,6 @@ After:
 }
 ```
 
-The `version` field and per-provider `tools` toggles are removed. The
-`/web-providers` settings command now has a dedicated tool-mapping section.
-Existing config files must be migrated to the new format.
+Per-provider `tools` toggles are removed. The `/web-providers` settings command
+now has a dedicated tool-mapping section. Existing config files must be migrated
+to the new format.

--- a/changelog/unreleased/per-tool-provider-mapping-replaces-single-active-provider-model.md
+++ b/changelog/unreleased/per-tool-provider-mapping-replaces-single-active-provider-model.md
@@ -1,0 +1,53 @@
+---
+title: Per-tool provider mapping replaces single active-provider model
+type: breaking
+authors:
+  - mavam
+  - codex
+created: 2026-03-17T14:29:01.565226Z
+---
+
+The config file format changes from a single active-provider model to explicit
+per-tool provider mappings. Instead of enabling one provider and toggling its
+individual tool capabilities, you now assign each tool (`web_search`,
+`web_contents`, `web_answer`, `web_research`) to a specific provider or turn it
+off with `null`.
+
+Before:
+
+```json
+{
+  "version": 1,
+  "providers": {
+    "exa": {
+      "enabled": true,
+      "tools": {
+        "search": true,
+        "contents": true,
+        "answer": false
+      }
+    }
+  }
+}
+```
+
+After:
+
+```json
+{
+  "tools": {
+    "search": "exa",
+    "contents": "exa",
+    "answer": null
+  },
+  "providers": {
+    "exa": {
+      "apiKey": "EXA_API_KEY"
+    }
+  }
+}
+```
+
+The `version` field and per-provider `tools` toggles are removed. The
+`/web-providers` settings command now has a dedicated tool-mapping section.
+Existing config files must be migrated to the new format.

--- a/changelog/unreleased/per-tool-provider-mapping-replaces-single-active-provider-model.md
+++ b/changelog/unreleased/per-tool-provider-mapping-replaces-single-active-provider-model.md
@@ -47,6 +47,10 @@ After:
 }
 ```
 
-Per-provider `tools` toggles are removed. The `/web-providers` settings command
-now has a dedicated tool-mapping section. Existing config files must be migrated
-to the new format.
+Per-provider `tools` toggles are removed and shared execution defaults
+(`requestTimeoutMs`, `retryCount`, `retryDelayMs`, and the research lifecycle
+settings) move from per-provider `policy` blocks into a top-level
+`genericSettings` section. Provider-specific `policy` overrides still take
+precedence. The `/web-providers` settings command now has three sections: tool
+routing, provider settings, and generic settings. Existing config files must be
+migrated to the new format.

--- a/changelog/unreleased/prettier-tool-call-display-and-markdown-results.md
+++ b/changelog/unreleased/prettier-tool-call-display-and-markdown-results.md
@@ -1,0 +1,18 @@
+---
+title: Prettier tool-call display and Markdown web results
+type: change
+authors:
+  - mavam
+  - codex
+created: 2026-03-16T18:55:00Z
+---
+
+Web tool rendering is now cleaner and more consistent:
+
+- `provider=auto` is no longer shown in tool-call headers
+- default `maxResults=5` is hidden, while non-default values are shown compactly
+- single-query and single-URL calls render on one line with the tool name
+- collapsed summaries now consistently show the resolved provider, for example `3 results via gemini`
+- provider casing is normalized in partial progress updates
+
+Expanded `web_search` and `web_answer` output now renders as Markdown blocks with `##` headings for each query or question, along with improved spacing between sections. This makes batched results much easier to scan without changing the tool output content.

--- a/example-config.json
+++ b/example-config.json
@@ -1,5 +1,4 @@
 {
-  "version": 2,
   "tools": {
     "search": "codex",
     "contents": null,

--- a/example-config.json
+++ b/example-config.json
@@ -5,14 +5,17 @@
     "answer": null,
     "research": null
   },
+  "genericSettings": {
+    "requestTimeoutMs": 30000,
+    "retryCount": 3,
+    "retryDelayMs": 2000,
+    "researchPollIntervalMs": 3000,
+    "researchTimeoutMs": 21600000,
+    "researchMaxConsecutivePollErrors": 3
+  },
   "providers": {
     "claude": {
-      "enabled": false,
-      "policy": {
-        "requestTimeoutMs": 30000,
-        "retryCount": 3,
-        "retryDelayMs": 2000
-      }
+      "enabled": false
     },
     "codex": {
       "enabled": true,
@@ -20,11 +23,6 @@
         "networkAccessEnabled": true,
         "webSearchEnabled": true,
         "webSearchMode": "live"
-      },
-      "policy": {
-        "requestTimeoutMs": 30000,
-        "retryCount": 3,
-        "retryDelayMs": 2000
       }
     },
     "exa": {
@@ -35,14 +33,6 @@
         "contents": {
           "text": true
         }
-      },
-      "policy": {
-        "requestTimeoutMs": 30000,
-        "retryCount": 3,
-        "retryDelayMs": 2000,
-        "researchPollIntervalMs": 3000,
-        "researchTimeoutMs": 21600000,
-        "researchMaxConsecutivePollErrors": 3
       }
     },
     "gemini": {
@@ -54,11 +44,6 @@
         "researchAgent": "deep-research-pro-preview-12-2025"
       },
       "policy": {
-        "requestTimeoutMs": 30000,
-        "retryCount": 3,
-        "retryDelayMs": 2000,
-        "researchPollIntervalMs": 3000,
-        "researchTimeoutMs": 21600000,
         "researchMaxConsecutivePollErrors": 10
       }
     },
@@ -72,11 +57,6 @@
         "research": {
           "model": "sonar-deep-research"
         }
-      },
-      "policy": {
-        "requestTimeoutMs": 30000,
-        "retryCount": 3,
-        "retryDelayMs": 2000
       }
     },
     "parallel": {
@@ -90,11 +70,6 @@
           "excerpts": true,
           "full_content": false
         }
-      },
-      "policy": {
-        "requestTimeoutMs": 30000,
-        "retryCount": 3,
-        "retryDelayMs": 2000
       }
     },
     "valyu": {
@@ -103,14 +78,6 @@
       "native": {
         "searchType": "all",
         "responseLength": "short"
-      },
-      "policy": {
-        "requestTimeoutMs": 30000,
-        "retryCount": 3,
-        "retryDelayMs": 2000,
-        "researchPollIntervalMs": 3000,
-        "researchTimeoutMs": 21600000,
-        "researchMaxConsecutivePollErrors": 3
       }
     }
   }

--- a/example-config.json
+++ b/example-config.json
@@ -57,14 +57,12 @@
       "enabled": false,
       "tools": {
         "search": true,
-        "contents": true,
         "answer": true,
         "research": true
       },
       "apiKey": "GOOGLE_API_KEY",
       "native": {
         "searchModel": "gemini-2.5-flash",
-        "contentsModel": "gemini-2.5-flash",
         "answerModel": "gemini-2.5-flash",
         "researchAgent": "deep-research-pro-preview-12-2025"
       },

--- a/example-config.json
+++ b/example-config.json
@@ -7,6 +7,7 @@
   },
   "providers": {
     "claude": {
+      "enabled": false,
       "policy": {
         "requestTimeoutMs": 30000,
         "retryCount": 3,
@@ -14,6 +15,7 @@
       }
     },
     "codex": {
+      "enabled": true,
       "native": {
         "networkAccessEnabled": true,
         "webSearchEnabled": true,
@@ -26,6 +28,7 @@
       }
     },
     "exa": {
+      "enabled": false,
       "apiKey": "EXA_API_KEY",
       "native": {
         "type": "auto",
@@ -43,6 +46,7 @@
       }
     },
     "gemini": {
+      "enabled": false,
       "apiKey": "GOOGLE_API_KEY",
       "native": {
         "searchModel": "gemini-2.5-flash",
@@ -59,6 +63,7 @@
       }
     },
     "perplexity": {
+      "enabled": false,
       "apiKey": "PERPLEXITY_API_KEY",
       "native": {
         "answer": {
@@ -75,6 +80,7 @@
       }
     },
     "parallel": {
+      "enabled": false,
       "apiKey": "PARALLEL_API_KEY",
       "native": {
         "search": {
@@ -92,6 +98,7 @@
       }
     },
     "valyu": {
+      "enabled": false,
       "apiKey": "VALYU_API_KEY",
       "native": {
         "searchType": "all",

--- a/example-config.json
+++ b/example-config.json
@@ -1,12 +1,13 @@
 {
-  "version": 1,
+  "version": 2,
+  "tools": {
+    "search": "codex",
+    "contents": null,
+    "answer": null,
+    "research": null
+  },
   "providers": {
     "claude": {
-      "enabled": false,
-      "tools": {
-        "search": true,
-        "answer": true
-      },
       "policy": {
         "requestTimeoutMs": 30000,
         "retryCount": 3,
@@ -14,10 +15,6 @@
       }
     },
     "codex": {
-      "enabled": true,
-      "tools": {
-        "search": true
-      },
       "native": {
         "networkAccessEnabled": true,
         "webSearchEnabled": true,
@@ -30,13 +27,6 @@
       }
     },
     "exa": {
-      "enabled": false,
-      "tools": {
-        "search": true,
-        "contents": true,
-        "answer": true,
-        "research": true
-      },
       "apiKey": "EXA_API_KEY",
       "native": {
         "type": "auto",
@@ -54,12 +44,6 @@
       }
     },
     "gemini": {
-      "enabled": false,
-      "tools": {
-        "search": true,
-        "answer": true,
-        "research": true
-      },
       "apiKey": "GOOGLE_API_KEY",
       "native": {
         "searchModel": "gemini-2.5-flash",
@@ -76,12 +60,6 @@
       }
     },
     "perplexity": {
-      "enabled": false,
-      "tools": {
-        "search": true,
-        "answer": true,
-        "research": true
-      },
       "apiKey": "PERPLEXITY_API_KEY",
       "native": {
         "answer": {
@@ -98,11 +76,6 @@
       }
     },
     "parallel": {
-      "enabled": false,
-      "tools": {
-        "search": true,
-        "contents": true
-      },
       "apiKey": "PARALLEL_API_KEY",
       "native": {
         "search": {
@@ -120,13 +93,6 @@
       }
     },
     "valyu": {
-      "enabled": false,
-      "tools": {
-        "search": true,
-        "contents": true,
-        "answer": true,
-        "research": true
-      },
       "apiKey": "VALYU_API_KEY",
       "native": {
         "searchType": "all",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-web-providers",
   "version": "0.3.0",
-  "description": "Configurable web access extension for pi that routes search, contents, answers, and research across Claude, Codex, Exa, Gemini, Perplexity, Parallel, and Valyu providers.",
+  "description": "Configurable web access extension for pi with per-tool provider routing for search, contents, answers, and research across Claude, Codex, Exa, Gemini, Perplexity, Parallel, and Valyu.",
   "type": "module",
   "files": [
     "dist",

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,9 +49,11 @@ export function createDefaultConfig(): WebProvidersConfig {
     },
     providers: {
       claude: {
+        enabled: false,
         policy: createDefaultRequestPolicy(),
       },
       codex: {
+        enabled: true,
         native: {
           networkAccessEnabled: true,
           webSearchEnabled: true,
@@ -60,6 +62,7 @@ export function createDefaultConfig(): WebProvidersConfig {
         policy: createDefaultRequestPolicy(),
       },
       exa: {
+        enabled: false,
         apiKey: "EXA_API_KEY",
         native: {
           type: "auto",
@@ -70,6 +73,7 @@ export function createDefaultConfig(): WebProvidersConfig {
         policy: createDefaultLifecyclePolicy(),
       },
       gemini: {
+        enabled: false,
         apiKey: "GOOGLE_API_KEY",
         native: {
           searchModel: "gemini-2.5-flash",
@@ -82,6 +86,7 @@ export function createDefaultConfig(): WebProvidersConfig {
         }),
       },
       perplexity: {
+        enabled: false,
         apiKey: "PERPLEXITY_API_KEY",
         native: {
           answer: {
@@ -94,6 +99,7 @@ export function createDefaultConfig(): WebProvidersConfig {
         policy: createDefaultRequestPolicy(),
       },
       parallel: {
+        enabled: false,
         apiKey: "PARALLEL_API_KEY",
         native: {
           search: {
@@ -107,6 +113,7 @@ export function createDefaultConfig(): WebProvidersConfig {
         policy: createDefaultRequestPolicy(),
       },
       valyu: {
+        enabled: false,
         apiKey: "VALYU_API_KEY",
         native: {
           searchType: "all",
@@ -332,6 +339,15 @@ function normalizeConfig(raw: unknown, source: string): WebProvidersConfig {
     }
   }
 
+  if (config.providers) {
+    for (const providerId of Object.keys(config.providers) as ProviderId[]) {
+      const provider = config.providers[providerId];
+      if (provider && provider.enabled === undefined) {
+        provider.enabled = inferProviderEnabled(config, providerId);
+      }
+    }
+  }
+
   if (
     raw.version !== undefined &&
     typeof raw.version !== "number" &&
@@ -348,7 +364,7 @@ function normalizeClaudeProvider(
   source: string,
 ): ClaudeProviderConfig {
   const provider = parseProviderObject(raw, source, "claude");
-  rejectLegacyProviderRoutingFields(provider, source, "claude");
+  rejectLegacyProviderToolFields(provider, source, "claude");
   const native = parseOptionalJsonObject(
     getProviderNativeSource(provider),
     source,
@@ -358,6 +374,11 @@ function normalizeClaudeProvider(
   );
 
   return {
+    enabled: parseOptionalBoolean(
+      provider.enabled,
+      source,
+      "providers.claude.enabled",
+    ),
     pathToClaudeCodeExecutable: parseOptionalString(
       provider.pathToClaudeCodeExecutable,
       source,
@@ -399,7 +420,7 @@ function normalizeCodexProvider(
   source: string,
 ): CodexProviderConfig {
   const provider = parseProviderObject(raw, source, "codex");
-  rejectLegacyProviderRoutingFields(provider, source, "codex");
+  rejectLegacyProviderToolFields(provider, source, "codex");
   const native = parseOptionalJsonObject(
     getProviderNativeSource(provider),
     source,
@@ -408,6 +429,11 @@ function normalizeCodexProvider(
       : "providers.codex.defaults",
   );
   return {
+    enabled: parseOptionalBoolean(
+      provider.enabled,
+      source,
+      "providers.codex.enabled",
+    ),
     codexPath: parseOptionalString(
       provider.codexPath,
       source,
@@ -478,8 +504,13 @@ function normalizeCodexProvider(
 
 function normalizeExaProvider(raw: unknown, source: string): ExaProviderConfig {
   const provider = parseProviderObject(raw, source, "exa");
-  rejectLegacyProviderRoutingFields(provider, source, "exa");
+  rejectLegacyProviderToolFields(provider, source, "exa");
   return {
+    enabled: parseOptionalBoolean(
+      provider.enabled,
+      source,
+      "providers.exa.enabled",
+    ),
     apiKey: parseOptionalString(
       provider.apiKey,
       source,
@@ -512,8 +543,13 @@ function normalizeValyuProvider(
   source: string,
 ): ValyuProviderConfig {
   const provider = parseProviderObject(raw, source, "valyu");
-  rejectLegacyProviderRoutingFields(provider, source, "valyu");
+  rejectLegacyProviderToolFields(provider, source, "valyu");
   return {
+    enabled: parseOptionalBoolean(
+      provider.enabled,
+      source,
+      "providers.valyu.enabled",
+    ),
     apiKey: parseOptionalString(
       provider.apiKey,
       source,
@@ -546,7 +582,7 @@ function normalizeGeminiProvider(
   source: string,
 ): GeminiProviderConfig {
   const provider = parseProviderObject(raw, source, "gemini");
-  rejectLegacyProviderRoutingFields(provider, source, "gemini");
+  rejectLegacyProviderToolFields(provider, source, "gemini");
   const native = parseOptionalJsonObject(
     stripPolicyFields(getProviderNativeSource(provider)),
     source,
@@ -556,6 +592,11 @@ function normalizeGeminiProvider(
   );
 
   return {
+    enabled: parseOptionalBoolean(
+      provider.enabled,
+      source,
+      "providers.gemini.enabled",
+    ),
     apiKey: parseOptionalString(
       provider.apiKey,
       source,
@@ -601,7 +642,7 @@ function normalizePerplexityProvider(
   source: string,
 ): PerplexityProviderConfig {
   const provider = parseProviderObject(raw, source, "perplexity");
-  rejectLegacyProviderRoutingFields(provider, source, "perplexity");
+  rejectLegacyProviderToolFields(provider, source, "perplexity");
   const native = parseOptionalJsonObject(
     stripPolicyFields(getProviderNativeSource(provider)),
     source,
@@ -611,6 +652,11 @@ function normalizePerplexityProvider(
   );
 
   return {
+    enabled: parseOptionalBoolean(
+      provider.enabled,
+      source,
+      "providers.perplexity.enabled",
+    ),
     apiKey: parseOptionalString(
       provider.apiKey,
       source,
@@ -656,7 +702,7 @@ function normalizeParallelProvider(
   source: string,
 ): ParallelProviderConfig {
   const provider = parseProviderObject(raw, source, "parallel");
-  rejectLegacyProviderRoutingFields(provider, source, "parallel");
+  rejectLegacyProviderToolFields(provider, source, "parallel");
   const native = parseOptionalJsonObject(
     stripPolicyFields(getProviderNativeSource(provider)),
     source,
@@ -666,6 +712,11 @@ function normalizeParallelProvider(
   );
 
   return {
+    enabled: parseOptionalBoolean(
+      provider.enabled,
+      source,
+      "providers.parallel.enabled",
+    ),
     apiKey: parseOptionalString(
       provider.apiKey,
       source,
@@ -850,21 +901,25 @@ function parseToolProviderMappingEntry(
   return providerId;
 }
 
-function rejectLegacyProviderRoutingFields(
+function rejectLegacyProviderToolFields(
   provider: JsonObject,
   source: string,
   providerId: ProviderId,
 ): void {
-  if (provider.enabled !== undefined) {
-    throw new Error(
-      `'providers.${providerId}.enabled' in ${source} is no longer supported. Use top-level 'tools' mappings instead.`,
-    );
-  }
   if (provider.tools !== undefined) {
     throw new Error(
       `'providers.${providerId}.tools' in ${source} is no longer supported. Use top-level 'tools' mappings instead.`,
     );
   }
+}
+
+function inferProviderEnabled(
+  config: WebProvidersConfig,
+  providerId: ProviderId,
+): boolean {
+  return (Object.values(config.tools ?? {}) as Array<ProviderId | null | undefined>).some(
+    (mappedProviderId) => mappedProviderId === providerId,
+  );
 }
 
 function parseOptionalStringMap(

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,7 +30,6 @@ import type {
 } from "./types.js";
 
 const CONFIG_FILE_NAME = "web-providers.json";
-const VERSION = 2 as const;
 const commandValueCache = new Map<
   string,
   { value?: string; errorMessage?: string }
@@ -42,7 +41,6 @@ export function getConfigPath(): string {
 
 export function createDefaultConfig(): WebProvidersConfig {
   return {
-    version: VERSION,
     tools: {
       search: "codex",
       contents: null,
@@ -186,7 +184,6 @@ export function parseProviderConfig(
 
   const wrapper = normalizeConfig(
     {
-      version: VERSION,
       providers: {
         [providerId]: raw,
       },
@@ -258,7 +255,7 @@ export function resolveEnvMap(
 }
 
 function emptyConfig(): WebProvidersConfig {
-  return { version: VERSION };
+  return {};
 }
 
 function normalizeConfig(raw: unknown, source: string): WebProvidersConfig {
@@ -266,14 +263,7 @@ function normalizeConfig(raw: unknown, source: string): WebProvidersConfig {
     throw new Error(`Config in ${source} must be a JSON object.`);
   }
 
-  const version = raw.version ?? VERSION;
-  if (version !== VERSION) {
-    throw new Error(
-      `Unsupported config version '${String(version)}' in ${source}. Expected ${VERSION}.`,
-    );
-  }
-
-  const config: WebProvidersConfig = { version: VERSION };
+  const config: WebProvidersConfig = {};
 
   if (raw.tools !== undefined) {
     config.tools = parseToolProviderMapping(raw.tools, source, "tools");
@@ -340,6 +330,14 @@ function normalizeConfig(raw: unknown, source: string): WebProvidersConfig {
         `Unknown providers in ${source}: ${unknownProviders.join(", ")}.`,
       );
     }
+  }
+
+  if (
+    raw.version !== undefined &&
+    typeof raw.version !== "number" &&
+    typeof raw.version !== "string"
+  ) {
+    throw new Error(`'version' in ${source}, when present, must be a string or number.`);
   }
 
   return config;

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,6 @@ import { dirname, join } from "node:path";
 import { getAgentDir } from "@mariozechner/pi-coding-agent";
 import {
   createDefaultLifecyclePolicy,
-  createDefaultRequestPolicy,
   DEFAULT_GEMINI_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS,
 } from "./execution-policy-defaults.js";
 import {
@@ -12,13 +11,13 @@ import {
   type ProviderToolId,
   supportsProviderTool,
 } from "./provider-tools.js";
-import { PROVIDER_IDS } from "./types.js";
 import type {
   ClaudeProviderConfig,
   CodexProviderConfig,
   ExaProviderConfig,
   ExecutionPolicyDefaults,
   GeminiProviderConfig,
+  GenericSettingsConfig,
   JsonObject,
   ParallelProviderConfig,
   PerplexityProviderConfig,
@@ -30,6 +29,7 @@ import type {
   ValyuProviderConfig,
   WebProvidersConfig,
 } from "./types.js";
+import { PROVIDER_IDS } from "./types.js";
 
 const CONFIG_FILE_NAME = "web-providers.json";
 const commandValueCache = new Map<
@@ -49,10 +49,10 @@ export function createDefaultConfig(): WebProvidersConfig {
       answer: null,
       research: null,
     },
+    genericSettings: createDefaultLifecyclePolicy(),
     providers: {
       claude: {
         enabled: false,
-        policy: createDefaultRequestPolicy(),
       },
       codex: {
         enabled: true,
@@ -61,7 +61,6 @@ export function createDefaultConfig(): WebProvidersConfig {
           webSearchEnabled: true,
           webSearchMode: "live",
         },
-        policy: createDefaultRequestPolicy(),
       },
       exa: {
         enabled: false,
@@ -72,7 +71,6 @@ export function createDefaultConfig(): WebProvidersConfig {
             text: true,
           },
         },
-        policy: createDefaultLifecyclePolicy(),
       },
       gemini: {
         enabled: false,
@@ -82,10 +80,10 @@ export function createDefaultConfig(): WebProvidersConfig {
           answerModel: "gemini-2.5-flash",
           researchAgent: "deep-research-pro-preview-12-2025",
         },
-        policy: createDefaultLifecyclePolicy({
+        policy: {
           researchMaxConsecutivePollErrors:
             DEFAULT_GEMINI_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS,
-        }),
+        },
       },
       perplexity: {
         enabled: false,
@@ -98,7 +96,6 @@ export function createDefaultConfig(): WebProvidersConfig {
             model: "sonar-deep-research",
           },
         },
-        policy: createDefaultRequestPolicy(),
       },
       parallel: {
         enabled: false,
@@ -112,7 +109,6 @@ export function createDefaultConfig(): WebProvidersConfig {
             full_content: false,
           },
         },
-        policy: createDefaultRequestPolicy(),
       },
       valyu: {
         enabled: false,
@@ -121,7 +117,6 @@ export function createDefaultConfig(): WebProvidersConfig {
           searchType: "all",
           responseLength: "short",
         },
-        policy: createDefaultLifecyclePolicy(),
       },
     },
   };
@@ -282,6 +277,14 @@ function normalizeConfig(raw: unknown, source: string): WebProvidersConfig {
     config.toolSettings = parseToolSettingsConfig(raw.toolSettings, source);
   }
 
+  if (raw.genericSettings !== undefined) {
+    config.genericSettings = parseOptionalGenericSettings(
+      raw.genericSettings,
+      source,
+      "genericSettings",
+    );
+  }
+
   if (raw.providers !== undefined) {
     if (!isPlainObject(raw.providers)) {
       throw new Error(`'providers' in ${source} must be a JSON object.`);
@@ -359,7 +362,9 @@ function normalizeConfig(raw: unknown, source: string): WebProvidersConfig {
     typeof raw.version !== "number" &&
     typeof raw.version !== "string"
   ) {
-    throw new Error(`'version' in ${source}, when present, must be a string or number.`);
+    throw new Error(
+      `'version' in ${source}, when present, must be a string or number.`,
+    );
   }
 
   return config;
@@ -836,6 +841,58 @@ function parseOptionalExecutionPolicy(
     : undefined;
 }
 
+function parseOptionalGenericSettings(
+  value: unknown,
+  source: string,
+  field: string,
+): GenericSettingsConfig | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const settings = parseOptionalJsonObject(value, source, field);
+  if (!settings) {
+    return undefined;
+  }
+
+  const parsed: GenericSettingsConfig = {
+    requestTimeoutMs: parseOptionalInteger(
+      settings.requestTimeoutMs,
+      source,
+      `${field}.requestTimeoutMs`,
+    ),
+    retryCount: parseOptionalNonNegativeInteger(
+      settings.retryCount,
+      source,
+      `${field}.retryCount`,
+    ),
+    retryDelayMs: parseOptionalInteger(
+      settings.retryDelayMs,
+      source,
+      `${field}.retryDelayMs`,
+    ),
+    researchPollIntervalMs: parseOptionalInteger(
+      settings.researchPollIntervalMs,
+      source,
+      `${field}.researchPollIntervalMs`,
+    ),
+    researchTimeoutMs: parseOptionalInteger(
+      settings.researchTimeoutMs,
+      source,
+      `${field}.researchTimeoutMs`,
+    ),
+    researchMaxConsecutivePollErrors: parseOptionalInteger(
+      settings.researchMaxConsecutivePollErrors,
+      source,
+      `${field}.researchMaxConsecutivePollErrors`,
+    ),
+  };
+
+  return Object.values(parsed).some((entry) => entry !== undefined)
+    ? parsed
+    : undefined;
+}
+
 function parseProviderObject(
   raw: unknown,
   source: string,
@@ -893,12 +950,7 @@ function parseToolProviderMappingEntry(
   if (value === null) {
     return null;
   }
-  const providerId = parseLiteral(
-    value,
-    source,
-    field,
-    PROVIDER_IDS,
-  );
+  const providerId = parseLiteral(value, source, field, PROVIDER_IDS);
   if (!supportsProviderTool(providerId, capability as ProviderToolId)) {
     throw new Error(
       `'${field}' in ${source} must name a provider that supports '${capability}'.`,
@@ -920,7 +972,11 @@ function parseToolSettingsConfig(
     if (key !== "search") {
       throw new Error(`Unknown tool settings in ${source}: ${key}.`);
     }
-    parsed.search = parseSearchToolSettings(entry, source, "toolSettings.search");
+    parsed.search = parseSearchToolSettings(
+      entry,
+      source,
+      "toolSettings.search",
+    );
   }
 
   return parsed;
@@ -971,10 +1027,7 @@ function parseSearchContentsPrefetchConfig(
   };
 
   const unknownFields = Object.keys(value).filter(
-    (key) =>
-      key !== "provider" &&
-      key !== "maxUrls" &&
-      key !== "ttlMs",
+    (key) => key !== "provider" && key !== "maxUrls" && key !== "ttlMs",
   );
   if (unknownFields.length > 0) {
     throw new Error(
@@ -1022,9 +1075,9 @@ function inferProviderEnabled(
   config: WebProvidersConfig,
   providerId: ProviderId,
 ): boolean {
-  return (Object.values(config.tools ?? {}) as Array<ProviderId | null | undefined>).some(
-    (mappedProviderId) => mappedProviderId === providerId,
-  );
+  return (
+    Object.values(config.tools ?? {}) as Array<ProviderId | null | undefined>
+  ).some((mappedProviderId) => mappedProviderId === providerId);
 }
 
 function parseOptionalStringMap(

--- a/src/config.ts
+++ b/src/config.ts
@@ -78,14 +78,12 @@ export function createDefaultConfig(): WebProvidersConfig {
         enabled: false,
         tools: {
           search: true,
-          contents: true,
           answer: true,
           research: true,
         },
         apiKey: "GOOGLE_API_KEY",
         native: {
           searchModel: "gemini-2.5-flash",
-          contentsModel: "gemini-2.5-flash",
           answerModel: "gemini-2.5-flash",
           researchAgent: "deep-research-pro-preview-12-2025",
         },
@@ -651,11 +649,6 @@ function normalizeGeminiProvider(
               native.searchModel,
               source,
               "providers.gemini.native.searchModel",
-            ),
-            contentsModel: parseOptionalString(
-              native.contentsModel,
-              source,
-              "providers.gemini.native.contentsModel",
             ),
             answerModel: parseOptionalString(
               native.answerModel,

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,8 @@ import type {
   PerplexityProviderConfig,
   ProviderCapability,
   ProviderId,
+  SearchPrefetchSettings,
+  SearchToolSettings,
   ToolProviderMapping,
   ValyuProviderConfig,
   WebProvidersConfig,
@@ -274,6 +276,10 @@ function normalizeConfig(raw: unknown, source: string): WebProvidersConfig {
 
   if (raw.tools !== undefined) {
     config.tools = parseToolProviderMapping(raw.tools, source, "tools");
+  }
+
+  if (raw.toolSettings !== undefined) {
+    config.toolSettings = parseToolSettingsConfig(raw.toolSettings, source);
   }
 
   if (raw.providers !== undefined) {
@@ -893,6 +899,105 @@ function parseToolProviderMappingEntry(
     field,
     PROVIDER_IDS,
   );
+  if (!supportsProviderTool(providerId, capability as ProviderToolId)) {
+    throw new Error(
+      `'${field}' in ${source} must name a provider that supports '${capability}'.`,
+    );
+  }
+  return providerId;
+}
+
+function parseToolSettingsConfig(
+  value: unknown,
+  source: string,
+): WebProvidersConfig["toolSettings"] {
+  if (!isPlainObject(value)) {
+    throw new Error(`'toolSettings' in ${source} must be a JSON object.`);
+  }
+
+  const parsed: NonNullable<WebProvidersConfig["toolSettings"]> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (key !== "search") {
+      throw new Error(`Unknown tool settings in ${source}: ${key}.`);
+    }
+    parsed.search = parseSearchToolSettings(entry, source, "toolSettings.search");
+  }
+
+  return parsed;
+}
+
+function parseSearchToolSettings(
+  value: unknown,
+  source: string,
+  field: string,
+): SearchToolSettings {
+  if (!isPlainObject(value)) {
+    throw new Error(`'${field}' in ${source} must be a JSON object.`);
+  }
+
+  const parsed: SearchToolSettings = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (key !== "prefetch") {
+      throw new Error(`Unknown search tool settings in ${source}: ${key}.`);
+    }
+    parsed.prefetch = parseSearchContentsPrefetchConfig(
+      entry,
+      source,
+      `${field}.prefetch`,
+    );
+  }
+
+  return parsed;
+}
+
+function parseSearchContentsPrefetchConfig(
+  value: unknown,
+  source: string,
+  field: string,
+): SearchPrefetchSettings {
+  if (!isPlainObject(value)) {
+    throw new Error(`'${field}' in ${source} must be a JSON object.`);
+  }
+
+  const parsed: SearchPrefetchSettings = {
+    provider: parseOptionalToolProviderId(
+      value.provider,
+      source,
+      `${field}.provider`,
+      "contents",
+    ),
+    maxUrls: parseOptionalInteger(value.maxUrls, source, `${field}.maxUrls`),
+    ttlMs: parseOptionalInteger(value.ttlMs, source, `${field}.ttlMs`),
+  };
+
+  const unknownFields = Object.keys(value).filter(
+    (key) =>
+      key !== "provider" &&
+      key !== "maxUrls" &&
+      key !== "ttlMs",
+  );
+  if (unknownFields.length > 0) {
+    throw new Error(
+      `Unknown prefetch settings in ${source}: ${unknownFields.join(", ")}.`,
+    );
+  }
+
+  return parsed;
+}
+
+function parseOptionalToolProviderId(
+  value: unknown,
+  source: string,
+  field: string,
+  capability: ProviderCapability,
+): ProviderId | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null) {
+    return null;
+  }
+  const providerId = parseLiteral(value, source, field, PROVIDER_IDS);
   if (!supportsProviderTool(providerId, capability as ProviderToolId)) {
     throw new Error(
       `'${field}' in ${source} must name a provider that supports '${capability}'.`,

--- a/src/config.ts
+++ b/src/config.ts
@@ -357,16 +357,6 @@ function normalizeConfig(raw: unknown, source: string): WebProvidersConfig {
     }
   }
 
-  if (
-    raw.version !== undefined &&
-    typeof raw.version !== "number" &&
-    typeof raw.version !== "string"
-  ) {
-    throw new Error(
-      `'version' in ${source}, when present, must be a string or number.`,
-    );
-  }
-
   return config;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,12 @@ import {
   createDefaultRequestPolicy,
   DEFAULT_GEMINI_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS,
 } from "./execution-policy-defaults.js";
-import { type ProviderToolId, supportsProviderTool } from "./provider-tools.js";
+import {
+  PROVIDER_TOOL_IDS,
+  type ProviderToolId,
+  supportsProviderTool,
+} from "./provider-tools.js";
+import { PROVIDER_IDS } from "./types.js";
 import type {
   ClaudeProviderConfig,
   CodexProviderConfig,
@@ -17,13 +22,15 @@ import type {
   JsonObject,
   ParallelProviderConfig,
   PerplexityProviderConfig,
+  ProviderCapability,
   ProviderId,
+  ToolProviderMapping,
   ValyuProviderConfig,
   WebProvidersConfig,
 } from "./types.js";
 
 const CONFIG_FILE_NAME = "web-providers.json";
-const VERSION = 1 as const;
+const VERSION = 2 as const;
 const commandValueCache = new Map<
   string,
   { value?: string; errorMessage?: string }
@@ -36,20 +43,17 @@ export function getConfigPath(): string {
 export function createDefaultConfig(): WebProvidersConfig {
   return {
     version: VERSION,
+    tools: {
+      search: "codex",
+      contents: null,
+      answer: null,
+      research: null,
+    },
     providers: {
       claude: {
-        enabled: false,
-        tools: {
-          search: true,
-          answer: true,
-        },
         policy: createDefaultRequestPolicy(),
       },
       codex: {
-        enabled: true,
-        tools: {
-          search: true,
-        },
         native: {
           networkAccessEnabled: true,
           webSearchEnabled: true,
@@ -58,13 +62,6 @@ export function createDefaultConfig(): WebProvidersConfig {
         policy: createDefaultRequestPolicy(),
       },
       exa: {
-        enabled: false,
-        tools: {
-          search: true,
-          contents: true,
-          answer: true,
-          research: true,
-        },
         apiKey: "EXA_API_KEY",
         native: {
           type: "auto",
@@ -75,12 +72,6 @@ export function createDefaultConfig(): WebProvidersConfig {
         policy: createDefaultLifecyclePolicy(),
       },
       gemini: {
-        enabled: false,
-        tools: {
-          search: true,
-          answer: true,
-          research: true,
-        },
         apiKey: "GOOGLE_API_KEY",
         native: {
           searchModel: "gemini-2.5-flash",
@@ -93,12 +84,6 @@ export function createDefaultConfig(): WebProvidersConfig {
         }),
       },
       perplexity: {
-        enabled: false,
-        tools: {
-          search: true,
-          answer: true,
-          research: true,
-        },
         apiKey: "PERPLEXITY_API_KEY",
         native: {
           answer: {
@@ -111,11 +96,6 @@ export function createDefaultConfig(): WebProvidersConfig {
         policy: createDefaultRequestPolicy(),
       },
       parallel: {
-        enabled: false,
-        tools: {
-          search: true,
-          contents: true,
-        },
         apiKey: "PARALLEL_API_KEY",
         native: {
           search: {
@@ -129,13 +109,6 @@ export function createDefaultConfig(): WebProvidersConfig {
         policy: createDefaultRequestPolicy(),
       },
       valyu: {
-        enabled: false,
-        tools: {
-          search: true,
-          contents: true,
-          answer: true,
-          research: true,
-        },
         apiKey: "VALYU_API_KEY",
         native: {
           searchType: "all",
@@ -302,6 +275,10 @@ function normalizeConfig(raw: unknown, source: string): WebProvidersConfig {
 
   const config: WebProvidersConfig = { version: VERSION };
 
+  if (raw.tools !== undefined) {
+    config.tools = parseToolProviderMapping(raw.tools, source, "tools");
+  }
+
   if (raw.providers !== undefined) {
     if (!isPlainObject(raw.providers)) {
       throw new Error(`'providers' in ${source} must be a JSON object.`);
@@ -373,6 +350,7 @@ function normalizeClaudeProvider(
   source: string,
 ): ClaudeProviderConfig {
   const provider = parseProviderObject(raw, source, "claude");
+  rejectLegacyProviderRoutingFields(provider, source, "claude");
   const native = parseOptionalJsonObject(
     getProviderNativeSource(provider),
     source,
@@ -382,17 +360,6 @@ function normalizeClaudeProvider(
   );
 
   return {
-    enabled: parseOptionalBoolean(
-      provider.enabled,
-      source,
-      "providers.claude.enabled",
-    ),
-    tools: parseOptionalProviderTools(
-      "claude",
-      provider.tools,
-      source,
-      "providers.claude.tools",
-    ) as ClaudeProviderConfig["tools"],
     pathToClaudeCodeExecutable: parseOptionalString(
       provider.pathToClaudeCodeExecutable,
       source,
@@ -434,6 +401,7 @@ function normalizeCodexProvider(
   source: string,
 ): CodexProviderConfig {
   const provider = parseProviderObject(raw, source, "codex");
+  rejectLegacyProviderRoutingFields(provider, source, "codex");
   const native = parseOptionalJsonObject(
     getProviderNativeSource(provider),
     source,
@@ -442,17 +410,6 @@ function normalizeCodexProvider(
       : "providers.codex.defaults",
   );
   return {
-    enabled: parseOptionalBoolean(
-      provider.enabled,
-      source,
-      "providers.codex.enabled",
-    ),
-    tools: parseOptionalProviderTools(
-      "codex",
-      provider.tools,
-      source,
-      "providers.codex.tools",
-    ) as CodexProviderConfig["tools"],
     codexPath: parseOptionalString(
       provider.codexPath,
       source,
@@ -523,18 +480,8 @@ function normalizeCodexProvider(
 
 function normalizeExaProvider(raw: unknown, source: string): ExaProviderConfig {
   const provider = parseProviderObject(raw, source, "exa");
+  rejectLegacyProviderRoutingFields(provider, source, "exa");
   return {
-    enabled: parseOptionalBoolean(
-      provider.enabled,
-      source,
-      "providers.exa.enabled",
-    ),
-    tools: parseOptionalProviderTools(
-      "exa",
-      provider.tools,
-      source,
-      "providers.exa.tools",
-    ) as ExaProviderConfig["tools"],
     apiKey: parseOptionalString(
       provider.apiKey,
       source,
@@ -567,18 +514,8 @@ function normalizeValyuProvider(
   source: string,
 ): ValyuProviderConfig {
   const provider = parseProviderObject(raw, source, "valyu");
+  rejectLegacyProviderRoutingFields(provider, source, "valyu");
   return {
-    enabled: parseOptionalBoolean(
-      provider.enabled,
-      source,
-      "providers.valyu.enabled",
-    ),
-    tools: parseOptionalProviderTools(
-      "valyu",
-      provider.tools,
-      source,
-      "providers.valyu.tools",
-    ) as ValyuProviderConfig["tools"],
     apiKey: parseOptionalString(
       provider.apiKey,
       source,
@@ -611,6 +548,7 @@ function normalizeGeminiProvider(
   source: string,
 ): GeminiProviderConfig {
   const provider = parseProviderObject(raw, source, "gemini");
+  rejectLegacyProviderRoutingFields(provider, source, "gemini");
   const native = parseOptionalJsonObject(
     stripPolicyFields(getProviderNativeSource(provider)),
     source,
@@ -620,17 +558,6 @@ function normalizeGeminiProvider(
   );
 
   return {
-    enabled: parseOptionalBoolean(
-      provider.enabled,
-      source,
-      "providers.gemini.enabled",
-    ),
-    tools: parseOptionalProviderTools(
-      "gemini",
-      provider.tools,
-      source,
-      "providers.gemini.tools",
-    ) as GeminiProviderConfig["tools"],
     apiKey: parseOptionalString(
       provider.apiKey,
       source,
@@ -676,6 +603,7 @@ function normalizePerplexityProvider(
   source: string,
 ): PerplexityProviderConfig {
   const provider = parseProviderObject(raw, source, "perplexity");
+  rejectLegacyProviderRoutingFields(provider, source, "perplexity");
   const native = parseOptionalJsonObject(
     stripPolicyFields(getProviderNativeSource(provider)),
     source,
@@ -685,17 +613,6 @@ function normalizePerplexityProvider(
   );
 
   return {
-    enabled: parseOptionalBoolean(
-      provider.enabled,
-      source,
-      "providers.perplexity.enabled",
-    ),
-    tools: parseOptionalProviderTools(
-      "perplexity",
-      provider.tools,
-      source,
-      "providers.perplexity.tools",
-    ) as PerplexityProviderConfig["tools"],
     apiKey: parseOptionalString(
       provider.apiKey,
       source,
@@ -741,6 +658,7 @@ function normalizeParallelProvider(
   source: string,
 ): ParallelProviderConfig {
   const provider = parseProviderObject(raw, source, "parallel");
+  rejectLegacyProviderRoutingFields(provider, source, "parallel");
   const native = parseOptionalJsonObject(
     stripPolicyFields(getProviderNativeSource(provider)),
     source,
@@ -750,17 +668,6 @@ function normalizeParallelProvider(
   );
 
   return {
-    enabled: parseOptionalBoolean(
-      provider.enabled,
-      source,
-      "providers.parallel.enabled",
-    ),
-    tools: parseOptionalProviderTools(
-      "parallel",
-      provider.tools,
-      source,
-      "providers.parallel.tools",
-    ) as ParallelProviderConfig["tools"],
     apiKey: parseOptionalString(
       provider.apiKey,
       source,
@@ -897,23 +804,22 @@ function parseOptionalJsonObject(
   return value;
 }
 
-function parseOptionalProviderTools(
-  providerId: ProviderId,
+function parseToolProviderMapping(
   value: unknown,
   source: string,
   field: string,
-): Partial<Record<ProviderToolId, boolean>> | undefined {
-  if (value === undefined) return undefined;
+): ToolProviderMapping {
   if (!isPlainObject(value)) {
     throw new Error(`'${field}' in ${source} must be a JSON object.`);
   }
 
-  const parsed: Partial<Record<ProviderToolId, boolean>> = {};
+  const parsed: ToolProviderMapping = {};
   for (const [key, entry] of Object.entries(value)) {
-    if (!supportsProviderTool(providerId, key as ProviderToolId)) {
-      throw new Error(`Unknown tools for ${providerId} in ${source}: ${key}.`);
+    if (!PROVIDER_TOOL_IDS.includes(key as ProviderToolId)) {
+      throw new Error(`Unknown tools in ${source}: ${key}.`);
     }
-    parsed[key as ProviderToolId] = parseBoolean(
+    parsed[key as ProviderToolId] = parseToolProviderMappingEntry(
+      key as ProviderToolId,
       entry,
       source,
       `${field}.${key}`,
@@ -921,6 +827,46 @@ function parseOptionalProviderTools(
   }
 
   return parsed;
+}
+
+function parseToolProviderMappingEntry(
+  capability: ProviderCapability,
+  value: unknown,
+  source: string,
+  field: string,
+): ProviderId | null {
+  if (value === null) {
+    return null;
+  }
+  const providerId = parseLiteral(
+    value,
+    source,
+    field,
+    PROVIDER_IDS,
+  );
+  if (!supportsProviderTool(providerId, capability as ProviderToolId)) {
+    throw new Error(
+      `'${field}' in ${source} must name a provider that supports '${capability}'.`,
+    );
+  }
+  return providerId;
+}
+
+function rejectLegacyProviderRoutingFields(
+  provider: JsonObject,
+  source: string,
+  providerId: ProviderId,
+): void {
+  if (provider.enabled !== undefined) {
+    throw new Error(
+      `'providers.${providerId}.enabled' in ${source} is no longer supported. Use top-level 'tools' mappings instead.`,
+    );
+  }
+  if (provider.tools !== undefined) {
+    throw new Error(
+      `'providers.${providerId}.tools' in ${source} is no longer supported. Use top-level 'tools' mappings instead.`,
+    );
+  }
 }
 
 function parseOptionalStringMap(
@@ -1028,6 +974,21 @@ function parseOptionalLiteral<T extends readonly string[]>(
     );
   }
   return value as T[number];
+}
+
+function parseLiteral<T extends readonly string[]>(
+  value: unknown,
+  source: string,
+  field: string,
+  allowed: T,
+): T[number] {
+  const parsed = parseOptionalLiteral(value, source, field, allowed);
+  if (parsed === undefined) {
+    throw new Error(
+      `'${field}' in ${source} must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return parsed;
 }
 
 function isPlainObject(value: unknown): value is JsonObject {

--- a/src/execution-policy-defaults.ts
+++ b/src/execution-policy-defaults.ts
@@ -8,49 +8,17 @@ export const DEFAULT_RESEARCH_TIMEOUT_MS = 21600000;
 export const DEFAULT_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS = 3;
 export const DEFAULT_GEMINI_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS = 10;
 
-export function createDefaultRequestPolicy(): ExecutionPolicyDefaults {
+export function createDefaultLifecyclePolicy(
+  overrides: Partial<ExecutionPolicyDefaults> = {},
+): ExecutionPolicyDefaults {
   return {
     requestTimeoutMs: DEFAULT_REQUEST_TIMEOUT_MS,
     retryCount: DEFAULT_RETRY_COUNT,
     retryDelayMs: DEFAULT_RETRY_DELAY_MS,
-  };
-}
-
-export function createDefaultResearchLifecyclePolicy(
-  overrides: Partial<
-    Pick<
-      ExecutionPolicyDefaults,
-      | "researchPollIntervalMs"
-      | "researchTimeoutMs"
-      | "researchMaxConsecutivePollErrors"
-    >
-  > = {},
-): ExecutionPolicyDefaults {
-  return {
     researchPollIntervalMs: DEFAULT_RESEARCH_POLL_INTERVAL_MS,
     researchTimeoutMs: DEFAULT_RESEARCH_TIMEOUT_MS,
     researchMaxConsecutivePollErrors:
       DEFAULT_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS,
-    ...overrides,
-  };
-}
-
-export function createDefaultLifecyclePolicy(
-  overrides: Partial<
-    Pick<
-      ExecutionPolicyDefaults,
-      | "requestTimeoutMs"
-      | "retryCount"
-      | "retryDelayMs"
-      | "researchPollIntervalMs"
-      | "researchTimeoutMs"
-      | "researchMaxConsecutivePollErrors"
-    >
-  > = {},
-): ExecutionPolicyDefaults {
-  return {
-    ...createDefaultRequestPolicy(),
-    ...createDefaultResearchLifecyclePolicy(overrides),
     ...overrides,
   };
 }

--- a/src/execution-policy-defaults.ts
+++ b/src/execution-policy-defaults.ts
@@ -16,6 +16,25 @@ export function createDefaultRequestPolicy(): ExecutionPolicyDefaults {
   };
 }
 
+export function createDefaultResearchLifecyclePolicy(
+  overrides: Partial<
+    Pick<
+      ExecutionPolicyDefaults,
+      | "researchPollIntervalMs"
+      | "researchTimeoutMs"
+      | "researchMaxConsecutivePollErrors"
+    >
+  > = {},
+): ExecutionPolicyDefaults {
+  return {
+    researchPollIntervalMs: DEFAULT_RESEARCH_POLL_INTERVAL_MS,
+    researchTimeoutMs: DEFAULT_RESEARCH_TIMEOUT_MS,
+    researchMaxConsecutivePollErrors:
+      DEFAULT_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS,
+    ...overrides,
+  };
+}
+
 export function createDefaultLifecyclePolicy(
   overrides: Partial<
     Pick<
@@ -31,10 +50,7 @@ export function createDefaultLifecyclePolicy(
 ): ExecutionPolicyDefaults {
   return {
     ...createDefaultRequestPolicy(),
-    researchPollIntervalMs: DEFAULT_RESEARCH_POLL_INTERVAL_MS,
-    researchTimeoutMs: DEFAULT_RESEARCH_TIMEOUT_MS,
-    researchMaxConsecutivePollErrors:
-      DEFAULT_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS,
+    ...createDefaultResearchLifecyclePolicy(overrides),
     ...overrides,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,7 @@ import type {
   CodexProviderConfig,
   ExaProviderConfig,
   GeminiProviderConfig,
+  GenericSettingsConfig,
   JsonObject,
   ParallelProviderConfig,
   ProviderId,
@@ -79,8 +80,8 @@ import type {
   ProviderToolDetails,
   ProviderToolOutput,
   SearchPrefetchSettings,
-  SearchToolSettings,
   SearchResponse,
+  SearchToolSettings,
   ValyuProviderConfig,
   WebProvidersConfig,
   WebSearchDetails,
@@ -1036,7 +1037,12 @@ async function executeProviderTool({
   await cleanupContentStore();
 
   const provider = explicitProvider
-    ? resolveProviderForCapability(config, explicitProvider, ctx.cwd, capability)
+    ? resolveProviderForCapability(
+        config,
+        explicitProvider,
+        ctx.cwd,
+        capability,
+      )
     : resolveProviderForCapability(config, ctx.cwd, capability);
   const providerConfig = getEffectiveProviderConfig(config, provider.id);
   if (!providerConfig) {
@@ -1442,13 +1448,172 @@ function getSearchPrefetchDefaults(
   return getSearchToolSettings(config)?.prefetch;
 }
 
+type GenericSettingId = keyof GenericSettingsConfig & string;
+
+const GENERIC_SETTING_IDS: readonly GenericSettingId[] = [
+  "requestTimeoutMs",
+  "retryCount",
+  "retryDelayMs",
+  "researchPollIntervalMs",
+  "researchTimeoutMs",
+  "researchMaxConsecutivePollErrors",
+] as const;
+
+const GENERIC_SETTING_META: Record<
+  GenericSettingId,
+  {
+    label: string;
+    help: string;
+    parse: (value: string) => number | undefined;
+  }
+> = {
+  requestTimeoutMs: {
+    label: "Request timeout (ms)",
+    help: "Default maximum time to wait for a single provider request before failing that attempt. Applies to every provider unless overridden.",
+    parse: (value) =>
+      parseOptionalPositiveIntegerInput(
+        value,
+        "Request timeout must be a positive integer.",
+      ),
+  },
+  retryCount: {
+    label: "Retry count",
+    help: "Default number of times transient provider failures should be retried. Applies to every provider unless overridden.",
+    parse: (value) =>
+      parseOptionalNonNegativeIntegerInput(
+        value,
+        "Retry count must be a non-negative integer.",
+      ),
+  },
+  retryDelayMs: {
+    label: "Retry delay (ms)",
+    help: "Default initial delay before retrying failed requests. Later retries back off automatically. Applies to every provider unless overridden.",
+    parse: (value) =>
+      parseOptionalPositiveIntegerInput(
+        value,
+        "Retry delay must be a positive integer.",
+      ),
+  },
+  researchPollIntervalMs: {
+    label: "Research poll interval (ms)",
+    help: "Default poll interval for long-running research jobs. Applies to research-capable providers unless overridden.",
+    parse: (value) =>
+      parseOptionalPositiveIntegerInput(
+        value,
+        "Research poll interval must be a positive integer.",
+      ),
+  },
+  researchTimeoutMs: {
+    label: "Research timeout (ms)",
+    help: "Default maximum total time to wait for research before returning a resumable timeout error. Applies to research-capable providers unless overridden.",
+    parse: (value) =>
+      parseOptionalPositiveIntegerInput(
+        value,
+        "Research timeout must be a positive integer.",
+      ),
+  },
+  researchMaxConsecutivePollErrors: {
+    label: "Max poll errors",
+    help: "Default number of consecutive poll failures to tolerate before stopping a local research run. Applies to research-capable providers unless overridden.",
+    parse: (value) =>
+      parseOptionalPositiveIntegerInput(
+        value,
+        "Max poll errors must be a positive integer.",
+      ),
+  },
+};
+
+function getGenericSettingValue(
+  config: WebProvidersConfig,
+  id: GenericSettingId,
+): number | "mixed" | undefined {
+  const explicitValue = config.genericSettings?.[id];
+  if (typeof explicitValue === "number") {
+    return explicitValue;
+  }
+
+  const values = new Set<number>();
+  for (const providerId of PROVIDER_IDS) {
+    const value = config.providers?.[providerId]?.policy?.[id];
+    if (typeof value === "number") {
+      values.add(value);
+      if (values.size > 1) {
+        return "mixed";
+      }
+    }
+  }
+
+  const [onlyValue] = values;
+  return onlyValue;
+}
+
+function getGenericSettingDisplayValue(
+  config: WebProvidersConfig,
+  id: GenericSettingId,
+): string {
+  const value = getGenericSettingValue(config, id);
+  if (value === "mixed") {
+    return "mixed";
+  }
+  return summarizeStringValue(
+    typeof value === "number" ? String(value) : undefined,
+    false,
+  );
+}
+
+function getGenericSettingRawValue(
+  config: WebProvidersConfig,
+  id: GenericSettingId,
+): string {
+  const value = getGenericSettingValue(config, id);
+  return typeof value === "number" ? String(value) : "";
+}
+
+function ensureGenericSettings(
+  config: WebProvidersConfig,
+): GenericSettingsConfig {
+  config.genericSettings = { ...(config.genericSettings ?? {}) };
+  return config.genericSettings;
+}
+
+function cleanupGenericSettings(config: WebProvidersConfig): void {
+  if (
+    config.genericSettings &&
+    Object.keys(config.genericSettings).length === 0
+  ) {
+    delete config.genericSettings;
+  }
+}
+
+function stripGenericPolicyDuplicates(config: WebProvidersConfig): void {
+  for (const providerId of PROVIDER_IDS) {
+    const providerConfig = config.providers?.[providerId] as
+      | ProviderConfigUnion
+      | undefined;
+    if (!providerConfig?.policy) {
+      continue;
+    }
+
+    for (const key of GENERIC_SETTING_IDS) {
+      if (providerConfig.policy[key] === config.genericSettings?.[key]) {
+        delete providerConfig.policy[key];
+      }
+    }
+
+    if (Object.keys(providerConfig.policy).length === 0) {
+      delete providerConfig.policy;
+    }
+  }
+}
+
 class WebProvidersSettingsView implements Component {
   private config: WebProvidersConfig;
   private activeProvider: ProviderId;
-  private activeSection: "provider" | "tools" = "tools";
+  private activeSection: "provider" | "tools" | "generic" = "tools";
   private selection = {
     provider: 0,
     tools: 0,
+    generic: 0,
   };
   private submenu: Component | undefined;
 
@@ -1481,6 +1646,12 @@ class WebProvidersSettingsView implements Component {
     const providerItems = this.buildProviderSectionItems();
     lines.push(
       ...this.renderSection(width, "Providers", "provider", providerItems),
+    );
+    lines.push("");
+
+    const genericItems = this.buildGenericSectionItems();
+    lines.push(
+      ...this.renderSection(width, "Generic Settings", "generic", genericItems),
     );
 
     const selected = this.getSelectedEntry();
@@ -1557,8 +1728,8 @@ class WebProvidersSettingsView implements Component {
         currentValue: enabled ? "on" : "off",
         description:
           provider.id === this.activeProvider
-            ? `Press Enter to configure ${provider.label}. Current status: ${status.summary}.`
-            : `Move here and press Enter to configure ${provider.label}. Current status: ${status.summary}.`,
+            ? `Press Enter to configure ${provider.label}'s provider-specific settings. Current status: ${status.summary}.`
+            : `Move here and press Enter to configure ${provider.label}'s provider-specific settings. Current status: ${status.summary}.`,
         kind: "action",
       };
     });
@@ -1598,6 +1769,16 @@ class WebProvidersSettingsView implements Component {
     );
   }
 
+  private buildGenericSectionItems(): SettingsEntry[] {
+    return GENERIC_SETTING_IDS.map((id) => ({
+      id: `generic:${id}`,
+      label: GENERIC_SETTING_META[id].label,
+      currentValue: getGenericSettingDisplayValue(this.config, id),
+      description: GENERIC_SETTING_META[id].help,
+      kind: "text",
+    }));
+  }
+
   private buildProviderItem(
     setting: ProviderSettingDescriptor<ProviderConfigUnion>,
     providerConfig: ProviderConfigUnion | undefined,
@@ -1623,16 +1804,11 @@ class WebProvidersSettingsView implements Component {
     };
   }
 
-  private currentProviderConfig(): ProviderConfigUnion | undefined {
-    return this.config.providers?.[this.activeProvider] as
-      | ProviderConfigUnion
-      | undefined;
-  }
-
   private getSectionEntries(
-    section: "provider" | "tools",
+    section: "provider" | "tools" | "generic",
   ): SettingsEntry[] {
     if (section === "provider") return this.buildProviderSectionItems();
+    if (section === "generic") return this.buildGenericSectionItems();
     return this.buildToolSectionItems();
   }
 
@@ -1646,7 +1822,11 @@ class WebProvidersSettingsView implements Component {
   }
 
   private moveSection(direction: 1 | -1): void {
-    const sections: Array<"provider" | "tools"> = ["provider", "tools"];
+    const sections: Array<"provider" | "tools" | "generic"> = [
+      "tools",
+      "provider",
+      "generic",
+    ];
     const index = sections.indexOf(this.activeSection);
     for (let offset = 1; offset <= sections.length; offset++) {
       const next =
@@ -1662,7 +1842,11 @@ class WebProvidersSettingsView implements Component {
   }
 
   private moveSelection(direction: 1 | -1): void {
-    const sections: Array<"provider" | "tools"> = ["provider", "tools"];
+    const sections: Array<"provider" | "tools" | "generic"> = [
+      "tools",
+      "provider",
+      "generic",
+    ];
     const currentEntries = this.getActiveSectionEntries();
     const currentIndex = this.selection[this.activeSection];
 
@@ -1710,7 +1894,7 @@ class WebProvidersSettingsView implements Component {
   private renderSection(
     width: number,
     title: string,
-    section: "provider" | "tools",
+    section: "provider" | "tools" | "generic",
     entries: SettingsEntry[],
   ): string[] {
     const lines = [
@@ -1749,6 +1933,25 @@ class WebProvidersSettingsView implements Component {
     const entry = this.getSelectedEntry();
     if (!entry) return;
 
+    if (entry.id.startsWith("generic:")) {
+      const settingId = entry.id.slice("generic:".length) as GenericSettingId;
+      this.submenu = new TextValueSubmenu(
+        this.tui,
+        this.theme,
+        entry.label,
+        this.currentGenericSettingRawValue(settingId),
+        entry.description,
+        (selectedValue) => {
+          this.submenu = undefined;
+          if (selectedValue !== undefined) {
+            void this.handleGenericSettingChange(settingId, selectedValue);
+          }
+          this.tui.requestRender();
+        },
+      );
+      return;
+    }
+
     if (entry.kind === "action" && entry.id.startsWith("tool:")) {
       const toolId = entry.id.slice("tool:".length) as ProviderToolId;
       this.submenu = new ToolSettingsSubmenu(
@@ -1780,9 +1983,7 @@ class WebProvidersSettingsView implements Component {
             config.providers ??= {};
             const providerConfig = getEditableProviderConfig(
               providerId,
-              config.providers?.[providerId] as
-                | ProviderConfigUnion
-                | undefined,
+              config.providers?.[providerId] as ProviderConfigUnion | undefined,
             );
             mutate(providerConfig);
             config.providers[providerId] = providerConfig as never;
@@ -1797,10 +1998,33 @@ class WebProvidersSettingsView implements Component {
     }
   }
 
+  private currentGenericSettingRawValue(id: GenericSettingId): string {
+    return getGenericSettingRawValue(this.config, id);
+  }
+
+  private async handleGenericSettingChange(
+    id: GenericSettingId,
+    value: string,
+  ): Promise<void> {
+    await this.persist((config) => {
+      const parsed = GENERIC_SETTING_META[id].parse(value);
+      const settings = ensureGenericSettings(config);
+      if (parsed === undefined) {
+        delete settings[id];
+      } else {
+        settings[id] = parsed;
+      }
+      cleanupGenericSettings(config);
+      stripGenericPolicyDuplicates(config);
+    });
+  }
+
   private currentProviderConfigFor(
     providerId: ProviderId,
   ): ProviderConfigUnion | undefined {
-    return this.config.providers?.[providerId] as ProviderConfigUnion | undefined;
+    return this.config.providers?.[providerId] as
+      | ProviderConfigUnion
+      | undefined;
   }
 
   private async persist(
@@ -1809,6 +2033,8 @@ class WebProvidersSettingsView implements Component {
     const nextConfig = structuredClone(this.config);
     try {
       mutate(nextConfig);
+      cleanupGenericSettings(nextConfig);
+      stripGenericPolicyDuplicates(nextConfig);
       await writeConfigFile(nextConfig);
       if (didContentsCacheInputsChange(this.config, nextConfig)) {
         resetContentStore();
@@ -1906,7 +2132,10 @@ class ToolSettingsSubmenu implements Component {
 
   private getEntries(): SettingsEntry[] {
     const config = this.getConfig();
-    const mappedProviderId = getMappedProviderIdForCapability(config, this.toolId);
+    const mappedProviderId = getMappedProviderIdForCapability(
+      config,
+      this.toolId,
+    );
     const enabledProviderIds = getEnabledCompatibleProvidersForTool(
       config,
       this.toolId,
@@ -1939,11 +2168,12 @@ class ToolSettingsSubmenu implements Component {
       );
       const prefetchValues = [
         "off",
-        ...prefetchProviderIds.map((providerId) => PROVIDER_MAP[providerId].label),
+        ...prefetchProviderIds.map(
+          (providerId) => PROVIDER_MAP[providerId].label,
+        ),
       ];
       const currentPrefetchProviderValue =
-        prefetch?.provider &&
-        prefetchProviderIds.includes(prefetch.provider)
+        prefetch?.provider && prefetchProviderIds.includes(prefetch.provider)
           ? PROVIDER_MAP[prefetch.provider].label
           : "off";
 
@@ -1961,7 +2191,9 @@ class ToolSettingsSubmenu implements Component {
           id: "prefetchMaxUrls",
           label: "Prefetch URLs",
           currentValue:
-            prefetch?.maxUrls !== undefined ? String(prefetch.maxUrls) : "default",
+            prefetch?.maxUrls !== undefined
+              ? String(prefetch.maxUrls)
+              : "default",
           description:
             "Maximum number of search result URLs to prefetch. Leave blank to use the built-in default.",
           kind: "text",
@@ -2052,17 +2284,17 @@ class ToolSettingsSubmenu implements Component {
           config.tools[this.toolId] =
             value === "off"
               ? null
-              : getEnabledCompatibleProvidersForTool(config, this.toolId).find(
-                    (providerId) => PROVIDER_MAP[providerId].label === value,
-                  ) ?? null;
+              : (getEnabledCompatibleProvidersForTool(config, this.toolId).find(
+                  (providerId) => PROVIDER_MAP[providerId].label === value,
+                ) ?? null);
           return;
         case "prefetchProvider": {
           const providerId =
             value === "off"
               ? null
-              : getEnabledCompatibleProvidersForTool(config, "contents").find(
-                    (candidate) => PROVIDER_MAP[candidate].label === value,
-                  ) ?? null;
+              : (getEnabledCompatibleProvidersForTool(config, "contents").find(
+                  (candidate) => PROVIDER_MAP[candidate].label === value,
+                ) ?? null);
           ensureSearchToolSettings(config).prefetch ??= {};
           ensureSearchToolSettings(config).prefetch!.provider = providerId;
           return;
@@ -2323,6 +2555,24 @@ function parseOptionalPositiveIntegerInput(
   return parsed;
 }
 
+function parseOptionalNonNegativeIntegerInput(
+  value: string,
+  errorMessage: string,
+): number | undefined {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(errorMessage);
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(errorMessage);
+  }
+  return parsed;
+}
+
 class TextValueSubmenu implements Component {
   private readonly editor: Editor;
 
@@ -2391,10 +2641,10 @@ function getEditableProviderConfig(
   ) as ProviderConfigUnion;
 }
 
-function getInitialProviderSelection(
-  config: WebProvidersConfig,
-): ProviderId {
-  for (const capability of Object.keys(CAPABILITY_TOOL_NAMES) as ProviderCapability[]) {
+function getInitialProviderSelection(config: WebProvidersConfig): ProviderId {
+  for (const capability of Object.keys(
+    CAPABILITY_TOOL_NAMES,
+  ) as ProviderCapability[]) {
     const providerId = getMappedProviderIdForCapability(config, capability);
     if (providerId) {
       return providerId;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
   type ExtensionAPI,
   type ExtensionCommandContext,
   formatSize,
+  getMarkdownTheme,
   keyHint,
   type Theme,
   truncateHead,
@@ -17,6 +18,7 @@ import {
   type EditorTheme,
   getEditorKeybindings,
   Key,
+  Markdown,
   matchesKey,
   Text,
   type TUI,
@@ -208,28 +210,13 @@ function registerWebSearchTool(
       );
     },
 
-    renderResult(result, { expanded, isPartial }, theme) {
-      const text = extractTextContent(result.content);
-      const isError = Boolean((result as { isError?: boolean }).isError);
-
-      if (isPartial) {
-        return undefined;
-      }
-
-      if (isError) {
-        return renderBlockText(text ?? "web_search failed", theme, "error");
-      }
-
-      const details = result.details as WebSearchDetails | undefined;
-      if (!details) {
-        return renderBlockText(text ?? "", theme, "toolOutput");
-      }
-
-      if (expanded) {
-        return renderBlockText(text ?? "", theme, "toolOutput");
-      }
-
-      return renderCollapsedSearchSummary(details, text, theme);
+    renderResult(result, state, theme) {
+      return renderSearchToolResult(
+        result,
+        state.expanded,
+        state.isPartial,
+        theme,
+      );
     },
   });
 }
@@ -269,42 +256,13 @@ function registerWebContentsTool(
       });
     },
     renderCall(args, theme) {
-      const urls: string[] = Array.isArray((args as { urls?: string[] }).urls)
-        ? ((args as { urls?: string[] }).urls ?? [])
-        : [];
-      const provider = String(
-        (args as { provider?: string }).provider ?? "auto",
+      return renderListCallHeader(
+        "web_contents",
+        Array.isArray((args as { urls?: string[] }).urls)
+          ? ((args as { urls?: string[] }).urls ?? [])
+          : [],
+        theme,
       );
-      return {
-        invalidate() {},
-        render(width: number) {
-          const lines: string[] = [];
-          const header = theme.fg("toolTitle", theme.bold("web_contents"));
-          const headerLine = truncateToWidth(header.trimEnd(), width);
-          lines.push(
-            headerLine +
-              " ".repeat(Math.max(0, width - visibleWidth(headerLine))),
-          );
-          for (const url of urls) {
-            const urlLine = truncateToWidth(
-              `  ${theme.fg("accent", url)}`,
-              width,
-            );
-            lines.push(
-              urlLine + " ".repeat(Math.max(0, width - visibleWidth(urlLine))),
-            );
-          }
-          const detailLine = truncateToWidth(
-            `  ${theme.fg("muted", `provider=${provider}`)}`,
-            width,
-          );
-          lines.push(
-            detailLine +
-              " ".repeat(Math.max(0, width - visibleWidth(detailLine))),
-          );
-          return lines;
-        },
-      };
     },
     renderResult(result, state, theme) {
       return renderProviderToolResult(
@@ -313,7 +271,6 @@ function registerWebContentsTool(
         state.isPartial,
         "web_contents failed",
         theme,
-        { hidePartial: true },
       );
     },
   });
@@ -374,7 +331,7 @@ function registerWebAnswerTool(
         state.isPartial,
         "web_answer failed",
         theme,
-        { hidePartial: true },
+        { markdownWhenExpanded: true },
       );
     },
   });
@@ -413,12 +370,11 @@ function registerWebResearchTool(
       });
     },
     renderCall(args, theme) {
-      return renderToolCallHeader(
-        "web_research",
-        formatQuotedPreview(String((args as { input?: string }).input ?? "")),
-        [
-          `provider=${String((args as { provider?: string }).provider ?? "auto")}`,
-        ],
+      return renderResearchCallHeader(
+        {
+          input: String((args as { input?: string }).input ?? ""),
+          provider: (args as { provider?: ProviderId }).provider,
+        },
         theme,
       );
     },
@@ -961,27 +917,26 @@ function buildAnswerBatchError(outcomes: AnswerQueryOutcome[]): Error {
 }
 
 function formatAnswerResponses(outcomes: AnswerQueryOutcome[]): string {
-  if (outcomes.length === 1) {
-    return formatSingleAnswerOutcome(outcomes[0]);
-  }
-
   return outcomes
-    .map((outcome, index) => {
-      const section = outcome.response
-        ? outcome.response.text
-        : `Answer failed: ${outcome.error ?? "Unknown error."}`;
-      return `Question ${index + 1}: ${formatQuotedPreview(outcome.query)}\n${section}`;
-    })
+    .map((outcome, index) =>
+      formatAnswerOutcomeSection(outcome, index, outcomes.length),
+    )
     .join("\n\n");
 }
 
-function formatSingleAnswerOutcome(
-  outcome: AnswerQueryOutcome | undefined,
+function formatAnswerOutcomeSection(
+  outcome: AnswerQueryOutcome,
+  index: number,
+  total: number,
 ): string {
-  if (outcome?.response) {
-    return outcome.response.text;
-  }
-  return `Answer failed: ${outcome?.error ?? "Unknown error."}`;
+  const heading =
+    total > 1
+      ? `## Question ${index + 1}: ${formatAnswerHeading(outcome.query)}`
+      : `## ${formatAnswerHeading(outcome.query)}`;
+  const body = outcome.response
+    ? outcome.response.text
+    : `Answer failed: ${outcome.error ?? "Unknown error."}`;
+  return `${heading}\n\n${body}`;
 }
 
 function buildWebAnswerDetails(
@@ -1276,18 +1231,35 @@ function createToolProgressReporter(
   };
 }
 
-function renderToolCallHeader(
+function renderListCallHeader(
   toolName: string,
-  primary: string,
-  details: string[],
+  items: string[],
   theme: Theme,
+  options: {
+    singleItemFormatter?: (item: string) => string;
+    multiItemFormatter?: (item: string) => string;
+    suffix?: string;
+    forceMultiline?: boolean;
+  } = {},
 ): Component {
   return {
     invalidate() {},
     render(width) {
+      const normalizedItems = items
+        .map((item) => cleanSingleLine(item))
+        .filter((item) => item.length > 0);
+      const showItemsInline =
+        normalizedItems.length === 1 && options.forceMultiline !== true;
+
       let header = theme.fg("toolTitle", theme.bold(toolName));
-      if (primary.trim().length > 0) {
-        header += ` ${theme.fg("accent", primary)}`;
+      if (showItemsInline) {
+        const singleItem =
+          options.singleItemFormatter?.(normalizedItems[0]) ??
+          normalizedItems[0];
+        header += ` ${theme.fg("accent", singleItem)}`;
+      }
+      if (options.suffix) {
+        header += theme.fg("muted", options.suffix);
       }
 
       const lines: string[] = [];
@@ -1296,20 +1268,40 @@ function renderToolCallHeader(
         headerLine + " ".repeat(Math.max(0, width - visibleWidth(headerLine))),
       );
 
-      if (details.length > 0) {
-        const detailLine = truncateToWidth(
-          `  ${theme.fg("muted", details.join(" "))}`,
-          width,
-        );
-        lines.push(
-          detailLine +
-            " ".repeat(Math.max(0, width - visibleWidth(detailLine))),
-        );
+      if (normalizedItems.length > (showItemsInline ? 1 : 0)) {
+        for (const item of normalizedItems) {
+          const renderedItem =
+            options.multiItemFormatter?.(item) ?? truncateInline(item, 120);
+          const itemLine = truncateToWidth(
+            `  ${theme.fg("accent", renderedItem)}`,
+            width,
+          );
+          lines.push(
+            itemLine + " ".repeat(Math.max(0, width - visibleWidth(itemLine))),
+          );
+        }
       }
 
       return lines;
     },
   };
+}
+
+function renderToolCallHeader(
+  toolName: string,
+  primary: string,
+  details: string[],
+  theme: Theme,
+): Component {
+  return renderListCallHeader(
+    toolName,
+    primary.trim().length > 0 ? [primary] : [],
+    theme,
+    {
+      singleItemFormatter: (item) => item,
+      suffix: details.length > 0 ? ` ${details.join(" ")}` : undefined,
+    },
+  );
 }
 
 function renderQuestionCallHeader(
@@ -1319,38 +1311,55 @@ function renderQuestionCallHeader(
   },
   theme: Theme,
 ): Component {
-  return {
-    invalidate() {},
-    render(width) {
-      const header = theme.fg("toolTitle", theme.bold("web_answer"));
-      const questions = getAnswerQueriesForDisplay(params.queries);
-      const lines: string[] = [];
-      const headerLine = truncateToWidth(header, width);
-      lines.push(
-        headerLine + " ".repeat(Math.max(0, width - visibleWidth(headerLine))),
-      );
-
-      for (const question of questions) {
-        const questionLine = truncateToWidth(
-          `  ${theme.fg("accent", truncateInline(cleanSingleLine(question), 120))}`,
-          width,
-        );
-        lines.push(
-          questionLine +
-            " ".repeat(Math.max(0, width - visibleWidth(questionLine))),
-        );
-      }
-
-      const detailLine = truncateToWidth(
-        `  ${theme.fg("muted", `provider=${params.provider ?? "auto"}`)}`,
-        width,
-      );
-      lines.push(
-        detailLine + " ".repeat(Math.max(0, width - visibleWidth(detailLine))),
-      );
-      return lines;
+  return renderListCallHeader(
+    "web_answer",
+    getAnswerQueriesForDisplay(params.queries),
+    theme,
+    {
+      singleItemFormatter: (question) => formatQuotedPreview(question),
     },
-  };
+  );
+}
+
+function renderResearchCallHeader(
+  params: {
+    input: string;
+    provider?: ProviderId;
+  },
+  theme: Theme,
+): Component {
+  return renderListCallHeader("web_research", [params.input], theme, {
+    forceMultiline: true,
+  });
+}
+
+function renderSearchToolResult(
+  result: {
+    content?: Array<{ type: string; text?: string }>;
+    details?: unknown;
+    isError?: boolean;
+  },
+  expanded: boolean,
+  isPartial: boolean,
+  theme: Theme,
+): Component | undefined {
+  const text = extractTextContent(result.content);
+  const isError = Boolean((result as { isError?: boolean }).isError);
+
+  if (isPartial) {
+    return renderSimpleText(text ?? "Working…", theme, "warning");
+  }
+
+  if (isError) {
+    return renderBlockText(text ?? "web_search failed", theme, "error");
+  }
+
+  const details = result.details as WebSearchDetails | undefined;
+  if (!details || expanded) {
+    return renderMarkdownBlock(text ?? "");
+  }
+
+  return renderCollapsedSearchSummary(details, text, theme);
 }
 
 function renderProviderToolResult(
@@ -1363,14 +1372,13 @@ function renderProviderToolResult(
   isPartial: boolean,
   failureText: string,
   theme: Theme,
-  options: { hidePartial?: boolean } = {},
-): Text | undefined {
+  options: {
+    markdownWhenExpanded?: boolean;
+  } = {},
+): Component | undefined {
   const text = extractTextContent(result.content);
 
   if (isPartial) {
-    if (options.hidePartial === true) {
-      return undefined;
-    }
     return renderSimpleText(text ?? "Working…", theme, "warning");
   }
 
@@ -1379,7 +1387,9 @@ function renderProviderToolResult(
   }
 
   if (expanded) {
-    return renderBlockText(text ?? "", theme, "toolOutput");
+    return options.markdownWhenExpanded
+      ? renderMarkdownBlock(text ?? "")
+      : renderBlockText(text ?? "", theme, "toolOutput");
   }
 
   const details = result.details as ProviderToolDetails | undefined;
@@ -1405,11 +1415,34 @@ function renderCollapsedProviderToolSummary(
     return `${details.queryCount} questions via ${details.provider}${failureSuffix}`;
   }
 
-  return (
+  const baseSummary =
+    getCompactProviderToolSummary(details) ??
     details?.summary ??
     getFirstLine(text) ??
-    `${details?.tool ?? "tool"} output available`
-  );
+    `${details?.tool ?? "tool"} output available`;
+
+  if (!details?.provider) {
+    return baseSummary;
+  }
+
+  return appendProviderSummary(baseSummary, details.provider);
+}
+
+function getCompactProviderToolSummary(
+  details: ProviderToolDetails | undefined,
+): string | undefined {
+  if (!details) {
+    return undefined;
+  }
+
+  if (
+    details.tool === "web_contents" &&
+    typeof details.itemCount === "number"
+  ) {
+    return `${details.itemCount} page${details.itemCount === 1 ? "" : "s"}`;
+  }
+
+  return undefined;
 }
 
 interface ProviderToolMenuOption {
@@ -2110,49 +2143,27 @@ function renderCallHeader(
   },
   theme: Theme,
 ): Component {
-  return {
-    invalidate() {},
-    render(width) {
-      let header = theme.fg("toolTitle", theme.bold("web_search"));
-      const queries = getSearchQueriesForDisplay(params.queries);
-      const showExpandedQueries = queries.length > 1;
-      if (queries.length === 1) {
-        header += ` ${theme.fg("accent", formatQuotedPreview(queries[0]))} `;
-      }
+  const maxResultsSuffix =
+    params.maxResults !== undefined && params.maxResults !== DEFAULT_MAX_RESULTS
+      ? ` (max ${params.maxResults})`
+      : undefined;
 
-      const lines: string[] = [];
-      const headerLine = truncateToWidth(header.trimEnd(), width);
-      lines.push(
-        headerLine + " ".repeat(Math.max(0, width - visibleWidth(headerLine))),
-      );
-
-      if (showExpandedQueries) {
-        for (const query of queries) {
-          const queryLine = truncateToWidth(
-            `  ${theme.fg("accent", truncateInline(cleanSingleLine(query), 120))}`,
-            width,
-          );
-          lines.push(
-            queryLine +
-              " ".repeat(Math.max(0, width - visibleWidth(queryLine))),
-          );
-        }
-      }
-
-      const detailParts = [
-        `provider=${params.provider ?? "auto"}`,
-        `maxResults=${params.maxResults ?? DEFAULT_MAX_RESULTS}`,
-      ];
-      const details = truncateToWidth(
-        `  ${theme.fg("muted", detailParts.join(" "))}`,
-        width,
-      );
-      lines.push(
-        details + " ".repeat(Math.max(0, width - visibleWidth(details))),
-      );
-      return lines;
+  return renderListCallHeader(
+    "web_search",
+    getSearchQueriesForDisplay(params.queries),
+    theme,
+    {
+      singleItemFormatter: (query) => formatQuotedPreview(query),
+      suffix: maxResultsSuffix,
     },
-  };
+  );
+}
+
+function renderMarkdownBlock(text: string): Markdown | Text {
+  if (!text) {
+    return new Text("", 0, 0);
+  }
+  return new Markdown(`\n${text}`, 0, 0, getMarkdownTheme());
 }
 
 function renderBlockText(
@@ -2180,20 +2191,26 @@ function renderSimpleText(
 
 function renderCollapsedSearchSummary(
   details: WebSearchDetails,
-  text: string | undefined,
+  _text: string | undefined,
   theme: Pick<Theme, "fg">,
 ): Text {
   const count = `${details.resultCount} result${details.resultCount === 1 ? "" : "s"}`;
-  const queryCount = details.queryCount;
   const failureSuffix =
     details.failedQueryCount > 0 ? `, ${details.failedQueryCount} failed` : "";
   const base =
-    queryCount > 1
-      ? `${queryCount} queries, ${count} via ${details.provider}${failureSuffix}`
-      : (getFirstLine(text) ?? `${count} via ${details.provider}`);
+    details.queryCount > 1
+      ? `${details.queryCount} queries, ${count} via ${details.provider}${failureSuffix}`
+      : `${count} via ${details.provider}${failureSuffix}`;
   let summary = theme.fg("success", base);
   summary += theme.fg("muted", ` (${getExpandHint()})`);
   return new Text(summary, 0, 0);
+}
+
+function appendProviderSummary(summary: string, provider: ProviderId): string {
+  const providerSuffix = `via ${provider}`;
+  return summary.toLowerCase().includes(providerSuffix)
+    ? summary
+    : `${summary} ${providerSuffix}`;
 }
 
 function getFirstLine(text: string | undefined): string | undefined {
@@ -2224,32 +2241,40 @@ function formatSearchResponses(
   outcomes: SearchQueryOutcome[],
   prefetch?: { prefetchId: string; provider: ProviderId; urlCount: number },
 ): string {
-  const body =
-    outcomes.length === 1
-      ? formatSingleSearchOutcome(outcomes[0])
-      : outcomes
-          .map((outcome, index) => {
-            const section = outcome.response
-              ? formatSearchResponse(outcome.response)
-              : `Search failed: ${outcome.error ?? "Unknown error."}`;
-            return `Query ${index + 1}: ${formatQuotedPreview(outcome.query)}\n${section}`;
-          })
-          .join("\n\n");
+  const body = outcomes
+    .map((outcome, index) =>
+      formatSearchOutcomeSection(outcome, index, outcomes.length),
+    )
+    .join("\n\n");
 
   if (!prefetch) {
     return body;
   }
 
-  return `${body}\n\nBackground contents prefetch started via ${prefetch.provider} for ${prefetch.urlCount} URL(s). Prefetch id: ${prefetch.prefetchId}`;
+  return `${body}\n\n---\n\nBackground contents prefetch started via ${prefetch.provider} for ${prefetch.urlCount} URL(s). Prefetch id: ${prefetch.prefetchId}`;
 }
 
-function formatSingleSearchOutcome(
-  outcome: SearchQueryOutcome | undefined,
+function formatSearchOutcomeSection(
+  outcome: SearchQueryOutcome,
+  index: number,
+  total: number,
 ): string {
-  if (outcome?.response) {
-    return formatSearchResponse(outcome.response);
-  }
-  return `Search failed: ${outcome?.error ?? "Unknown error."}`;
+  const heading =
+    total > 1
+      ? `## Query ${index + 1}: ${formatSearchHeading(outcome.query)}`
+      : `## ${formatSearchHeading(outcome.query)}`;
+  const body = outcome.response
+    ? formatSearchResponseMarkdown(outcome.response)
+    : `Search failed: ${outcome.error ?? "Unknown error."}`;
+  return `${heading}\n\n${body}`;
+}
+
+function formatSearchHeading(query: string): string {
+  return `"${escapeMarkdownText(cleanSingleLine(query))}"`;
+}
+
+function formatAnswerHeading(query: string): string {
+  return `"${escapeMarkdownText(cleanSingleLine(query))}"`;
 }
 
 function collectSearchResultUrls(outcomes: SearchQueryOutcome[]): string[] {
@@ -2258,21 +2283,41 @@ function collectSearchResultUrls(outcomes: SearchQueryOutcome[]): string[] {
   );
 }
 
-function formatSearchResponse(response: SearchResponse): string {
+function formatSearchResponseMarkdown(response: SearchResponse): string {
   if (response.results.length === 0) {
     return "No results found.";
   }
 
-  const lines: string[] = [];
-  for (const [index, result] of response.results.entries()) {
-    lines.push(`${index + 1}. ${result.title}`);
-    lines.push(`   ${result.url}`);
-    if (result.snippet) {
-      lines.push(`   ${result.snippet}`);
-    }
-    lines.push("");
-  }
-  return lines.join("\n").trimEnd();
+  return response.results
+    .map((result, index) => {
+      const lines = [
+        `${index + 1}. ${formatMarkdownLink(result.title, result.url)}`,
+      ];
+      if (result.snippet) {
+        lines.push(`   ${escapeMarkdownText(cleanSingleLine(result.snippet))}`);
+      }
+      return lines.join("\n");
+    })
+    .join("\n\n");
+}
+
+function formatMarkdownLink(label: string, url: string): string {
+  return `[${escapeMarkdownLinkLabel(label)}](<${url}>)`;
+}
+
+function escapeMarkdownLinkLabel(text: string): string {
+  return cleanSingleLine(text).replaceAll("\\", "\\\\").replaceAll("]", "\\]");
+}
+
+function escapeMarkdownText(text: string): string {
+  return text
+    .replaceAll("\\", "\\\\")
+    .replaceAll("*", "\\*")
+    .replaceAll("_", "\\_")
+    .replaceAll("`", "\\`")
+    .replaceAll("#", "\\#")
+    .replaceAll("[", "\\[")
+    .replaceAll("]", "\\]");
 }
 
 async function truncateAndSave(text: string, prefix: string): Promise<string> {
@@ -2329,5 +2374,12 @@ export const __test__ = {
   getSyncedActiveTools,
   renderCallHeader,
   renderQuestionCallHeader,
+  renderResearchCallHeader,
+  renderToolCallHeader,
   renderCollapsedSearchSummary,
+  renderCollapsedProviderToolSummary,
+  renderSearchToolResult,
+  renderProviderToolResult,
+  formatSearchResponses,
+  formatAnswerResponses,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1417,11 +1417,10 @@ function getProviderSettings(
 class WebProvidersSettingsView implements Component {
   private config: WebProvidersConfig;
   private activeProvider: ProviderId;
-  private activeSection: "provider" | "tools" | "config" = "tools";
+  private activeSection: "provider" | "tools" = "tools";
   private selection = {
     provider: 0,
     tools: 0,
-    config: 0,
   };
   private submenu: Component | undefined;
 
@@ -1455,17 +1454,6 @@ class WebProvidersSettingsView implements Component {
     lines.push(
       ...this.renderSection(width, "Providers", "provider", providerItems),
     );
-    lines.push("");
-
-    const configItems = this.buildConfigSectionItems();
-    lines.push(
-      ...this.renderSection(
-        width,
-        "General",
-        "config",
-        configItems,
-      ),
-    );
 
     const selected = this.getSelectedEntry();
     if (selected) {
@@ -1483,7 +1471,7 @@ class WebProvidersSettingsView implements Component {
       truncateToWidth(
         this.theme.fg(
           "dim",
-          "↑↓ move · Tab/Shift+Tab switch section · Enter select/edit/toggle · Esc close",
+          "↑↓ move · Tab/Shift+Tab switch section · Enter edit/open · Esc close",
         ),
         width,
       ),
@@ -1534,14 +1522,15 @@ class WebProvidersSettingsView implements Component {
         | ProviderConfigUnion
         | undefined;
       const status = provider.getStatus(providerConfig as never, this.ctx.cwd);
+      const enabled = providerConfig?.enabled === true;
       return {
         id: `provider:${provider.id}`,
         label: provider.label,
-        currentValue: "",
+        currentValue: enabled ? "on" : "off",
         description:
           provider.id === this.activeProvider
-            ? `Editing ${provider.label} settings below. Current status: ${status.summary}.`
-            : `Select ${provider.label} to edit its settings. Current status: ${status.summary}.`,
+            ? `Press Enter to configure ${provider.label}. Current status: ${status.summary}.`
+            : `Move here and press Enter to configure ${provider.label}. Current status: ${status.summary}.`,
         kind: "action",
       };
     });
@@ -1551,14 +1540,23 @@ class WebProvidersSettingsView implements Component {
     return (Object.keys(CAPABILITY_TOOL_NAMES) as ProviderToolId[]).map(
       (toolId) => {
         const compatibleProviders = getCompatibleProvidersForTool(toolId);
+        const enabledCompatibleProviders = compatibleProviders.filter(
+          (providerId) =>
+            (this.config.providers?.[providerId] as ProviderConfigUnion | undefined)
+              ?.enabled === true,
+        );
         const mappedProviderId = getMappedProviderIdForCapability(
           this.config,
           toolId,
         );
-        const currentValue = mappedProviderId
-          ? PROVIDER_MAP[mappedProviderId].label
-          : "off";
-        const compatibleLabels = compatibleProviders.map(
+        const currentValue =
+          mappedProviderId &&
+          enabledCompatibleProviders.includes(mappedProviderId)
+            ? PROVIDER_MAP[mappedProviderId].label
+            : mappedProviderId
+              ? `${PROVIDER_MAP[mappedProviderId].label} (disabled)`
+              : "off";
+        const compatibleLabels = enabledCompatibleProviders.map(
           (providerId) => PROVIDER_MAP[providerId].label,
         );
         return {
@@ -1568,19 +1566,12 @@ class WebProvidersSettingsView implements Component {
           description:
             `${PROVIDER_TOOL_META[toolId].help} Route web_${toolId} to one compatible provider or turn it off.` +
             (compatibleLabels.length > 0
-              ? ` Compatible providers: ${compatibleLabels.join(", ")}.`
+              ? ` Enabled compatible providers: ${compatibleLabels.join(", ")}.`
               : ""),
           kind: "cycle",
           values: ["off", ...compatibleLabels],
         };
       },
-    );
-  }
-
-  private buildConfigSectionItems(): SettingsEntry[] {
-    const providerConfig = this.currentProviderConfig();
-    return getProviderSettings(this.activeProvider).map((setting) =>
-      this.buildProviderItem(setting, providerConfig),
     );
   }
 
@@ -1616,11 +1607,10 @@ class WebProvidersSettingsView implements Component {
   }
 
   private getSectionEntries(
-    section: "provider" | "tools" | "config",
+    section: "provider" | "tools",
   ): SettingsEntry[] {
     if (section === "provider") return this.buildProviderSectionItems();
-    if (section === "tools") return this.buildToolSectionItems();
-    return this.buildConfigSectionItems();
+    return this.buildToolSectionItems();
   }
 
   private getActiveSectionEntries(): SettingsEntry[] {
@@ -1633,11 +1623,7 @@ class WebProvidersSettingsView implements Component {
   }
 
   private moveSection(direction: 1 | -1): void {
-    const sections: Array<"provider" | "tools" | "config"> = [
-      "provider",
-      "tools",
-      "config",
-    ];
+    const sections: Array<"provider" | "tools"> = ["provider", "tools"];
     const index = sections.indexOf(this.activeSection);
     for (let offset = 1; offset <= sections.length; offset++) {
       const next =
@@ -1646,27 +1632,26 @@ class WebProvidersSettingsView implements Component {
         ];
       if (this.getSectionEntries(next).length > 0) {
         this.activeSection = next;
+        this.syncActiveProviderToSelection();
         return;
       }
     }
   }
 
   private moveSelection(direction: 1 | -1): void {
-    const sections: Array<"provider" | "tools" | "config"> = [
-      "provider",
-      "tools",
-      "config",
-    ];
+    const sections: Array<"provider" | "tools"> = ["provider", "tools"];
     const currentEntries = this.getActiveSectionEntries();
     const currentIndex = this.selection[this.activeSection];
 
     if (direction === -1 && currentIndex > 0) {
       this.selection[this.activeSection] = currentIndex - 1;
+      this.syncActiveProviderToSelection();
       return;
     }
 
     if (direction === 1 && currentIndex < currentEntries.length - 1) {
       this.selection[this.activeSection] = currentIndex + 1;
+      this.syncActiveProviderToSelection();
       return;
     }
 
@@ -1683,14 +1668,26 @@ class WebProvidersSettingsView implements Component {
       this.activeSection = nextSection;
       this.selection[nextSection] =
         direction === 1 ? 0 : nextEntries.length - 1;
+      this.syncActiveProviderToSelection();
       return;
     }
+  }
+
+  private syncActiveProviderToSelection(): void {
+    if (this.activeSection !== "provider") {
+      return;
+    }
+    const provider = PROVIDERS[this.selection.provider];
+    if (!provider) {
+      return;
+    }
+    this.activeProvider = provider.id;
   }
 
   private renderSection(
     width: number,
     title: string,
-    section: "provider" | "tools" | "config",
+    section: "provider" | "tools",
     entries: SettingsEntry[],
   ): string[] {
     const lines = [
@@ -1729,8 +1726,32 @@ class WebProvidersSettingsView implements Component {
     const entry = this.getSelectedEntry();
     if (!entry) return;
 
-    if (entry.kind === "action") {
-      await this.handleChange(entry.id, entry.currentValue);
+    if (entry.kind === "action" && entry.id.startsWith("provider:")) {
+      const providerId = entry.id.slice("provider:".length) as ProviderId;
+      this.activeProvider = providerId;
+      this.submenu = new ProviderSettingsSubmenu(
+        this.tui,
+        this.theme,
+        providerId,
+        () => this.currentProviderConfigFor(providerId),
+        async (mutate) => {
+          await this.persist((config) => {
+            config.providers ??= {};
+            const providerConfig = getEditableProviderConfig(
+              providerId,
+              config.providers?.[providerId] as
+                | ProviderConfigUnion
+                | undefined,
+            );
+            mutate(providerConfig);
+            config.providers[providerId] = providerConfig as never;
+          });
+        },
+        () => {
+          this.submenu = undefined;
+          this.tui.requestRender();
+        },
+      );
       return;
     }
 
@@ -1773,31 +1794,28 @@ class WebProvidersSettingsView implements Component {
   }
 
   private async handleChange(id: string, value: string): Promise<void> {
-    if (id.startsWith("provider:")) {
-      const nextProvider = id.slice("provider:".length) as ProviderId;
-      if (nextProvider === this.activeProvider) {
-        return;
-      }
-      this.activeProvider = nextProvider;
-      this.selection.config = 0;
-      this.tui.requestRender();
-      return;
-    }
-
     await this.persist((config) => {
+      config.providers ??= {};
+
       if (id.startsWith("tool:")) {
         const toolId = id.slice("tool:".length) as ProviderToolId;
         config.tools ??= {};
         config.tools[toolId] =
           value === "off"
             ? null
-            : getCompatibleProvidersForTool(toolId).find(
+            : getCompatibleProvidersForTool(toolId)
+                .filter(
+                  (providerId) =>
+                    (config.providers?.[providerId] as
+                      | ProviderConfigUnion
+                      | undefined)?.enabled === true,
+                )
+                .find(
                 (providerId) => PROVIDER_MAP[providerId].label === value,
               ) ?? null;
         return;
       }
 
-      config.providers ??= {};
       const providerConfig = getEditableProviderConfig(
         this.activeProvider,
         config.providers?.[this.activeProvider] as
@@ -1815,6 +1833,12 @@ class WebProvidersSettingsView implements Component {
     });
   }
 
+  private currentProviderConfigFor(
+    providerId: ProviderId,
+  ): ProviderConfigUnion | undefined {
+    return this.config.providers?.[providerId] as ProviderConfigUnion | undefined;
+  }
+
   private async persist(
     mutate: (config: WebProvidersConfig) => void,
   ): Promise<void> {
@@ -1830,6 +1854,213 @@ class WebProvidersSettingsView implements Component {
     } catch (error) {
       this.ctx.ui.notify((error as Error).message, "error");
     }
+  }
+}
+
+class ProviderSettingsSubmenu implements Component {
+  private selection = 0;
+  private submenu: Component | undefined;
+
+  constructor(
+    private readonly tui: TUI,
+    private readonly theme: Theme,
+    private readonly providerId: ProviderId,
+    private readonly getProviderConfig: () => ProviderConfigUnion | undefined,
+    private readonly persist: (
+      mutate: (config: ProviderConfigUnion) => void,
+    ) => Promise<void>,
+    private readonly done: () => void,
+  ) {}
+
+  render(width: number): string[] {
+    if (this.submenu) {
+      return this.submenu.render(width);
+    }
+
+    const provider = PROVIDER_MAP[this.providerId];
+    const providerConfig = this.getProviderConfig();
+    const entries = this.getEntries();
+    const lines = [
+      truncateToWidth(this.theme.fg("accent", provider.label), width),
+      "",
+      ...this.renderEntries(width, entries),
+    ];
+
+    const selected = entries[this.selection];
+    if (selected) {
+      lines.push("");
+      for (const line of wrapTextWithAnsi(
+        selected.description,
+        Math.max(10, width - 2),
+      )) {
+        lines.push(truncateToWidth(this.theme.fg("dim", line), width));
+      }
+    }
+
+    const status = provider.getStatus(providerConfig as never, "");
+    lines.push("");
+    lines.push(
+      truncateToWidth(this.theme.fg("dim", `Status: ${status.summary}`), width),
+    );
+    lines.push(
+      truncateToWidth(
+        this.theme.fg("dim", "↑↓ move · Enter edit/toggle · Esc back"),
+        width,
+      ),
+    );
+    return lines;
+  }
+
+  invalidate(): void {
+    this.submenu?.invalidate();
+  }
+
+  handleInput(data: string): void {
+    if (this.submenu) {
+      this.submenu.handleInput?.(data);
+      this.tui.requestRender();
+      return;
+    }
+
+    const kb = getEditorKeybindings();
+    const entries = this.getEntries();
+
+    if (kb.matches(data, "selectUp")) {
+      if (this.selection > 0) {
+        this.selection -= 1;
+      }
+    } else if (kb.matches(data, "selectDown")) {
+      if (this.selection < entries.length - 1) {
+        this.selection += 1;
+      }
+    } else if (kb.matches(data, "selectConfirm") || data === " ") {
+      void this.activateCurrentEntry();
+    } else if (kb.matches(data, "selectCancel")) {
+      this.done();
+      return;
+    }
+
+    this.tui.requestRender();
+  }
+
+  private getEntries(): SettingsEntry[] {
+    const providerConfig = this.getProviderConfig();
+    return [
+      {
+        id: "providerEnabled",
+        label: "Enabled",
+        currentValue: providerConfig?.enabled === true ? "on" : "off",
+        description:
+          "Whether this provider is eligible for tool mappings and runtime use.",
+        kind: "cycle",
+        values: ["on", "off"],
+      },
+      ...getProviderSettings(this.providerId).map((setting) =>
+        this.buildProviderItem(setting, providerConfig),
+      ),
+    ];
+  }
+
+  private buildProviderItem(
+    setting: ProviderSettingDescriptor<ProviderConfigUnion>,
+    providerConfig: ProviderConfigUnion | undefined,
+  ): SettingsEntry {
+    if (setting.kind === "values") {
+      return {
+        id: setting.id,
+        label: setting.label,
+        currentValue: setting.getValue(providerConfig),
+        values: setting.values,
+        description: setting.help,
+        kind: "cycle",
+      };
+    }
+
+    const currentValue = setting.getValue(providerConfig);
+    return {
+      id: setting.id,
+      label: setting.label,
+      currentValue: summarizeStringValue(currentValue, setting.secret === true),
+      description: setting.help,
+      kind: "text",
+    };
+  }
+
+  private renderEntries(width: number, entries: SettingsEntry[]): string[] {
+    const labelWidth = Math.min(
+      24,
+      Math.max(...entries.map((entry) => entry.label.length), 0),
+    );
+    return entries.map((entry, index) => {
+      const selected = this.selection === index;
+      const prefix = selected ? this.theme.fg("accent", "→ ") : "  ";
+      const paddedLabel = entry.label.padEnd(labelWidth, " ");
+      const label = selected
+        ? this.theme.fg("accent", paddedLabel)
+        : paddedLabel;
+      const value = selected
+        ? this.theme.fg("accent", entry.currentValue)
+        : this.theme.fg("muted", entry.currentValue);
+      return truncateToWidth(`${prefix}${label}  ${value}`, width);
+    });
+  }
+
+  private async activateCurrentEntry(): Promise<void> {
+    const entry = this.getEntries()[this.selection];
+    if (!entry) return;
+
+    if (entry.kind === "cycle" && entry.values && entry.values.length > 0) {
+      const currentIndex = entry.values.indexOf(entry.currentValue);
+      const nextValue = entry.values[(currentIndex + 1) % entry.values.length];
+      await this.handleChange(entry.id, nextValue);
+      return;
+    }
+
+    if (entry.kind === "text") {
+      const currentValue = this.getEntryRawValue(entry.id) ?? "";
+      this.submenu = new TextValueSubmenu(
+        this.tui,
+        this.theme,
+        entry.label,
+        currentValue,
+        entry.description,
+        (selectedValue) => {
+          this.submenu = undefined;
+          if (selectedValue !== undefined) {
+            void this.handleChange(entry.id, selectedValue);
+          }
+          this.tui.requestRender();
+        },
+      );
+    }
+  }
+
+  private getEntryRawValue(id: string): string | undefined {
+    const providerConfig = this.getProviderConfig();
+    const setting = getProviderSettings(this.providerId).find(
+      (candidate) => candidate.id === id,
+    );
+    if (!setting || setting.kind !== "text") {
+      return undefined;
+    }
+    return setting.getValue(providerConfig);
+  }
+
+  private async handleChange(id: string, value: string): Promise<void> {
+    await this.persist((providerConfig) => {
+      if (id === "providerEnabled") {
+        providerConfig.enabled = value === "on";
+        return;
+      }
+
+      const setting = getProviderSettings(this.providerId).find(
+        (candidate) => candidate.id === id,
+      );
+      if (!setting) {
+        throw new Error(`Unknown setting '${id}'.`);
+      }
+      setting.setValue(providerConfig, value);
+    });
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ import {
 } from "./provider-config-manifests.js";
 import {
   getEffectiveProviderConfig,
+  getMappedProviderIdForCapability,
   resolveProviderChoice,
   resolveProviderForCapability,
   supportsProviderCapability,
@@ -58,9 +59,8 @@ import {
   resolvePlanExecutionSupport,
 } from "./provider-runtime.js";
 import {
-  isProviderToolEnabled,
+  getCompatibleProvidersForTool,
   PROVIDER_TOOL_META,
-  PROVIDER_TOOLS,
   type ProviderConfigUnion,
   type ProviderToolId,
 } from "./provider-tools.js";
@@ -96,9 +96,6 @@ const CAPABILITY_TOOL_NAMES: Record<ProviderCapability, string> = {
   research: "web_research",
 };
 const MANAGED_TOOL_NAMES = Object.values(CAPABILITY_TOOL_NAMES);
-const PROVIDER_OVERRIDE_GUIDELINES = [
-  "Do not set provider unless the user asks for one.",
-];
 
 export default function webProvidersExtension(pi: ExtensionAPI) {
   registerManagedTools(pi);
@@ -161,7 +158,6 @@ function registerWebSearchTool(
       `Find likely sources on the public web for up to ${MAX_SEARCH_QUERIES} queries in a single call and return titles, URLs, and snippets grouped by query. ` +
       `Output is truncated to ${DEFAULT_MAX_LINES} lines or ${formatSize(DEFAULT_MAX_BYTES)} when needed.`,
     promptGuidelines: [
-      ...PROVIDER_OVERRIDE_GUIDELINES,
       "Prefer batching related searches into one web_search call instead of making multiple calls.",
     ],
     parameters: Type.Object({
@@ -180,16 +176,11 @@ function registerWebSearchTool(
       options: jsonOptionsSchema(
         describeOptionsField("search", visibleProviderIds),
       ),
-      provider: providerEnum(
-        visibleProviderIds,
-        "Provider override. If omitted, uses the active configured provider or falls back to Codex for search when it is not explicitly disabled.",
-      ),
     }),
 
     async execute(_toolCallId, params, signal, onUpdate, ctx) {
       return executeSearchTool({
         config: await loadConfig(),
-        explicitProvider: params.provider,
         ctx,
         signal,
         onUpdate,
@@ -203,7 +194,6 @@ function registerWebSearchTool(
       return renderCallHeader(
         args as {
           queries?: string[];
-          provider?: ProviderId;
           maxResults?: number;
         },
         theme,
@@ -237,17 +227,11 @@ function registerWebContentsTool(
         description: "One or more URLs to extract",
       }),
       options: jsonOptionsSchema(describeOptionsField("contents", providerIds)),
-      provider: providerEnum(
-        providerIds,
-        "Provider override. If omitted, uses the active configured provider that supports web contents.",
-      ),
     }),
-    promptGuidelines: PROVIDER_OVERRIDE_GUIDELINES,
     async execute(_toolCallId, params, signal, onUpdate, ctx) {
       return executeProviderTool({
         capability: "contents",
         config: await loadConfig(),
-        explicitProvider: params.provider,
         ctx,
         signal,
         onUpdate,
@@ -293,19 +277,13 @@ function registerWebAnswerTool(
         description: `One or more questions to answer in one call (max ${MAX_SEARCH_QUERIES})`,
       }),
       options: jsonOptionsSchema(describeOptionsField("answer", providerIds)),
-      provider: providerEnum(
-        providerIds,
-        "Provider override. If omitted, uses the active configured provider that supports web answers.",
-      ),
     }),
     promptGuidelines: [
-      ...PROVIDER_OVERRIDE_GUIDELINES,
       "Prefer batching related questions into one web_answer call instead of making multiple calls.",
     ],
     async execute(_toolCallId, params, signal, onUpdate, ctx) {
       return executeAnswerTool({
         config: await loadConfig(),
-        explicitProvider: params.provider,
         ctx,
         signal,
         onUpdate,
@@ -319,7 +297,6 @@ function registerWebAnswerTool(
           queries: Array.isArray((args as { queries?: unknown }).queries)
             ? ((args as { queries?: string[] }).queries ?? [])
             : [],
-          provider: (args as { provider?: ProviderId }).provider,
         },
         theme,
       );
@@ -351,17 +328,11 @@ function registerWebResearchTool(
     parameters: Type.Object({
       input: Type.String({ description: "Research brief or question" }),
       options: jsonOptionsSchema(describeOptionsField("research", providerIds)),
-      provider: providerEnum(
-        providerIds,
-        "Provider override. If omitted, uses the active configured provider that supports research.",
-      ),
     }),
-    promptGuidelines: PROVIDER_OVERRIDE_GUIDELINES,
     async execute(_toolCallId, params, signal, onUpdate, ctx) {
       return executeProviderTool({
         capability: "research",
         config: await loadConfig(),
-        explicitProvider: params.provider,
         ctx,
         signal,
         onUpdate,
@@ -373,7 +344,6 @@ function registerWebResearchTool(
       return renderResearchCallHeader(
         {
           input: String((args as { input?: string }).input ?? ""),
-          provider: (args as { provider?: ProviderId }).provider,
         },
         theme,
       );
@@ -395,7 +365,7 @@ async function runWebProvidersConfig(
   ctx: ExtensionCommandContext,
 ): Promise<void> {
   const config = await loadConfig();
-  const activeProvider = await getPreferredProvider(ctx.cwd);
+  const activeProvider = getInitialProviderSelection(config);
 
   await ctx.ui.custom(
     (tui, theme, _keybindings, done) =>
@@ -417,18 +387,17 @@ function getAvailableProviderIdsForCapability(
   cwd: string,
   capability: ProviderCapability,
 ): ProviderId[] {
-  const providerIds: ProviderId[] = [];
-
-  for (const providerId of getProviderIdsForCapability(capability)) {
-    try {
-      resolveProviderForCapability(config, providerId, cwd, capability);
-      providerIds.push(providerId);
-    } catch {
-      // Exclude unavailable or disabled providers from the visible override list.
-    }
+  const providerId = getMappedProviderIdForCapability(config, capability);
+  if (!providerId) {
+    return [];
   }
 
-  return providerIds;
+  try {
+    resolveProviderForCapability(config, cwd, capability);
+    return [providerId];
+  } catch {
+    return [];
+  }
 }
 
 function getAvailableManagedToolNames(
@@ -510,18 +479,6 @@ function getProviderIdsForCapability(
   return PROVIDERS.filter((provider) =>
     supportsProviderCapability(provider, capability),
   ).map((provider) => provider.id);
-}
-
-function providerEnum(providerIds: readonly ProviderId[], description: string) {
-  if (providerIds.length === 1) {
-    return Type.Optional(Type.Literal(providerIds[0], { description }));
-  }
-  return Type.Optional(
-    Type.Union(
-      providerIds.map((id) => Type.Literal(id)),
-      { description },
-    ),
-  );
 }
 
 function jsonOptionsSchema(description: string) {
@@ -636,7 +593,7 @@ async function executeSearchTool({
   planOverrides,
 }: {
   config: WebProvidersConfig;
-  explicitProvider: ProviderId | undefined;
+  explicitProvider?: ProviderId;
   ctx: { cwd: string };
   signal: AbortSignal | null | undefined;
   onUpdate:
@@ -652,7 +609,11 @@ async function executeSearchTool({
 }) {
   await cleanupContentStore();
 
-  const provider = resolveProviderChoice(config, explicitProvider, ctx.cwd);
+  const provider = resolveProviderChoice(
+    config,
+    explicitProvider ?? ctx.cwd,
+    explicitProvider ? ctx.cwd : undefined,
+  );
   const providerConfig = getEffectiveProviderConfig(config, provider.id);
   if (!providerConfig) {
     throw new Error(`Provider '${provider.id}' is not configured.`);
@@ -809,7 +770,7 @@ async function executeAnswerTool({
   planOverrides,
 }: {
   config: WebProvidersConfig;
-  explicitProvider: ProviderId | undefined;
+  explicitProvider?: ProviderId;
   ctx: { cwd: string };
   signal: AbortSignal | null | undefined;
   onUpdate:
@@ -822,12 +783,9 @@ async function executeAnswerTool({
   queries: string[];
   planOverrides?: ProviderOperationPlan<ProviderToolOutput>[];
 }) {
-  const provider = resolveProviderForCapability(
-    config,
-    explicitProvider,
-    ctx.cwd,
-    "answer",
-  );
+  const provider = explicitProvider
+    ? resolveProviderForCapability(config, explicitProvider, ctx.cwd, "answer")
+    : resolveProviderForCapability(config, ctx.cwd, "answer");
   const providerConfig = getEffectiveProviderConfig(config, provider.id);
   if (!providerConfig) {
     throw new Error(`Provider '${provider.id}' is not configured.`);
@@ -1055,7 +1013,7 @@ async function executeProviderTool({
 }: {
   capability: Exclude<ProviderCapability, "search">;
   config: WebProvidersConfig;
-  explicitProvider: ProviderId | undefined;
+  explicitProvider?: ProviderId;
   ctx: { cwd: string };
   signal: AbortSignal | null | undefined;
   onUpdate:
@@ -1072,12 +1030,9 @@ async function executeProviderTool({
 }) {
   await cleanupContentStore();
 
-  const provider = resolveProviderForCapability(
-    config,
-    explicitProvider,
-    ctx.cwd,
-    capability,
-  );
+  const provider = explicitProvider
+    ? resolveProviderForCapability(config, explicitProvider, ctx.cwd, capability)
+    : resolveProviderForCapability(config, ctx.cwd, capability);
   const providerConfig = getEffectiveProviderConfig(config, provider.id);
   if (!providerConfig) {
     throw new Error(`Provider '${provider.id}' is not configured.`);
@@ -1307,7 +1262,6 @@ function renderToolCallHeader(
 function renderQuestionCallHeader(
   params: {
     queries: string[];
-    provider?: ProviderId;
   },
   theme: Theme,
 ): Component {
@@ -1324,7 +1278,6 @@ function renderQuestionCallHeader(
 function renderResearchCallHeader(
   params: {
     input: string;
-    provider?: ProviderId;
   },
   theme: Theme,
 ): Component {
@@ -1445,29 +1398,13 @@ function getCompactProviderToolSummary(
   return undefined;
 }
 
-interface ProviderToolMenuOption {
-  key: ProviderToolId;
-  label: string;
-  help: string;
-}
-
 interface SettingsEntry {
   id: string;
   label: string;
   currentValue: string;
   description: string;
-  kind: "cycle" | "text";
+  kind: "action" | "cycle" | "text";
   values?: string[];
-}
-
-function buildProviderToolMenuOptions(
-  providerId: ProviderId,
-): ProviderToolMenuOption[] {
-  return PROVIDER_TOOLS[providerId].map((toolId) => ({
-    key: toolId,
-    label: PROVIDER_TOOL_META[toolId].label,
-    help: PROVIDER_TOOL_META[toolId].help,
-  }));
 }
 
 function getProviderSettings(
@@ -1498,6 +1435,10 @@ class WebProvidersSettingsView implements Component {
   ) {
     this.config = structuredClone(initialConfig);
     this.activeProvider = initialProvider;
+    this.selection.provider = Math.max(
+      0,
+      PROVIDERS.findIndex((provider) => provider.id === initialProvider),
+    );
   }
 
   render(width: number): string[] {
@@ -1508,7 +1449,7 @@ class WebProvidersSettingsView implements Component {
     const lines: string[] = [];
     const providerItems = this.buildProviderSectionItems();
     lines.push(
-      ...this.renderSection(width, "Provider", "provider", providerItems),
+      ...this.renderSection(width, "Providers", "provider", providerItems),
     );
     lines.push("");
 
@@ -1542,7 +1483,7 @@ class WebProvidersSettingsView implements Component {
       truncateToWidth(
         this.theme.fg(
           "dim",
-          "↑↓ move · Tab/Shift+Tab switch section · Enter edit/toggle · Esc close",
+          "↑↓ move · Tab/Shift+Tab switch section · Enter select/edit/toggle · Esc close",
         ),
         width,
       ),
@@ -1588,34 +1529,55 @@ class WebProvidersSettingsView implements Component {
   }
 
   private buildProviderSectionItems(): SettingsEntry[] {
-    return [
-      {
-        id: "provider",
-        label: "Engine",
-        currentValue: PROVIDER_MAP[this.activeProvider].label,
-        description: "Active web provider. Enter cycles through providers.",
-        kind: "cycle",
-        values: PROVIDERS.map((provider) => provider.label),
-      },
-    ];
+    return PROVIDERS.map((provider) => {
+      const providerConfig = this.config.providers?.[provider.id] as
+        | ProviderConfigUnion
+        | undefined;
+      const status = provider.getStatus(providerConfig as never, this.ctx.cwd);
+      return {
+        id: `provider:${provider.id}`,
+        label: provider.label,
+        currentValue:
+          provider.id === this.activeProvider
+            ? `selected · ${status.summary}`
+            : status.summary,
+        description:
+          provider.id === this.activeProvider
+            ? `Editing ${provider.label} settings below. Current status: ${status.summary}.`
+            : `Select ${provider.label} to edit its settings. Current status: ${status.summary}.`,
+        kind: "action",
+      };
+    });
   }
 
   private buildToolSectionItems(): SettingsEntry[] {
-    const providerConfig = this.currentProviderConfig();
-    return buildProviderToolMenuOptions(this.activeProvider).map((option) => ({
-      id: `tool:${option.key}`,
-      label: option.label,
-      currentValue: isProviderToolEnabled(
-        this.activeProvider,
-        providerConfig,
-        option.key,
-      )
-        ? "on"
-        : "off",
-      description: option.help,
-      kind: "cycle",
-      values: ["on", "off"],
-    }));
+    return (Object.keys(CAPABILITY_TOOL_NAMES) as ProviderToolId[]).map(
+      (toolId) => {
+        const compatibleProviders = getCompatibleProvidersForTool(toolId);
+        const mappedProviderId = getMappedProviderIdForCapability(
+          this.config,
+          toolId,
+        );
+        const currentValue = mappedProviderId
+          ? PROVIDER_MAP[mappedProviderId].label
+          : "off";
+        const compatibleLabels = compatibleProviders.map(
+          (providerId) => PROVIDER_MAP[providerId].label,
+        );
+        return {
+          id: `tool:${toolId}`,
+          label: PROVIDER_TOOL_META[toolId].label,
+          currentValue,
+          description:
+            `${PROVIDER_TOOL_META[toolId].help} Route web_${toolId} to one compatible provider or turn it off.` +
+            (compatibleLabels.length > 0
+              ? ` Compatible providers: ${compatibleLabels.join(", ")}.`
+              : ""),
+          kind: "cycle",
+          values: ["off", ...compatibleLabels],
+        };
+      },
+    );
   }
 
   private buildConfigSectionItems(): SettingsEntry[] {
@@ -1766,6 +1728,11 @@ class WebProvidersSettingsView implements Component {
     const entry = this.getSelectedEntry();
     if (!entry) return;
 
+    if (entry.kind === "action") {
+      await this.handleChange(entry.id, entry.currentValue);
+      return;
+    }
+
     if (entry.kind === "cycle" && entry.values && entry.values.length > 0) {
       const currentIndex = entry.values.indexOf(entry.currentValue);
       const nextValue = entry.values[(currentIndex + 1) % entry.values.length];
@@ -1805,23 +1772,30 @@ class WebProvidersSettingsView implements Component {
   }
 
   private async handleChange(id: string, value: string): Promise<void> {
-    if (id === "provider") {
-      const nextProvider = PROVIDERS.find(
-        (provider) => provider.label === value,
-      )?.id;
-      if (!nextProvider || nextProvider === this.activeProvider) {
+    if (id.startsWith("provider:")) {
+      const nextProvider = id.slice("provider:".length) as ProviderId;
+      if (nextProvider === this.activeProvider) {
         return;
       }
       this.activeProvider = nextProvider;
-      await this.persist((config) => {
-        setActiveProvider(config, nextProvider);
-      });
-      this.selection.tools = 0;
       this.selection.config = 0;
+      this.tui.requestRender();
       return;
     }
 
     await this.persist((config) => {
+      if (id.startsWith("tool:")) {
+        const toolId = id.slice("tool:".length) as ProviderToolId;
+        config.tools ??= {};
+        config.tools[toolId] =
+          value === "off"
+            ? null
+            : getCompatibleProvidersForTool(toolId).find(
+                (providerId) => PROVIDER_MAP[providerId].label === value,
+              ) ?? null;
+        return;
+      }
+
       config.providers ??= {};
       const providerConfig = getEditableProviderConfig(
         this.activeProvider,
@@ -1829,18 +1803,6 @@ class WebProvidersSettingsView implements Component {
           | ProviderConfigUnion
           | undefined,
       );
-
-      if (id.startsWith("tool:")) {
-        const toolId = id.slice("tool:".length) as ProviderToolId;
-        const tools = (providerConfig.tools ?? {}) as Partial<
-          Record<ProviderToolId, boolean>
-        >;
-        tools[toolId] = value === "on";
-        providerConfig.tools = tools as typeof providerConfig.tools;
-        config.providers[this.activeProvider] = providerConfig as never;
-        return;
-      }
-
       const setting = getProviderSettings(this.activeProvider).find(
         (candidate) => candidate.id === id,
       );
@@ -1938,42 +1900,17 @@ function getEditableProviderConfig(
   ) as ProviderConfigUnion;
 }
 
-function setActiveProvider(
+function getInitialProviderSelection(
   config: WebProvidersConfig,
-  providerId: ProviderId,
-): void {
-  const currentProviders = config.providers ?? {};
-  const candidateIds = new Set<ProviderId>([providerId]);
-
-  for (const id of Object.keys(currentProviders) as ProviderId[]) {
-    candidateIds.add(id);
+): ProviderId {
+  for (const capability of Object.keys(CAPABILITY_TOOL_NAMES) as ProviderCapability[]) {
+    const providerId = getMappedProviderIdForCapability(config, capability);
+    if (providerId) {
+      return providerId;
+    }
   }
 
-  config.providers ??= {};
-  for (const id of candidateIds) {
-    const providerConfig = getEditableProviderConfig(
-      id,
-      config.providers?.[id] as ProviderConfigUnion | undefined,
-    ) as Record<string, JsonObject | string | boolean | undefined>;
-    providerConfig.enabled = id === providerId;
-    config.providers[id] = providerConfig as never;
-  }
-}
-
-function getResolvedProviderChoice(
-  effective: WebProvidersConfig,
-  cwd: string,
-): ProviderId | undefined {
-  try {
-    return resolveProviderChoice(effective, undefined, cwd).id;
-  } catch {
-    return undefined;
-  }
-}
-
-async function getPreferredProvider(cwd: string): Promise<ProviderId> {
-  const current = await loadConfig();
-  return getResolvedProviderChoice(current, cwd) ?? "codex";
+  return "codex";
 }
 
 function didContentsCacheInputsChange(
@@ -2138,7 +2075,6 @@ function extractTextContent(
 function renderCallHeader(
   params: {
     queries?: string[];
-    provider?: ProviderId;
     maxResults?: number;
   },
   theme: Theme,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1553,9 +1553,7 @@ class WebProvidersSettingsView implements Component {
           mappedProviderId &&
           enabledCompatibleProviders.includes(mappedProviderId)
             ? PROVIDER_MAP[mappedProviderId].label
-            : mappedProviderId
-              ? `${PROVIDER_MAP[mappedProviderId].label} (disabled)`
-              : "off";
+            : "off";
         const compatibleLabels = enabledCompatibleProviders.map(
           (providerId) => PROVIDER_MAP[providerId].label,
         );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1417,7 +1417,7 @@ function getProviderSettings(
 class WebProvidersSettingsView implements Component {
   private config: WebProvidersConfig;
   private activeProvider: ProviderId;
-  private activeSection: "provider" | "tools" | "config" = "provider";
+  private activeSection: "provider" | "tools" | "config" = "tools";
   private selection = {
     provider: 0,
     tools: 0,
@@ -1447,21 +1447,21 @@ class WebProvidersSettingsView implements Component {
     }
 
     const lines: string[] = [];
+    const toolItems = this.buildToolSectionItems();
+    lines.push(...this.renderSection(width, "Tools", "tools", toolItems));
+    lines.push("");
+
     const providerItems = this.buildProviderSectionItems();
     lines.push(
       ...this.renderSection(width, "Providers", "provider", providerItems),
     );
     lines.push("");
 
-    const toolItems = this.buildToolSectionItems();
-    lines.push(...this.renderSection(width, "Tools", "tools", toolItems));
-    lines.push("");
-
     const configItems = this.buildConfigSectionItems();
     lines.push(
       ...this.renderSection(
         width,
-        "Provider config & policy",
+        "General",
         "config",
         configItems,
       ),
@@ -1537,10 +1537,7 @@ class WebProvidersSettingsView implements Component {
       return {
         id: `provider:${provider.id}`,
         label: provider.label,
-        currentValue:
-          provider.id === this.activeProvider
-            ? `selected · ${status.summary}`
-            : status.summary,
+        currentValue: "",
         description:
           provider.id === this.activeProvider
             ? `Editing ${provider.label} settings below. Current status: ${status.summary}.`
@@ -1716,6 +1713,10 @@ class WebProvidersSettingsView implements Component {
       const label = selected
         ? this.theme.fg("accent", paddedLabel)
         : paddedLabel;
+      if (entry.currentValue.trim().length === 0) {
+        lines.push(truncateToWidth(`${prefix}${label}`, width));
+        continue;
+      }
       const value = selected
         ? this.theme.fg("accent", entry.currentValue)
         : this.theme.fg("muted", entry.currentValue);

--- a/src/index.ts
+++ b/src/index.ts
@@ -613,11 +613,7 @@ async function executeSearchTool({
 }) {
   await cleanupContentStore();
 
-  const provider = resolveProviderChoice(
-    config,
-    explicitProvider ?? ctx.cwd,
-    explicitProvider ? ctx.cwd : undefined,
-  );
+  const provider = resolveProviderChoice(config, ctx.cwd, explicitProvider);
   const providerConfig = getEffectiveProviderConfig(config, provider.id);
   if (!providerConfig) {
     throw new Error(`Provider '${provider.id}' is not configured.`);
@@ -789,9 +785,12 @@ async function executeAnswerTool({
   queries: string[];
   planOverrides?: ProviderOperationPlan<ProviderToolOutput>[];
 }) {
-  const provider = explicitProvider
-    ? resolveProviderForCapability(config, explicitProvider, ctx.cwd, "answer")
-    : resolveProviderForCapability(config, ctx.cwd, "answer");
+  const provider = resolveProviderForCapability(
+    config,
+    ctx.cwd,
+    "answer",
+    explicitProvider,
+  );
   const providerConfig = getEffectiveProviderConfig(config, provider.id);
   if (!providerConfig) {
     throw new Error(`Provider '${provider.id}' is not configured.`);
@@ -1036,14 +1035,12 @@ async function executeProviderTool({
 }) {
   await cleanupContentStore();
 
-  const provider = explicitProvider
-    ? resolveProviderForCapability(
-        config,
-        explicitProvider,
-        ctx.cwd,
-        capability,
-      )
-    : resolveProviderForCapability(config, ctx.cwd, capability);
+  const provider = resolveProviderForCapability(
+    config,
+    ctx.cwd,
+    capability,
+    explicitProvider,
+  );
   const providerConfig = getEffectiveProviderConfig(config, provider.id);
   if (!providerConfig) {
     throw new Error(`Provider '${provider.id}' is not configured.`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import {
   cleanupContentStore,
   formatPrefetchStatusText,
   getPrefetchStatus,
+  mergeSearchContentsPrefetchOptions,
   parseSearchContentsPrefetchOptions,
   resetContentStore,
   resolveContentsFromStore,
@@ -77,6 +78,8 @@ import type {
   ProviderOperationRequest,
   ProviderToolDetails,
   ProviderToolOutput,
+  SearchPrefetchSettings,
+  SearchToolSettings,
   SearchResponse,
   ValyuProviderConfig,
   WebProvidersConfig,
@@ -520,7 +523,7 @@ function describeOptionsField(
 
   if (capability === "search") {
     description +=
-      " Local orchestration options may include prefetch={ enabled, maxUrls, provider, ttlMs, contentsOptions }.";
+      " Local orchestration options may include prefetch={ provider, maxUrls, ttlMs, contentsOptions }. Prefetch runs only when prefetch.provider is set.";
   }
 
   return description;
@@ -619,7 +622,10 @@ async function executeSearchTool({
     throw new Error(`Provider '${provider.id}' is not configured.`);
   }
 
-  const prefetchOptions = parseSearchContentsPrefetchOptions(options);
+  const prefetchOptions = mergeSearchContentsPrefetchOptions(
+    getSearchPrefetchDefaults(config),
+    parseSearchContentsPrefetchOptions(options),
+  );
   const providerOptions = stripSearchContentsPrefetchOptions(options);
   const searchQueries = resolveSearchQueries(queries);
   if (
@@ -675,12 +681,11 @@ async function executeSearchTool({
   }
 
   const prefetch =
-    prefetchOptions?.enabled === true && planOverrides === undefined
+    prefetchOptions !== undefined && planOverrides === undefined
       ? await startContentsPrefetch({
           config,
           cwd: ctx.cwd,
           urls: collectSearchResultUrls(outcomes),
-          searchProviderId: provider.id,
           options: prefetchOptions,
         })
       : undefined;
@@ -1414,6 +1419,29 @@ function getProviderSettings(
     .settings as readonly ProviderSettingDescriptor<ProviderConfigUnion>[];
 }
 
+function getEnabledCompatibleProvidersForTool(
+  config: WebProvidersConfig,
+  toolId: ProviderToolId,
+): ProviderId[] {
+  return getCompatibleProvidersForTool(toolId).filter(
+    (providerId) =>
+      (config.providers?.[providerId] as ProviderConfigUnion | undefined)
+        ?.enabled === true,
+  );
+}
+
+function getSearchToolSettings(
+  config: WebProvidersConfig,
+): SearchToolSettings | undefined {
+  return config.toolSettings?.search;
+}
+
+function getSearchPrefetchDefaults(
+  config: WebProvidersConfig,
+): SearchPrefetchSettings | undefined {
+  return getSearchToolSettings(config)?.prefetch;
+}
+
 class WebProvidersSettingsView implements Component {
   private config: WebProvidersConfig;
   private activeProvider: ProviderId;
@@ -1539,11 +1567,9 @@ class WebProvidersSettingsView implements Component {
   private buildToolSectionItems(): SettingsEntry[] {
     return (Object.keys(CAPABILITY_TOOL_NAMES) as ProviderToolId[]).map(
       (toolId) => {
-        const compatibleProviders = getCompatibleProvidersForTool(toolId);
-        const enabledCompatibleProviders = compatibleProviders.filter(
-          (providerId) =>
-            (this.config.providers?.[providerId] as ProviderConfigUnion | undefined)
-              ?.enabled === true,
+        const enabledCompatibleProviders = getEnabledCompatibleProvidersForTool(
+          this.config,
+          toolId,
         );
         const mappedProviderId = getMappedProviderIdForCapability(
           this.config,
@@ -1562,12 +1588,11 @@ class WebProvidersSettingsView implements Component {
           label: PROVIDER_TOOL_META[toolId].label,
           currentValue,
           description:
-            `${PROVIDER_TOOL_META[toolId].help} Route web_${toolId} to one compatible provider or turn it off.` +
+            `Press Enter to configure web_${toolId}. ${PROVIDER_TOOL_META[toolId].help} Route web_${toolId} to one compatible provider or turn it off.` +
             (compatibleLabels.length > 0
               ? ` Enabled compatible providers: ${compatibleLabels.join(", ")}.`
               : ""),
-          kind: "cycle",
-          values: ["off", ...compatibleLabels],
+          kind: "action",
         };
       },
     );
@@ -1724,6 +1749,24 @@ class WebProvidersSettingsView implements Component {
     const entry = this.getSelectedEntry();
     if (!entry) return;
 
+    if (entry.kind === "action" && entry.id.startsWith("tool:")) {
+      const toolId = entry.id.slice("tool:".length) as ProviderToolId;
+      this.submenu = new ToolSettingsSubmenu(
+        this.tui,
+        this.theme,
+        toolId,
+        () => this.config,
+        async (mutate) => {
+          await this.persist(mutate);
+        },
+        () => {
+          this.submenu = undefined;
+          this.tui.requestRender();
+        },
+      );
+      return;
+    }
+
     if (entry.kind === "action" && entry.id.startsWith("provider:")) {
       const providerId = entry.id.slice("provider:".length) as ProviderId;
       this.activeProvider = providerId;
@@ -1752,83 +1795,6 @@ class WebProvidersSettingsView implements Component {
       );
       return;
     }
-
-    if (entry.kind === "cycle" && entry.values && entry.values.length > 0) {
-      const currentIndex = entry.values.indexOf(entry.currentValue);
-      const nextValue = entry.values[(currentIndex + 1) % entry.values.length];
-      await this.handleChange(entry.id, nextValue);
-      return;
-    }
-
-    if (entry.kind === "text") {
-      const currentValue = this.getEntryRawValue(entry.id) ?? "";
-      this.submenu = new TextValueSubmenu(
-        this.tui,
-        this.theme,
-        entry.label,
-        currentValue,
-        entry.description,
-        (selectedValue) => {
-          this.submenu = undefined;
-          if (selectedValue !== undefined) {
-            void this.handleChange(entry.id, selectedValue);
-          }
-          this.tui.requestRender();
-        },
-      );
-      return;
-    }
-  }
-
-  private getEntryRawValue(id: string): string | undefined {
-    const providerConfig = this.currentProviderConfig();
-    const setting = getProviderSettings(this.activeProvider).find(
-      (candidate) => candidate.id === id,
-    );
-    if (!setting || setting.kind !== "text") {
-      return undefined;
-    }
-    return setting.getValue(providerConfig);
-  }
-
-  private async handleChange(id: string, value: string): Promise<void> {
-    await this.persist((config) => {
-      config.providers ??= {};
-
-      if (id.startsWith("tool:")) {
-        const toolId = id.slice("tool:".length) as ProviderToolId;
-        config.tools ??= {};
-        config.tools[toolId] =
-          value === "off"
-            ? null
-            : getCompatibleProvidersForTool(toolId)
-                .filter(
-                  (providerId) =>
-                    (config.providers?.[providerId] as
-                      | ProviderConfigUnion
-                      | undefined)?.enabled === true,
-                )
-                .find(
-                (providerId) => PROVIDER_MAP[providerId].label === value,
-              ) ?? null;
-        return;
-      }
-
-      const providerConfig = getEditableProviderConfig(
-        this.activeProvider,
-        config.providers?.[this.activeProvider] as
-          | ProviderConfigUnion
-          | undefined,
-      );
-      const setting = getProviderSettings(this.activeProvider).find(
-        (candidate) => candidate.id === id,
-      );
-      if (!setting) {
-        throw new Error(`Unknown setting '${id}'.`);
-      }
-      setting.setValue(providerConfig, value);
-      config.providers[this.activeProvider] = providerConfig as never;
-    });
   }
 
   private currentProviderConfigFor(
@@ -1852,6 +1818,275 @@ class WebProvidersSettingsView implements Component {
     } catch (error) {
       this.ctx.ui.notify((error as Error).message, "error");
     }
+  }
+}
+
+class ToolSettingsSubmenu implements Component {
+  private selection = 0;
+  private submenu: Component | undefined;
+
+  constructor(
+    private readonly tui: TUI,
+    private readonly theme: Theme,
+    private readonly toolId: ProviderToolId,
+    private readonly getConfig: () => WebProvidersConfig,
+    private readonly persist: (
+      mutate: (config: WebProvidersConfig) => void,
+    ) => Promise<void>,
+    private readonly done: () => void,
+  ) {}
+
+  render(width: number): string[] {
+    if (this.submenu) {
+      return this.submenu.render(width);
+    }
+
+    const entries = this.getEntries();
+    const lines = [
+      truncateToWidth(
+        this.theme.fg("accent", PROVIDER_TOOL_META[this.toolId].label),
+        width,
+      ),
+      "",
+      ...this.renderEntries(width, entries),
+    ];
+
+    const selected = entries[this.selection];
+    if (selected) {
+      lines.push("");
+      for (const line of wrapTextWithAnsi(
+        selected.description,
+        Math.max(10, width - 2),
+      )) {
+        lines.push(truncateToWidth(this.theme.fg("dim", line), width));
+      }
+    }
+
+    lines.push("");
+    lines.push(
+      truncateToWidth(
+        this.theme.fg("dim", "↑↓ move · Enter edit/toggle · Esc back"),
+        width,
+      ),
+    );
+    return lines;
+  }
+
+  invalidate(): void {
+    this.submenu?.invalidate();
+  }
+
+  handleInput(data: string): void {
+    if (this.submenu) {
+      this.submenu.handleInput?.(data);
+      this.tui.requestRender();
+      return;
+    }
+
+    const kb = getEditorKeybindings();
+    const entries = this.getEntries();
+
+    if (kb.matches(data, "selectUp")) {
+      if (this.selection > 0) {
+        this.selection -= 1;
+      }
+    } else if (kb.matches(data, "selectDown")) {
+      if (this.selection < entries.length - 1) {
+        this.selection += 1;
+      }
+    } else if (kb.matches(data, "selectConfirm") || data === " ") {
+      void this.activateCurrentEntry();
+    } else if (kb.matches(data, "selectCancel")) {
+      this.done();
+      return;
+    }
+
+    this.tui.requestRender();
+  }
+
+  private getEntries(): SettingsEntry[] {
+    const config = this.getConfig();
+    const mappedProviderId = getMappedProviderIdForCapability(config, this.toolId);
+    const enabledProviderIds = getEnabledCompatibleProvidersForTool(
+      config,
+      this.toolId,
+    );
+    const providerValues = [
+      "off",
+      ...enabledProviderIds.map((providerId) => PROVIDER_MAP[providerId].label),
+    ];
+    const currentProviderValue =
+      mappedProviderId && enabledProviderIds.includes(mappedProviderId)
+        ? PROVIDER_MAP[mappedProviderId].label
+        : "off";
+
+    const entries: SettingsEntry[] = [
+      {
+        id: "provider",
+        label: "Provider",
+        currentValue: currentProviderValue,
+        description: `Route web_${this.toolId} to one compatible enabled provider or turn it off.`,
+        kind: "cycle",
+        values: providerValues,
+      },
+    ];
+
+    if (this.toolId === "search") {
+      const prefetch = getSearchPrefetchDefaults(config);
+      const prefetchProviderIds = getEnabledCompatibleProvidersForTool(
+        config,
+        "contents",
+      );
+      const prefetchValues = [
+        "off",
+        ...prefetchProviderIds.map((providerId) => PROVIDER_MAP[providerId].label),
+      ];
+      const currentPrefetchProviderValue =
+        prefetch?.provider &&
+        prefetchProviderIds.includes(prefetch.provider)
+          ? PROVIDER_MAP[prefetch.provider].label
+          : "off";
+
+      entries.push(
+        {
+          id: "prefetchProvider",
+          label: "Prefetch",
+          currentValue: currentPrefetchProviderValue,
+          description:
+            "Optionally start background web_contents extraction after search using a contents-capable provider. Off means no prefetch.",
+          kind: "cycle",
+          values: prefetchValues,
+        },
+        {
+          id: "prefetchMaxUrls",
+          label: "Prefetch URLs",
+          currentValue:
+            prefetch?.maxUrls !== undefined ? String(prefetch.maxUrls) : "default",
+          description:
+            "Maximum number of search result URLs to prefetch. Leave blank to use the built-in default.",
+          kind: "text",
+        },
+        {
+          id: "prefetchTtlMs",
+          label: "Prefetch TTL",
+          currentValue:
+            prefetch?.ttlMs !== undefined ? String(prefetch.ttlMs) : "default",
+          description:
+            "How long prefetched contents stay reusable in the local cache, in milliseconds. Leave blank to use the built-in default.",
+          kind: "text",
+        },
+      );
+    }
+
+    return entries;
+  }
+
+  private renderEntries(width: number, entries: SettingsEntry[]): string[] {
+    const labelWidth = Math.min(
+      24,
+      Math.max(...entries.map((entry) => entry.label.length), 0),
+    );
+    return entries.map((entry, index) => {
+      const selected = this.selection === index;
+      const prefix = selected ? this.theme.fg("accent", "→ ") : "  ";
+      const paddedLabel = entry.label.padEnd(labelWidth, " ");
+      const label = selected
+        ? this.theme.fg("accent", paddedLabel)
+        : paddedLabel;
+      const value = selected
+        ? this.theme.fg("accent", entry.currentValue)
+        : this.theme.fg("muted", entry.currentValue);
+      return truncateToWidth(`${prefix}${label}  ${value}`, width);
+    });
+  }
+
+  private async activateCurrentEntry(): Promise<void> {
+    const entry = this.getEntries()[this.selection];
+    if (!entry) {
+      return;
+    }
+
+    if (entry.kind === "cycle" && entry.values && entry.values.length > 0) {
+      const currentIndex = entry.values.indexOf(entry.currentValue);
+      const nextValue = entry.values[(currentIndex + 1) % entry.values.length];
+      await this.handleChange(entry.id, nextValue);
+      return;
+    }
+
+    if (entry.kind === "text") {
+      const currentValue = this.getEntryRawValue(entry.id);
+      this.submenu = new TextValueSubmenu(
+        this.tui,
+        this.theme,
+        entry.label,
+        currentValue,
+        entry.description,
+        (selectedValue) => {
+          this.submenu = undefined;
+          if (selectedValue !== undefined) {
+            void this.handleChange(entry.id, selectedValue);
+          }
+          this.tui.requestRender();
+        },
+      );
+    }
+  }
+
+  private getEntryRawValue(id: string): string {
+    const prefetch = getSearchPrefetchDefaults(this.getConfig());
+    switch (id) {
+      case "prefetchMaxUrls":
+        return prefetch?.maxUrls !== undefined ? String(prefetch.maxUrls) : "";
+      case "prefetchTtlMs":
+        return prefetch?.ttlMs !== undefined ? String(prefetch.ttlMs) : "";
+      default:
+        return "";
+    }
+  }
+
+  private async handleChange(id: string, value: string): Promise<void> {
+    await this.persist((config) => {
+      switch (id) {
+        case "provider":
+          config.tools ??= {};
+          config.tools[this.toolId] =
+            value === "off"
+              ? null
+              : getEnabledCompatibleProvidersForTool(config, this.toolId).find(
+                    (providerId) => PROVIDER_MAP[providerId].label === value,
+                  ) ?? null;
+          return;
+        case "prefetchProvider": {
+          const providerId =
+            value === "off"
+              ? null
+              : getEnabledCompatibleProvidersForTool(config, "contents").find(
+                    (candidate) => PROVIDER_MAP[candidate].label === value,
+                  ) ?? null;
+          ensureSearchToolSettings(config).prefetch ??= {};
+          ensureSearchToolSettings(config).prefetch!.provider = providerId;
+          return;
+        }
+        case "prefetchMaxUrls":
+          ensureSearchToolSettings(config).prefetch ??= {};
+          ensureSearchToolSettings(config).prefetch!.maxUrls =
+            parseOptionalPositiveIntegerInput(
+              value,
+              "Prefetch URLs must be a positive integer.",
+            );
+          return;
+        case "prefetchTtlMs":
+          ensureSearchToolSettings(config).prefetch ??= {};
+          ensureSearchToolSettings(config).prefetch!.ttlMs =
+            parseOptionalPositiveIntegerInput(
+              value,
+              "Prefetch TTL must be a positive integer.",
+            );
+          return;
+        default:
+          throw new Error(`Unknown tool setting '${id}'.`);
+      }
+    });
   }
 }
 
@@ -2060,6 +2295,32 @@ class ProviderSettingsSubmenu implements Component {
       setting.setValue(providerConfig, value);
     });
   }
+}
+
+function ensureSearchToolSettings(
+  config: WebProvidersConfig,
+): SearchToolSettings {
+  config.toolSettings ??= {};
+  config.toolSettings.search ??= {};
+  return config.toolSettings.search;
+}
+
+function parseOptionalPositiveIntegerInput(
+  value: string,
+  errorMessage: string,
+): number | undefined {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(errorMessage);
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(errorMessage);
+  }
+  return parsed;
 }
 
 class TextValueSubmenu implements Component {

--- a/src/prefetch-manager.ts
+++ b/src/prefetch-manager.ts
@@ -1149,35 +1149,32 @@ function resolveContentsProvider(
   searchProviderId: ProviderId | undefined,
 ) {
   if (explicitProvider) {
-    try {
-      return resolveProviderForCapability(
-        config,
-        explicitProvider,
-        cwd,
-        "contents",
-      );
-    } catch {
-      // Explicit prefetch provider is unavailable — fall through so prefetch
-      // is silently skipped rather than sinking a successful search.
-      return undefined;
+    const provider = PROVIDER_MAP[explicitProvider];
+    if (provider.capabilities.includes("contents")) {
+      const providerConfig = getEffectiveProviderConfig(config, explicitProvider);
+      const status = provider.getStatus(providerConfig as never, cwd);
+      if (status.available) {
+        return provider;
+      }
     }
+    // Explicit prefetch provider is unavailable — fall through so prefetch
+    // is silently skipped rather than sinking a successful search.
+    return undefined;
   }
 
   if (searchProviderId) {
-    try {
-      return resolveProviderForCapability(
-        config,
-        searchProviderId,
-        cwd,
-        "contents",
-      );
-    } catch {
-      // Fall back to the configured contents provider below.
+    const provider = PROVIDER_MAP[searchProviderId];
+    if (provider.capabilities.includes("contents")) {
+      const providerConfig = getEffectiveProviderConfig(config, searchProviderId);
+      const status = provider.getStatus(providerConfig as never, cwd);
+      if (status.available) {
+        return provider;
+      }
     }
   }
 
   try {
-    return resolveProviderForCapability(config, undefined, cwd, "contents");
+    return resolveProviderForCapability(config, cwd, "contents");
   } catch {
     return undefined;
   }

--- a/src/prefetch-manager.ts
+++ b/src/prefetch-manager.ts
@@ -6,10 +6,7 @@ import {
   MemoryContentStore,
 } from "./content-store.js";
 import { stripLocalExecutionOptions } from "./execution-policy.js";
-import {
-  getEffectiveProviderConfig,
-  resolveProviderForCapability,
-} from "./provider-resolution.js";
+import { getEffectiveProviderConfig } from "./provider-resolution.js";
 import { executeOperationPlan } from "./provider-runtime.js";
 import { PROVIDER_MAP } from "./providers/index.js";
 import type {
@@ -18,6 +15,7 @@ import type {
   ProviderContentsMetadataEntry,
   ProviderId,
   ProviderToolOutput,
+  SearchPrefetchSettings,
   WebProvidersConfig,
 } from "./types.js";
 
@@ -30,9 +28,8 @@ const DEFAULT_PREFETCH_MAX_URLS = 3;
 const MAX_PREFETCH_URLS = 5;
 
 export interface SearchContentsPrefetchOptions {
-  enabled?: boolean;
+  provider?: ProviderId | null;
   maxUrls?: number;
-  provider?: ProviderId;
   ttlMs?: number;
   contentsOptions?: JsonObject;
 }
@@ -162,14 +159,12 @@ export async function startContentsPrefetch({
   config,
   cwd,
   urls,
-  searchProviderId,
   options,
   onProgress,
 }: {
   config: WebProvidersConfig;
   cwd: string;
   urls: string[];
-  searchProviderId?: ProviderId;
   options: SearchContentsPrefetchOptions;
   onProgress?: (message: string) => void;
 }): Promise<PrefetchStartResult | undefined> {
@@ -178,12 +173,7 @@ export async function startContentsPrefetch({
     return undefined;
   }
 
-  const provider = resolveContentsProvider(
-    config,
-    cwd,
-    options.provider,
-    searchProviderId,
-  );
+  const provider = resolveContentsProvider(config, cwd, options.provider);
   if (!provider) {
     return undefined;
   }
@@ -612,10 +602,6 @@ export function parseSearchContentsPrefetchOptions(
     throw new Error("prefetch must be an object.");
   }
 
-  const enabled =
-    raw.enabled === undefined
-      ? true
-      : parseOptionalBoolean(raw.enabled, "enabled");
   const maxUrls = parseOptionalPositiveInteger(raw.maxUrls, "maxUrls");
   const provider = parseOptionalProviderId(raw.provider);
   const ttlMs = parseOptionalPositiveInteger(raw.ttlMs, "ttlMs");
@@ -625,11 +611,33 @@ export function parseSearchContentsPrefetchOptions(
       : assertJsonObject(raw.contentsOptions, "prefetch.contentsOptions");
 
   return {
-    enabled,
     maxUrls,
     provider,
     ttlMs,
     contentsOptions,
+  };
+}
+
+export function mergeSearchContentsPrefetchOptions(
+  defaults: SearchPrefetchSettings | undefined,
+  overrides: SearchContentsPrefetchOptions | undefined,
+): SearchContentsPrefetchOptions | undefined {
+  if (!defaults && !overrides) {
+    return undefined;
+  }
+
+  return {
+    provider:
+      overrides?.provider !== undefined
+        ? overrides.provider
+        : defaults?.provider,
+    maxUrls:
+      overrides?.maxUrls !== undefined ? overrides.maxUrls : defaults?.maxUrls,
+    ttlMs: overrides?.ttlMs !== undefined ? overrides.ttlMs : defaults?.ttlMs,
+    contentsOptions:
+      overrides?.contentsOptions !== undefined
+        ? overrides.contentsOptions
+        : undefined,
   };
 }
 
@@ -1145,39 +1153,25 @@ function buildPrefetchJobStoreKey(prefetchId: string): string {
 function resolveContentsProvider(
   config: WebProvidersConfig,
   cwd: string,
-  explicitProvider: ProviderId | undefined,
-  searchProviderId: ProviderId | undefined,
+  explicitProvider: ProviderId | null | undefined,
 ) {
-  if (explicitProvider) {
-    const provider = PROVIDER_MAP[explicitProvider];
-    if (provider.capabilities.includes("contents")) {
-      const providerConfig = getEffectiveProviderConfig(config, explicitProvider);
-      const status = provider.getStatus(providerConfig as never, cwd);
-      if (status.available) {
-        return provider;
-      }
-    }
-    // Explicit prefetch provider is unavailable — fall through so prefetch
-    // is silently skipped rather than sinking a successful search.
+  if (!explicitProvider) {
     return undefined;
   }
 
-  if (searchProviderId) {
-    const provider = PROVIDER_MAP[searchProviderId];
-    if (provider.capabilities.includes("contents")) {
-      const providerConfig = getEffectiveProviderConfig(config, searchProviderId);
-      const status = provider.getStatus(providerConfig as never, cwd);
-      if (status.available) {
-        return provider;
-      }
-    }
-  }
-
-  try {
-    return resolveProviderForCapability(config, cwd, "contents");
-  } catch {
+  const provider = PROVIDER_MAP[explicitProvider];
+  if (!provider.capabilities.includes("contents")) {
     return undefined;
   }
+
+  const providerConfig = getEffectiveProviderConfig(config, explicitProvider);
+  const status = provider.getStatus(providerConfig as never, cwd);
+  if (status.available) {
+    return provider;
+  }
+  // Explicit prefetch provider is unavailable, so skip prefetch instead of
+  // turning a successful search into a tool failure.
+  return undefined;
 }
 
 function canonicalizeUrl(url: string): string {
@@ -1360,13 +1354,6 @@ function assertJsonObject(value: unknown, field: string): JsonObject {
   return value;
 }
 
-function parseOptionalBoolean(value: unknown, field: string): boolean {
-  if (typeof value !== "boolean") {
-    throw new Error(`prefetch.${field} must be a boolean.`);
-  }
-  return value;
-}
-
 function parseOptionalPositiveInteger(
   value: unknown,
   field: string,
@@ -1380,14 +1367,19 @@ function parseOptionalPositiveInteger(
   return Number(value);
 }
 
-function parseOptionalProviderId(value: unknown): ProviderId | undefined {
+function parseOptionalProviderId(
+  value: unknown,
+): ProviderId | null | undefined {
   if (value === undefined) {
     return undefined;
+  }
+  if (value === null) {
+    return null;
   }
   if (isProviderId(value)) {
     return value;
   }
-  throw new Error("prefetch.provider must be a valid provider id.");
+  throw new Error("prefetch.provider must be a valid provider id or null.");
 }
 
 function isProviderId(value: unknown): value is ProviderId {

--- a/src/provider-config-manifests.ts
+++ b/src/provider-config-manifests.ts
@@ -315,20 +315,6 @@ export const PROVIDER_CONFIG_MANIFESTS = {
         },
       }),
       stringSetting<GeminiProviderConfig>({
-        id: "geminiContentsModel",
-        label: "Contents model",
-        help: "Model used for Gemini URL content extraction via URL Context.",
-        getValue: (config) => getGeminiNative(config)?.contentsModel,
-        setValue: (config, value) => {
-          assignOptionalString(
-            ensureGeminiNative(config),
-            "contentsModel",
-            value,
-          );
-          cleanupEmpty(config, "native");
-        },
-      }),
-      stringSetting<GeminiProviderConfig>({
         id: "geminiAnswerModel",
         label: "Answer model",
         help: "Model used for grounded Gemini answers.",

--- a/src/provider-config-manifests.ts
+++ b/src/provider-config-manifests.ts
@@ -105,7 +105,6 @@ export const PROVIDER_CONFIG_MANIFESTS = {
           );
         },
       }),
-      ...requestPolicySettings<ClaudeProviderConfig>(),
     ],
   },
   codex: {
@@ -215,7 +214,6 @@ export const PROVIDER_CONFIG_MANIFESTS = {
           cleanupEmpty(config, "native");
         },
       }),
-      ...requestPolicySettings<CodexProviderConfig>(),
     ],
   },
   exa: {
@@ -277,7 +275,6 @@ export const PROVIDER_CONFIG_MANIFESTS = {
           cleanupEmpty(config, "native");
         },
       }),
-      ...requestPolicySettings<ExaProviderConfig>(),
       ...lifecyclePolicySettings<ExaProviderConfig>(),
     ],
   },
@@ -342,7 +339,6 @@ export const PROVIDER_CONFIG_MANIFESTS = {
           cleanupEmpty(config, "native");
         },
       }),
-      ...requestPolicySettings<GeminiProviderConfig>(),
       ...lifecyclePolicySettings<GeminiProviderConfig>(),
     ],
   },
@@ -350,7 +346,6 @@ export const PROVIDER_CONFIG_MANIFESTS = {
     settings: [
       apiKeySetting<PerplexityProviderConfig>(),
       baseUrlSetting<PerplexityProviderConfig>(),
-      ...requestPolicySettings<PerplexityProviderConfig>(),
     ],
   },
   parallel: {
@@ -415,7 +410,6 @@ export const PROVIDER_CONFIG_MANIFESTS = {
           cleanupNestedObjects(config);
         },
       }),
-      ...requestPolicySettings<ParallelProviderConfig>(),
     ],
   },
   valyu: {
@@ -456,7 +450,6 @@ export const PROVIDER_CONFIG_MANIFESTS = {
           cleanupEmpty(config, "native");
         },
       }),
-      ...requestPolicySettings<ValyuProviderConfig>(),
       ...lifecyclePolicySettings<ValyuProviderConfig>(),
     ],
   },
@@ -523,65 +516,6 @@ function baseUrlSetting<TConfig extends { baseUrl?: string }>() {
   });
 }
 
-function requestPolicySettings<
-  TConfig extends { policy?: ExecutionPolicyDefaults },
->() {
-  return [
-    integerSetting<TConfig>({
-      id: "requestTimeoutMs",
-      label: "Request timeout (ms)",
-      help: "Maximum time to wait for a single provider request before failing that attempt.",
-      minimum: 1,
-      errorMessage: "Request timeout must be a positive integer.",
-      getValue: (config) => getIntegerString(config?.policy?.requestTimeoutMs),
-      setValue: (config, value) => {
-        assignOptionalInteger(
-          ensurePolicy(config),
-          "requestTimeoutMs",
-          value,
-          "Request timeout must be a positive integer.",
-        );
-        cleanupEmpty(config, "policy");
-      },
-    }),
-    integerSetting<TConfig>({
-      id: "retryCount",
-      label: "Retry count",
-      help: "How many times transient provider failures should be retried.",
-      minimum: 0,
-      errorMessage: "Retry count must be a non-negative integer.",
-      getValue: (config) => getIntegerString(config?.policy?.retryCount),
-      setValue: (config, value) => {
-        assignOptionalInteger(
-          ensurePolicy(config),
-          "retryCount",
-          value,
-          "Retry count must be a non-negative integer.",
-          { allowZero: true },
-        );
-        cleanupEmpty(config, "policy");
-      },
-    }),
-    integerSetting<TConfig>({
-      id: "retryDelayMs",
-      label: "Retry delay (ms)",
-      help: "Initial delay before retrying failed requests. Later retries back off automatically.",
-      minimum: 1,
-      errorMessage: "Retry delay must be a positive integer.",
-      getValue: (config) => getIntegerString(config?.policy?.retryDelayMs),
-      setValue: (config, value) => {
-        assignOptionalInteger(
-          ensurePolicy(config),
-          "retryDelayMs",
-          value,
-          "Retry delay must be a positive integer.",
-        );
-        cleanupEmpty(config, "policy");
-      },
-    }),
-  ] as const;
-}
-
 function lifecyclePolicySettings<
   TConfig extends { policy?: ExecutionPolicyDefaults },
 >() {
@@ -589,7 +523,7 @@ function lifecyclePolicySettings<
     integerSetting<TConfig>({
       id: "researchPollIntervalMs",
       label: "Research poll interval (ms)",
-      help: "How often to poll long-running research jobs for updates.",
+      help: "How often to poll long-running research jobs for updates for this provider. Leave empty to inherit the generic setting.",
       minimum: 1,
       errorMessage: "Research poll interval must be a positive integer.",
       getValue: (config) =>
@@ -607,7 +541,7 @@ function lifecyclePolicySettings<
     integerSetting<TConfig>({
       id: "researchTimeoutMs",
       label: "Research timeout (ms)",
-      help: "Maximum total time to wait for research before returning a resumable timeout error.",
+      help: "Maximum total time to wait for research before returning a resumable timeout error for this provider. Leave empty to inherit the generic setting.",
       minimum: 1,
       errorMessage: "Research timeout must be a positive integer.",
       getValue: (config) => getIntegerString(config?.policy?.researchTimeoutMs),
@@ -624,7 +558,7 @@ function lifecyclePolicySettings<
     integerSetting<TConfig>({
       id: "researchMaxConsecutivePollErrors",
       label: "Max poll errors",
-      help: "How many consecutive poll failures to tolerate before stopping the local research run.",
+      help: "How many consecutive poll failures to tolerate before stopping the local research run for this provider. Leave empty to inherit the generic setting.",
       minimum: 1,
       errorMessage: "Max poll errors must be a positive integer.",
       getValue: (config) =>

--- a/src/provider-resolution.ts
+++ b/src/provider-resolution.ts
@@ -1,104 +1,91 @@
-import {
-  isProviderToolEnabled,
-  type ProviderConfigUnion,
-  type ProviderToolId,
-} from "./provider-tools.js";
-import { PROVIDER_MAP, PROVIDERS } from "./providers/index.js";
-import type { ProviderId, WebProvider, WebProvidersConfig } from "./types.js";
-
-const IMPLICIT_PROVIDER_FALLBACKS: readonly ProviderId[] = ["codex"] as const;
+import { getMappedProviderForCapability, type ProviderConfigUnion } from "./provider-tools.js";
+import { PROVIDER_MAP } from "./providers/index.js";
+import type {
+  ProviderCapability,
+  ProviderId,
+  WebProvider,
+  WebProvidersConfig,
+} from "./types.js";
 
 export function supportsProviderCapability(
   provider: WebProvider<unknown>,
-  capability: ProviderToolId,
+  capability: ProviderCapability,
 ): boolean {
   return provider.capabilities.includes(capability);
 }
 
 export function resolveProviderChoice(
   config: WebProvidersConfig,
-  explicit: ProviderId | undefined,
-  cwd: string,
+  explicitOrCwd: ProviderId | string,
+  cwd?: string,
 ) {
-  return resolveProviderForCapability(config, explicit, cwd, "search");
+  if (cwd === undefined) {
+    return resolveProviderForCapability(config, explicitOrCwd, "search");
+  }
+  return resolveProviderForCapability(
+    config,
+    explicitOrCwd as ProviderId | undefined,
+    cwd,
+    "search",
+  );
 }
 
 export function getEffectiveProviderConfig(
   config: WebProvidersConfig,
   providerId: ProviderId,
 ): ProviderConfigUnion | undefined {
-  const configured = config.providers?.[providerId] as
-    | ProviderConfigUnion
-    | undefined;
-  if (configured) {
-    return configured;
-  }
-  if (IMPLICIT_PROVIDER_FALLBACKS.includes(providerId)) {
-    return {
-      ...PROVIDER_MAP[providerId].createTemplate(),
-      enabled: true,
-    } as ProviderConfigUnion;
-  }
-  return undefined;
+  return config.providers?.[providerId] as ProviderConfigUnion | undefined;
+}
+
+export function getMappedProviderIdForCapability(
+  config: WebProvidersConfig,
+  capability: ProviderCapability,
+): ProviderId | undefined {
+  const providerId = getMappedProviderForCapability(config, capability);
+  return providerId === null ? undefined : providerId;
 }
 
 export function resolveProviderForCapability(
   config: WebProvidersConfig,
-  explicit: ProviderId | undefined,
-  cwd: string,
-  capability: ProviderToolId,
+  explicitOrCwd: ProviderId | string | undefined,
+  cwdOrCapability: string | ProviderCapability,
+  maybeCapability?: ProviderCapability,
 ) {
-  if (explicit) {
-    const provider = PROVIDER_MAP[explicit];
-    const providerConfig = getEffectiveProviderConfig(config, explicit);
-    if (!supportsProviderCapability(provider, capability)) {
-      throw new Error(
-        `Provider '${explicit}' does not support '${capability}'.`,
-      );
-    }
-    if (!isProviderToolEnabled(explicit, providerConfig, capability)) {
-      throw new Error(
-        `Provider '${explicit}' has '${capability}' disabled in config.`,
-      );
-    }
-    const status = provider.getStatus(providerConfig as never, cwd);
-    if (!status.available) {
-      throw new Error(
-        `Provider '${explicit}' is not available: ${status.summary}.`,
-      );
-    }
-    return provider;
+  const explicitProvider =
+    maybeCapability === undefined
+      ? undefined
+      : (explicitOrCwd as ProviderId | undefined);
+  const cwd =
+    maybeCapability === undefined
+      ? (explicitOrCwd as string)
+      : (cwdOrCapability as string);
+  const capability =
+    maybeCapability === undefined
+      ? (cwdOrCapability as ProviderCapability)
+      : maybeCapability;
+
+  const providerId =
+    explicitProvider ?? getMappedProviderIdForCapability(config, capability);
+  if (!providerId) {
+    throw new Error(
+      `No provider is configured for '${capability}'. Run /web-providers to configure tool mappings.`,
+    );
   }
 
-  for (const provider of PROVIDERS) {
-    if (!supportsProviderCapability(provider, capability)) continue;
-    const providerConfig = config.providers?.[provider.id];
-    if (providerConfig?.enabled !== true) continue;
-    if (
-      !isProviderToolEnabled(
-        provider.id,
-        providerConfig as ProviderConfigUnion | undefined,
-        capability,
-      )
-    ) {
-      continue;
-    }
-    const status = provider.getStatus(providerConfig as never, cwd);
-    if (status.available) return provider;
+  const provider = PROVIDER_MAP[providerId];
+  if (!supportsProviderCapability(provider, capability)) {
+    throw new Error(
+      `Provider '${providerId}' does not support '${capability}'.`,
+    );
   }
 
-  for (const providerId of IMPLICIT_PROVIDER_FALLBACKS) {
-    const provider = PROVIDER_MAP[providerId];
-    if (!supportsProviderCapability(provider, capability)) continue;
-    const providerConfig = getEffectiveProviderConfig(config, provider.id);
-    if (!isProviderToolEnabled(provider.id, providerConfig, capability)) {
-      continue;
-    }
-    const status = provider.getStatus(providerConfig as never, cwd);
-    if (status.available) return provider;
+  const providerConfig = getEffectiveProviderConfig(config, providerId);
+  const status = provider.getStatus(providerConfig as never, cwd);
+  if (!status.available) {
+    throw new Error(
+      `Provider '${providerId}' is not available: ${status.summary}.`,
+    );
   }
 
-  throw new Error(
-    `No provider is configured for '${capability}'. Run /web-providers to create ~/.pi/agent/web-providers.json.`,
-  );
+  return provider;
 }

--- a/src/provider-resolution.ts
+++ b/src/provider-resolution.ts
@@ -1,6 +1,10 @@
-import { getMappedProviderForCapability, type ProviderConfigUnion } from "./provider-tools.js";
+import {
+  getMappedProviderForCapability,
+  type ProviderConfigUnion,
+} from "./provider-tools.js";
 import { PROVIDER_MAP } from "./providers/index.js";
 import type {
+  ExecutionPolicyDefaults,
   ProviderCapability,
   ProviderId,
   WebProvider,
@@ -34,7 +38,46 @@ export function getEffectiveProviderConfig(
   config: WebProvidersConfig,
   providerId: ProviderId,
 ): ProviderConfigUnion | undefined {
-  return config.providers?.[providerId] as ProviderConfigUnion | undefined;
+  const providerConfig = config.providers?.[providerId] as
+    | ProviderConfigUnion
+    | undefined;
+  if (!providerConfig) {
+    return undefined;
+  }
+
+  const mergedPolicy = mergeExecutionPolicyDefaults(
+    config.genericSettings,
+    providerConfig.policy,
+  );
+  if (!mergedPolicy) {
+    return providerConfig;
+  }
+
+  return {
+    ...providerConfig,
+    policy: mergedPolicy,
+  } as ProviderConfigUnion;
+}
+
+function mergeExecutionPolicyDefaults(
+  shared: WebProvidersConfig["genericSettings"],
+  provider: ExecutionPolicyDefaults | undefined,
+): ExecutionPolicyDefaults | undefined {
+  const merged: ExecutionPolicyDefaults = {
+    requestTimeoutMs: provider?.requestTimeoutMs ?? shared?.requestTimeoutMs,
+    retryCount: provider?.retryCount ?? shared?.retryCount,
+    retryDelayMs: provider?.retryDelayMs ?? shared?.retryDelayMs,
+    researchPollIntervalMs:
+      provider?.researchPollIntervalMs ?? shared?.researchPollIntervalMs,
+    researchTimeoutMs: provider?.researchTimeoutMs ?? shared?.researchTimeoutMs,
+    researchMaxConsecutivePollErrors:
+      provider?.researchMaxConsecutivePollErrors ??
+      shared?.researchMaxConsecutivePollErrors,
+  };
+
+  return Object.values(merged).some((value) => value !== undefined)
+    ? merged
+    : undefined;
 }
 
 export function getMappedProviderIdForCapability(

--- a/src/provider-resolution.ts
+++ b/src/provider-resolution.ts
@@ -20,18 +20,10 @@ export function supportsProviderCapability(
 
 export function resolveProviderChoice(
   config: WebProvidersConfig,
-  explicitOrCwd: ProviderId | string,
-  cwd?: string,
+  cwd: string,
+  explicit?: ProviderId,
 ) {
-  if (cwd === undefined) {
-    return resolveProviderForCapability(config, explicitOrCwd, "search");
-  }
-  return resolveProviderForCapability(
-    config,
-    explicitOrCwd as ProviderId | undefined,
-    cwd,
-    "search",
-  );
+  return resolveProviderForCapability(config, cwd, "search", explicit);
 }
 
 export function getEffectiveProviderConfig(
@@ -90,25 +82,12 @@ export function getMappedProviderIdForCapability(
 
 export function resolveProviderForCapability(
   config: WebProvidersConfig,
-  explicitOrCwd: ProviderId | string | undefined,
-  cwdOrCapability: string | ProviderCapability,
-  maybeCapability?: ProviderCapability,
+  cwd: string,
+  capability: ProviderCapability,
+  explicit?: ProviderId,
 ) {
-  const explicitProvider =
-    maybeCapability === undefined
-      ? undefined
-      : (explicitOrCwd as ProviderId | undefined);
-  const cwd =
-    maybeCapability === undefined
-      ? (explicitOrCwd as string)
-      : (cwdOrCapability as string);
-  const capability =
-    maybeCapability === undefined
-      ? (cwdOrCapability as ProviderCapability)
-      : maybeCapability;
-
   const providerId =
-    explicitProvider ?? getMappedProviderIdForCapability(config, capability);
+    explicit ?? getMappedProviderIdForCapability(config, capability);
   if (!providerId) {
     throw new Error(
       `No provider is configured for '${capability}'. Run /web-providers to configure tool mappings.`,

--- a/src/provider-tools.ts
+++ b/src/provider-tools.ts
@@ -3,8 +3,8 @@ import type {
   CodexProviderConfig,
   ExaProviderConfig,
   GeminiProviderConfig,
-  PerplexityProviderConfig,
   ParallelProviderConfig,
+  PerplexityProviderConfig,
   ProviderId,
   ValyuProviderConfig,
 } from "./types.js";
@@ -22,7 +22,7 @@ export const PROVIDER_TOOLS: Record<ProviderId, readonly ProviderToolId[]> = {
   claude: ["search", "answer"],
   codex: ["search"],
   exa: ["search", "contents", "answer", "research"],
-  gemini: ["search", "contents", "answer", "research"],
+  gemini: ["search", "answer", "research"],
   perplexity: ["search", "answer", "research"],
   parallel: ["search", "contents"],
   valyu: ["search", "contents", "answer", "research"],

--- a/src/provider-tools.ts
+++ b/src/provider-tools.ts
@@ -5,8 +5,10 @@ import type {
   GeminiProviderConfig,
   ParallelProviderConfig,
   PerplexityProviderConfig,
+  ProviderCapability,
   ProviderId,
   ValyuProviderConfig,
+  WebProvidersConfig,
 } from "./types.js";
 
 export const PROVIDER_TOOL_IDS = [
@@ -66,16 +68,17 @@ export function supportsProviderTool(
   return PROVIDER_TOOLS[providerId].includes(toolId);
 }
 
-export function isProviderToolEnabled(
-  providerId: ProviderId,
-  config: ProviderConfigUnion | undefined,
+export function getCompatibleProvidersForTool(
   toolId: ProviderToolId,
-): boolean {
-  if (!supportsProviderTool(providerId, toolId)) {
-    return false;
-  }
-  const tools = config?.tools as
-    | Partial<Record<ProviderToolId, boolean>>
-    | undefined;
-  return tools?.[toolId] ?? true;
+): ProviderId[] {
+  return (Object.keys(PROVIDER_TOOLS) as ProviderId[]).filter((providerId) =>
+    supportsProviderTool(providerId, toolId),
+  );
+}
+
+export function getMappedProviderForCapability(
+  config: WebProvidersConfig,
+  capability: ProviderCapability,
+): ProviderId | null | undefined {
+  return config.tools?.[capability];
 }

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -89,6 +89,7 @@ export class ClaudeProvider implements WebProvider<ClaudeProviderConfig> {
 
   createTemplate(): ClaudeProviderConfig {
     return {
+      enabled: false,
       policy: createDefaultRequestPolicy(),
     };
   }
@@ -99,6 +100,9 @@ export class ClaudeProvider implements WebProvider<ClaudeProviderConfig> {
   ): ProviderStatus {
     if (!config) {
       return { available: false, summary: "not configured" };
+    }
+    if (config.enabled === false) {
+      return { available: false, summary: "disabled" };
     }
     const executablePath = resolveClaudeExecutablePath(config);
     if (executablePath && !existsSync(executablePath)) {

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -7,7 +7,6 @@ import {
   type SDKMessage,
   type SDKResultMessage,
 } from "@anthropic-ai/claude-agent-sdk";
-import { createDefaultRequestPolicy } from "../execution-policy-defaults.js";
 import { createSilentForegroundPlan } from "../provider-plans.js";
 import type {
   ClaudeProviderConfig,
@@ -90,7 +89,6 @@ export class ClaudeProvider implements WebProvider<ClaudeProviderConfig> {
   createTemplate(): ClaudeProviderConfig {
     return {
       enabled: false,
-      policy: createDefaultRequestPolicy(),
     };
   }
 

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -89,11 +89,6 @@ export class ClaudeProvider implements WebProvider<ClaudeProviderConfig> {
 
   createTemplate(): ClaudeProviderConfig {
     return {
-      enabled: false,
-      tools: {
-        search: true,
-        answer: true,
-      },
       policy: createDefaultRequestPolicy(),
     };
   }
@@ -104,9 +99,6 @@ export class ClaudeProvider implements WebProvider<ClaudeProviderConfig> {
   ): ProviderStatus {
     if (!config) {
       return { available: false, summary: "not configured" };
-    }
-    if (config.enabled === false) {
-      return { available: false, summary: "disabled" };
     }
     const executablePath = resolveClaudeExecutablePath(config);
     if (executablePath && !existsSync(executablePath)) {

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -3,7 +3,6 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { Codex, type ThreadEvent } from "@openai/codex-sdk";
 import { resolveConfigValue, resolveEnvMap } from "../config.js";
-import { createDefaultRequestPolicy } from "../execution-policy-defaults.js";
 import { createSilentForegroundPlan } from "../provider-plans.js";
 import type {
   CodexProviderConfig,
@@ -58,7 +57,6 @@ export class CodexProvider implements WebProvider<CodexProviderConfig> {
         webSearchEnabled: true,
         webSearchMode: "live",
       },
-      policy: createDefaultRequestPolicy(),
     };
   }
 

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -52,10 +52,6 @@ export class CodexProvider implements WebProvider<CodexProviderConfig> {
 
   createTemplate(): CodexProviderConfig {
     return {
-      enabled: true,
-      tools: {
-        search: true,
-      },
       native: {
         networkAccessEnabled: true,
         webSearchEnabled: true,
@@ -71,9 +67,6 @@ export class CodexProvider implements WebProvider<CodexProviderConfig> {
   ): ProviderStatus {
     if (!config) {
       return { available: false, summary: "not configured" };
-    }
-    if (config.enabled === false) {
-      return { available: false, summary: "disabled" };
     }
     try {
       new Codex({

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -52,6 +52,7 @@ export class CodexProvider implements WebProvider<CodexProviderConfig> {
 
   createTemplate(): CodexProviderConfig {
     return {
+      enabled: true,
       native: {
         networkAccessEnabled: true,
         webSearchEnabled: true,
@@ -67,6 +68,9 @@ export class CodexProvider implements WebProvider<CodexProviderConfig> {
   ): ProviderStatus {
     if (!config) {
       return { available: false, summary: "not configured" };
+    }
+    if (config.enabled === false) {
+      return { available: false, summary: "disabled" };
     }
     try {
       new Codex({

--- a/src/providers/exa.ts
+++ b/src/providers/exa.ts
@@ -35,6 +35,7 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
 
   createTemplate(): ExaProviderConfig {
     return {
+      enabled: false,
       apiKey: "EXA_API_KEY",
       native: {
         type: "auto",
@@ -49,6 +50,9 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
   getStatus(config: ExaProviderConfig | undefined): ProviderStatus {
     if (!config) {
       return { available: false, summary: "not configured" };
+    }
+    if (config.enabled === false) {
+      return { available: false, summary: "disabled" };
     }
     const apiKey = resolveConfigValue(config.apiKey);
     if (!apiKey) {

--- a/src/providers/exa.ts
+++ b/src/providers/exa.ts
@@ -35,13 +35,6 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
 
   createTemplate(): ExaProviderConfig {
     return {
-      enabled: false,
-      tools: {
-        search: true,
-        contents: true,
-        answer: true,
-        research: true,
-      },
       apiKey: "EXA_API_KEY",
       native: {
         type: "auto",
@@ -56,9 +49,6 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
   getStatus(config: ExaProviderConfig | undefined): ProviderStatus {
     if (!config) {
       return { available: false, summary: "not configured" };
-    }
-    if (config.enabled === false) {
-      return { available: false, summary: "disabled" };
     }
     const apiKey = resolveConfigValue(config.apiKey);
     if (!apiKey) {

--- a/src/providers/exa.ts
+++ b/src/providers/exa.ts
@@ -19,7 +19,13 @@ import type {
   SearchResponse,
   WebProvider,
 } from "../types.js";
-import { asJsonObject, formatJson, trimSnippet } from "./shared.js";
+import {
+  asJsonObject,
+  formatJson,
+  normalizeContentText,
+  pushIndentedBlock,
+  trimSnippet,
+} from "./shared.js";
 
 export class ExaProvider implements WebProvider<ExaProviderConfig> {
   readonly id: "exa" = "exa";
@@ -202,16 +208,16 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
             : result.summary
               ? formatJson(result.summary)
               : undefined;
-        const text =
+        const fullText =
           typeof result.text === "string"
             ? result.text
-            : Array.isArray(result.highlights)
-              ? result.highlights.join(" ")
-              : "";
-        const body = trimSnippet(summary ?? text);
-        if (body) {
-          entryLines.push(`   ${body}`);
-        }
+            : summary
+              ? summary
+              : Array.isArray(result.highlights)
+                ? result.highlights.join("\n\n")
+                : "";
+        const body = normalizeContentText(fullText);
+        pushIndentedBlock(entryLines, body);
 
         lines.push(...entryLines, "");
 

--- a/src/providers/exa.ts
+++ b/src/providers/exa.ts
@@ -1,7 +1,6 @@
 import { Exa } from "exa-js";
 import { resolveConfigValue } from "../config.js";
 import { stripLocalExecutionOptions } from "../execution-policy.js";
-import { createDefaultLifecyclePolicy } from "../execution-policy-defaults.js";
 import {
   createBackgroundResearchPlan,
   createSilentForegroundPlan,
@@ -43,7 +42,6 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
           text: true,
         },
       },
-      policy: createDefaultLifecyclePolicy(),
     };
   }
 

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -32,21 +32,19 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
   readonly id: "gemini" = "gemini";
   readonly label = "Gemini";
   readonly docsUrl = "https://github.com/googleapis/js-genai";
-  readonly capabilities = ["search", "contents", "answer", "research"] as const;
+  readonly capabilities = ["search", "answer", "research"] as const;
 
   createTemplate(): GeminiProviderConfig {
     return {
       enabled: false,
       tools: {
         search: true,
-        contents: true,
         answer: true,
         research: true,
       },
       apiKey: "GOOGLE_API_KEY",
       native: {
         searchModel: DEFAULT_SEARCH_MODEL,
-        contentsModel: DEFAULT_CONTENTS_MODEL,
         answerModel: DEFAULT_ANSWER_MODEL,
         researchAgent: DEFAULT_RESEARCH_AGENT,
       },
@@ -198,27 +196,58 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
     );
 
     const urlList = urls.map((url) => `- ${url}`).join("\n");
-    const native = getGeminiNativeConfig(config);
-    const request = buildGeminiGenerateContentRequest({
-      defaultModel: native?.contentsModel ?? DEFAULT_CONTENTS_MODEL,
-      prompt:
-        `Extract the main textual content from each of the following URLs. ` +
-        `For every successfully retrieved URL, return exactly one block in this format:\n` +
-        `[[[URL]]]\n<resolved URL>\n[[[TITLE]]]\n<title>\n[[[BODY]]]\n<cleaned body text>\n[[[END]]]\n\n` +
-        `Only include successfully retrieved URLs. Preserve headings, paragraphs, and lists in BODY, ` +
-        `but remove navigation, ads, and boilerplate. Do not add any text outside these blocks.\n\n${urlList}`,
+    const defaultModel = DEFAULT_CONTENTS_MODEL;
+    const structuredPrompt =
+      `Extract the main textual content from each of the following URLs. ` +
+      `For every successfully retrieved URL, return exactly one block in this format:\n` +
+      `[[[URL]]]\n<resolved URL>\n[[[TITLE]]]\n<title>\n[[[BODY]]]\n<cleaned body text>\n[[[END]]]\n\n` +
+      `Only include successfully retrieved URLs. Preserve headings, paragraphs, and lists in BODY, ` +
+      `but remove navigation, ads, and boilerplate. Do not add any text outside these blocks.\n\n${urlList}`;
+
+    const structuredResponse = await requestGeminiContentsExtraction({
+      ai,
+      defaultModel,
+      prompt: structuredPrompt,
       options,
-      toolConfig: { urlContext: {} },
-    });
-    const response = await ai.models.generateContent({
-      model: request.model,
-      contents: [request.contents],
-      config: addAbortSignalToGeminiConfig(request.config, context.signal),
+      signal: context.signal,
     });
 
-    const text = response.text?.trim() || "";
-    const metadata = extractUrlContextMetadata(response.candidates);
-    const contentsEntries = buildGeminiContentsEntries(text, urls, metadata);
+    let text = structuredResponse.text;
+    let metadata = structuredResponse.metadata;
+    let contentsEntries = buildGeminiContentsEntries(text, urls, metadata);
+    const hasReadyEntries = contentsEntries.some(
+      (entry) => entry.status !== "failed",
+    );
+
+    if (
+      shouldFallbackToLegacyGeminiContentsPrompt(
+        text,
+        metadata,
+        hasReadyEntries,
+      )
+    ) {
+      const fallbackResponse = await requestGeminiContentsExtraction({
+        ai,
+        defaultModel,
+        prompt:
+          `Extract the main textual content from each of the following URLs. ` +
+          `For each URL, return the page title followed by the cleaned body text. ` +
+          `Preserve the original structure (headings, paragraphs, lists) but remove ` +
+          `navigation, ads, and boilerplate.\n\n${urlList}`,
+        options,
+        signal: context.signal,
+      });
+
+      text = fallbackResponse.text;
+      metadata = fallbackResponse.metadata;
+      contentsEntries = buildGeminiContentsEntries(text, urls, metadata);
+    }
+
+    if (shouldRetryEmptyGeminiContentsResponse(text, metadata)) {
+      throw new Error(
+        "Gemini returned an empty URL Context response. Retrying may succeed.",
+      );
+    }
     const lines: string[] = [];
 
     const successfulEntries = contentsEntries.filter(
@@ -557,6 +586,79 @@ function extractUrlContextMetadata(
   }
 
   return results;
+}
+
+async function requestGeminiContentsExtraction({
+  ai,
+  defaultModel,
+  prompt,
+  options,
+  signal,
+}: {
+  ai: GoogleGenAI;
+  defaultModel: string;
+  prompt: string;
+  options: JsonObject | undefined;
+  signal: AbortSignal | undefined;
+}): Promise<{
+  text: string;
+  metadata: Array<{ url: string; status: string | undefined }>;
+}> {
+  const request = buildGeminiGenerateContentRequest({
+    defaultModel,
+    prompt,
+    options,
+    toolConfig: { urlContext: {} },
+  });
+  const response = await ai.models.generateContent({
+    model: request.model,
+    contents: [request.contents],
+    config: addAbortSignalToGeminiConfig(request.config, signal),
+  });
+
+  return {
+    text: response.text?.trim() || "",
+    metadata: extractUrlContextMetadata(response.candidates),
+  };
+}
+
+function shouldFallbackToLegacyGeminiContentsPrompt(
+  text: string,
+  metadata: Array<{ url: string; status: string | undefined }>,
+  hasReadyEntries: boolean,
+): boolean {
+  if (hasReadyEntries) {
+    return false;
+  }
+
+  if (text.trim().length === 0) {
+    return true;
+  }
+
+  return metadata.some(
+    (entry) =>
+      entry.status === undefined ||
+      entry.status === "URL_RETRIEVAL_STATUS_SUCCESS",
+  );
+}
+
+function shouldRetryEmptyGeminiContentsResponse(
+  text: string,
+  metadata: Array<{ url: string; status: string | undefined }>,
+): boolean {
+  if (text.trim().length > 0) {
+    return false;
+  }
+
+  if (metadata.length === 0) {
+    return true;
+  }
+
+  return metadata.some(
+    (entry) =>
+      entry.status === undefined ||
+      entry.status === "URL_RETRIEVAL_STATUS_SUCCESS",
+  );
 }
 
 function buildGeminiContentsEntries(

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -1,9 +1,6 @@
 import { GoogleGenAI } from "@google/genai";
 import { resolveConfigValue } from "../config.js";
-import {
-  createDefaultLifecyclePolicy,
-  DEFAULT_GEMINI_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS,
-} from "../execution-policy-defaults.js";
+import { DEFAULT_GEMINI_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS } from "../execution-policy-defaults.js";
 import {
   createBackgroundResearchPlan,
   createSilentForegroundPlan,
@@ -43,10 +40,10 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
         answerModel: DEFAULT_ANSWER_MODEL,
         researchAgent: DEFAULT_RESEARCH_AGENT,
       },
-      policy: createDefaultLifecyclePolicy({
+      policy: {
         researchMaxConsecutivePollErrors:
           DEFAULT_GEMINI_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS,
-      }),
+      },
     };
   }
 

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -36,12 +36,6 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
 
   createTemplate(): GeminiProviderConfig {
     return {
-      enabled: false,
-      tools: {
-        search: true,
-        answer: true,
-        research: true,
-      },
       apiKey: "GOOGLE_API_KEY",
       native: {
         searchModel: DEFAULT_SEARCH_MODEL,
@@ -58,9 +52,6 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
   getStatus(config: GeminiProviderConfig | undefined): ProviderStatus {
     if (!config) {
       return { available: false, summary: "not configured" };
-    }
-    if (config.enabled === false) {
-      return { available: false, summary: "disabled" };
     }
     const apiKey = resolveConfigValue(config.apiKey);
     if (!apiKey) {

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -36,6 +36,7 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
 
   createTemplate(): GeminiProviderConfig {
     return {
+      enabled: false,
       apiKey: "GOOGLE_API_KEY",
       native: {
         searchModel: DEFAULT_SEARCH_MODEL,
@@ -52,6 +53,9 @@ export class GeminiProvider implements WebProvider<GeminiProviderConfig> {
   getStatus(config: GeminiProviderConfig | undefined): ProviderStatus {
     if (!config) {
       return { available: false, summary: "not configured" };
+    }
+    if (config.enabled === false) {
+      return { available: false, summary: "disabled" };
     }
     const apiKey = resolveConfigValue(config.apiKey);
     if (!apiKey) {

--- a/src/providers/parallel.ts
+++ b/src/providers/parallel.ts
@@ -29,11 +29,6 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
 
   createTemplate(): ParallelProviderConfig {
     return {
-      enabled: false,
-      tools: {
-        search: true,
-        contents: true,
-      },
       apiKey: "PARALLEL_API_KEY",
       native: {
         search: {
@@ -51,9 +46,6 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
   getStatus(config: ParallelProviderConfig | undefined): ProviderStatus {
     if (!config) {
       return { available: false, summary: "not configured" };
-    }
-    if (config.enabled === false) {
-      return { available: false, summary: "disabled" };
     }
     const apiKey = resolveConfigValue(config.apiKey);
     if (!apiKey) {

--- a/src/providers/parallel.ts
+++ b/src/providers/parallel.ts
@@ -1,7 +1,6 @@
 import Parallel from "parallel-web";
 import { resolveConfigValue } from "../config.js";
 import { stripLocalExecutionOptions } from "../execution-policy.js";
-import { createDefaultRequestPolicy } from "../execution-policy-defaults.js";
 import { createSilentForegroundPlan } from "../provider-plans.js";
 import type {
   JsonValue,
@@ -40,7 +39,6 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
           full_content: true,
         },
       },
-      policy: createDefaultRequestPolicy(),
     };
   }
 

--- a/src/providers/parallel.ts
+++ b/src/providers/parallel.ts
@@ -14,7 +14,12 @@ import type {
   SearchResponse,
   WebProvider,
 } from "../types.js";
-import { asJsonObject, trimSnippet } from "./shared.js";
+import {
+  asJsonObject,
+  normalizeContentText,
+  pushIndentedBlock,
+  trimSnippet,
+} from "./shared.js";
 
 export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
   readonly id: "parallel" = "parallel";
@@ -35,8 +40,8 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
           mode: "agentic",
         },
         extract: {
-          excerpts: true,
-          full_content: false,
+          excerpts: false,
+          full_content: true,
         },
       },
       policy: createDefaultRequestPolicy(),
@@ -150,11 +155,9 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
         const title = result.title ?? result.url;
         const entryLines = [`${index + 1}. ${title}`, `   ${result.url}`];
 
-        const text = result.excerpts?.join(" ") ?? result.full_content ?? "";
-        const body = trimSnippet(text);
-        if (body) {
-          entryLines.push(`   ${body}`);
-        }
+        const text = result.full_content ?? result.excerpts?.join("\n\n") ?? "";
+        const body = normalizeContentText(text);
+        pushIndentedBlock(entryLines, body);
 
         lines.push(...entryLines, "");
         return {

--- a/src/providers/parallel.ts
+++ b/src/providers/parallel.ts
@@ -29,6 +29,7 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
 
   createTemplate(): ParallelProviderConfig {
     return {
+      enabled: false,
       apiKey: "PARALLEL_API_KEY",
       native: {
         search: {
@@ -46,6 +47,9 @@ export class ParallelProvider implements WebProvider<ParallelProviderConfig> {
   getStatus(config: ParallelProviderConfig | undefined): ProviderStatus {
     if (!config) {
       return { available: false, summary: "not configured" };
+    }
+    if (config.enabled === false) {
+      return { available: false, summary: "disabled" };
     }
     const apiKey = resolveConfigValue(config.apiKey);
     if (!apiKey) {

--- a/src/providers/perplexity.ts
+++ b/src/providers/perplexity.ts
@@ -42,6 +42,7 @@ export class PerplexityProvider
 
   createTemplate(): PerplexityProviderConfig {
     return {
+      enabled: false,
       apiKey: "PERPLEXITY_API_KEY",
       native: {
         answer: {
@@ -58,6 +59,9 @@ export class PerplexityProvider
   getStatus(config: PerplexityProviderConfig | undefined): ProviderStatus {
     if (!config) {
       return { available: false, summary: "not configured" };
+    }
+    if (config.enabled === false) {
+      return { available: false, summary: "disabled" };
     }
     const apiKey = resolveConfigValue(config.apiKey);
     if (!apiKey) {

--- a/src/providers/perplexity.ts
+++ b/src/providers/perplexity.ts
@@ -42,12 +42,6 @@ export class PerplexityProvider
 
   createTemplate(): PerplexityProviderConfig {
     return {
-      enabled: false,
-      tools: {
-        search: true,
-        answer: true,
-        research: true,
-      },
       apiKey: "PERPLEXITY_API_KEY",
       native: {
         answer: {
@@ -64,9 +58,6 @@ export class PerplexityProvider
   getStatus(config: PerplexityProviderConfig | undefined): ProviderStatus {
     if (!config) {
       return { available: false, summary: "not configured" };
-    }
-    if (config.enabled === false) {
-      return { available: false, summary: "disabled" };
     }
     const apiKey = resolveConfigValue(config.apiKey);
     if (!apiKey) {

--- a/src/providers/perplexity.ts
+++ b/src/providers/perplexity.ts
@@ -1,7 +1,6 @@
 import Perplexity from "@perplexity-ai/perplexity_ai";
 import { resolveConfigValue } from "../config.js";
 import { stripLocalExecutionOptions } from "../execution-policy.js";
-import { createDefaultRequestPolicy } from "../execution-policy-defaults.js";
 import {
   createSilentForegroundPlan,
   createStreamingForegroundPlan,
@@ -52,7 +51,6 @@ export class PerplexityProvider
           model: DEFAULT_RESEARCH_MODEL,
         },
       },
-      policy: createDefaultRequestPolicy(),
     };
   }
 

--- a/src/providers/shared.ts
+++ b/src/providers/shared.ts
@@ -9,6 +9,30 @@ export function trimSnippet(
   return `${text.slice(0, maxLength - 1)}…`;
 }
 
+export function normalizeContentText(input: string | undefined): string {
+  const text = (input ?? "").replace(/\r/g, "").trim();
+  if (!text) {
+    return "";
+  }
+
+  return text
+    .split("\n")
+    .map((line) => line.replace(/[ \t]+$/g, ""))
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n");
+}
+
+export function pushIndentedBlock(lines: string[], text: string): void {
+  const normalized = normalizeContentText(text);
+  if (!normalized) {
+    return;
+  }
+
+  for (const line of normalized.split("\n")) {
+    lines.push(`   ${line}`);
+  }
+}
+
 export function asJsonObject(
   value: JsonObject | undefined,
 ): Record<string, unknown> {

--- a/src/providers/valyu.ts
+++ b/src/providers/valyu.ts
@@ -19,7 +19,13 @@ import type {
   ValyuProviderConfig,
   WebProvider,
 } from "../types.js";
-import { asJsonObject, formatJson, trimSnippet } from "./shared.js";
+import {
+  asJsonObject,
+  formatJson,
+  normalizeContentText,
+  pushIndentedBlock,
+  trimSnippet,
+} from "./shared.js";
 
 export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
   readonly id: "valyu" = "valyu";
@@ -201,32 +207,35 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
       results.flatMap<ProviderContentsMetadataEntry>((result, index) => {
         const entryLines = [`${index + 1}. ${result.url}`];
         if (result.status === "failed") {
-          entryLines.push(`   Failed: ${result.error}`);
+          const body = normalizeContentText(`Failed: ${result.error}`);
+          pushIndentedBlock(entryLines, body);
           lines.push(...entryLines, "");
           return [
             {
               url: result.url,
               title: result.url,
-              body: `Failed: ${result.error}`,
+              body,
               status: "failed",
             },
           ];
         }
 
-        const snippet =
-          typeof result.summary === "string"
-            ? result.summary
-            : result.summary
-              ? formatJson(result.summary)
-              : typeof result.content === "string" ||
-                  typeof result.content === "number"
-                ? String(result.content)
-                : formatJson(result.content);
-        const body = trimSnippet(snippet);
+        const contentText =
+          typeof result.content === "string" ||
+          typeof result.content === "number"
+            ? String(result.content)
+            : result.content
+              ? formatJson(result.content)
+              : typeof result.summary === "string"
+                ? result.summary
+                : result.summary
+                  ? formatJson(result.summary)
+                  : "";
+        const body = normalizeContentText(contentText);
         if (result.title) {
           entryLines.push(`   ${result.title}`);
         }
-        entryLines.push(`   ${body}`);
+        pushIndentedBlock(entryLines, body);
         lines.push(...entryLines, "");
         return [
           {

--- a/src/providers/valyu.ts
+++ b/src/providers/valyu.ts
@@ -35,13 +35,6 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
 
   createTemplate(): ValyuProviderConfig {
     return {
-      enabled: false,
-      tools: {
-        search: true,
-        contents: true,
-        answer: true,
-        research: true,
-      },
       apiKey: "VALYU_API_KEY",
       native: {
         searchType: "all",
@@ -54,9 +47,6 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
   getStatus(config: ValyuProviderConfig | undefined): ProviderStatus {
     if (!config) {
       return { available: false, summary: "not configured" };
-    }
-    if (config.enabled === false) {
-      return { available: false, summary: "disabled" };
     }
     const apiKey = resolveConfigValue(config.apiKey);
     if (!apiKey) {

--- a/src/providers/valyu.ts
+++ b/src/providers/valyu.ts
@@ -1,7 +1,6 @@
 import { Valyu } from "valyu-js";
 import { resolveConfigValue } from "../config.js";
 import { stripLocalExecutionOptions } from "../execution-policy.js";
-import { createDefaultLifecyclePolicy } from "../execution-policy-defaults.js";
 import {
   createBackgroundResearchPlan,
   createSilentForegroundPlan,
@@ -41,7 +40,6 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
         searchType: "all",
         responseLength: "short",
       },
-      policy: createDefaultLifecyclePolicy(),
     };
   }
 

--- a/src/providers/valyu.ts
+++ b/src/providers/valyu.ts
@@ -35,6 +35,7 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
 
   createTemplate(): ValyuProviderConfig {
     return {
+      enabled: false,
       apiKey: "VALYU_API_KEY",
       native: {
         searchType: "all",
@@ -47,6 +48,9 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
   getStatus(config: ValyuProviderConfig | undefined): ProviderStatus {
     if (!config) {
       return { available: false, summary: "not configured" };
+    }
+    if (config.enabled === false) {
+      return { available: false, summary: "disabled" };
     }
     const apiKey = resolveConfigValue(config.apiKey);
     if (!apiKey) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -180,7 +180,6 @@ export interface ValyuProviderConfig extends LegacyProviderRoutingConfig {
 }
 
 export interface WebProvidersConfig {
-  version: 1 | 2;
   tools?: ToolProviderMapping;
   providers?: {
     claude?: ClaudeProviderConfig;

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,20 @@ export type ToolProviderMapping = Partial<
   Record<ProviderCapability, ProviderId | null>
 >;
 
+export interface SearchPrefetchSettings {
+  provider?: ProviderId | null;
+  maxUrls?: number;
+  ttlMs?: number;
+}
+
+export interface SearchToolSettings {
+  prefetch?: SearchPrefetchSettings;
+}
+
+export interface ToolSettingsConfig {
+  search?: SearchToolSettings;
+}
+
 export type JsonValue =
   | string
   | number
@@ -181,6 +195,7 @@ export interface ValyuProviderConfig extends LegacyProviderRoutingConfig {
 
 export interface WebProvidersConfig {
   tools?: ToolProviderMapping;
+  toolSettings?: ToolSettingsConfig;
   providers?: {
     claude?: ClaudeProviderConfig;
     codex?: CodexProviderConfig;

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,9 @@ export const PROVIDER_IDS = [
 
 export type ProviderId = (typeof PROVIDER_IDS)[number];
 export type ProviderCapability = "search" | "contents" | "answer" | "research";
+export type ToolProviderMapping = Partial<
+  Record<ProviderCapability, ProviderId | null>
+>;
 
 export type JsonValue =
   | string
@@ -112,23 +115,21 @@ export interface ParallelProviderNativeConfig {
   extract?: JsonObject;
 }
 
-export interface ClaudeProviderConfig {
+// Legacy routing fields are tolerated in TypeScript shapes for internal tests,
+// but config parsing rejects them in persisted config files.
+export interface LegacyProviderRoutingConfig {
   enabled?: boolean;
-  tools?: {
-    search?: boolean;
-    answer?: boolean;
-  };
+  tools?: Partial<Record<ProviderCapability, boolean>>;
+}
+
+export interface ClaudeProviderConfig extends LegacyProviderRoutingConfig {
   pathToClaudeCodeExecutable?: string;
   native?: ClaudeProviderNativeConfig;
   policy?: ExecutionPolicyDefaults;
   defaults?: ClaudeProviderNativeConfig;
 }
 
-export interface CodexProviderConfig {
-  enabled?: boolean;
-  tools?: {
-    search?: boolean;
-  };
+export interface CodexProviderConfig extends LegacyProviderRoutingConfig {
   codexPath?: string;
   baseUrl?: string;
   apiKey?: string;
@@ -139,14 +140,7 @@ export interface CodexProviderConfig {
   defaults?: CodexProviderNativeConfig;
 }
 
-export interface ExaProviderConfig {
-  enabled?: boolean;
-  tools?: {
-    search?: boolean;
-    contents?: boolean;
-    answer?: boolean;
-    research?: boolean;
-  };
+export interface ExaProviderConfig extends LegacyProviderRoutingConfig {
   apiKey?: string;
   baseUrl?: string;
   native?: JsonObject;
@@ -154,26 +148,14 @@ export interface ExaProviderConfig {
   defaults?: JsonObject;
 }
 
-export interface GeminiProviderConfig {
-  enabled?: boolean;
-  tools?: {
-    search?: boolean;
-    answer?: boolean;
-    research?: boolean;
-  };
+export interface GeminiProviderConfig extends LegacyProviderRoutingConfig {
   apiKey?: string;
   native?: GeminiProviderNativeConfig;
   policy?: ExecutionPolicyDefaults;
   defaults?: GeminiProviderNativeConfig & ExecutionPolicyDefaults;
 }
 
-export interface PerplexityProviderConfig {
-  enabled?: boolean;
-  tools?: {
-    search?: boolean;
-    answer?: boolean;
-    research?: boolean;
-  };
+export interface PerplexityProviderConfig extends LegacyProviderRoutingConfig {
   apiKey?: string;
   baseUrl?: string;
   native?: PerplexityProviderNativeConfig;
@@ -181,12 +163,7 @@ export interface PerplexityProviderConfig {
   defaults?: PerplexityProviderNativeConfig;
 }
 
-export interface ParallelProviderConfig {
-  enabled?: boolean;
-  tools?: {
-    search?: boolean;
-    contents?: boolean;
-  };
+export interface ParallelProviderConfig extends LegacyProviderRoutingConfig {
   apiKey?: string;
   baseUrl?: string;
   native?: ParallelProviderNativeConfig;
@@ -194,14 +171,7 @@ export interface ParallelProviderConfig {
   defaults?: ParallelProviderNativeConfig;
 }
 
-export interface ValyuProviderConfig {
-  enabled?: boolean;
-  tools?: {
-    search?: boolean;
-    contents?: boolean;
-    answer?: boolean;
-    research?: boolean;
-  };
+export interface ValyuProviderConfig extends LegacyProviderRoutingConfig {
   apiKey?: string;
   baseUrl?: string;
   native?: JsonObject;
@@ -210,7 +180,8 @@ export interface ValyuProviderConfig {
 }
 
 export interface WebProvidersConfig {
-  version: 1;
+  version: 1 | 2;
+  tools?: ToolProviderMapping;
   providers?: {
     claude?: ClaudeProviderConfig;
     codex?: CodexProviderConfig;

--- a/src/types.ts
+++ b/src/types.ts
@@ -193,9 +193,19 @@ export interface ValyuProviderConfig extends LegacyProviderRoutingConfig {
   defaults?: JsonObject;
 }
 
+export interface GenericSettingsConfig {
+  requestTimeoutMs?: number;
+  retryCount?: number;
+  retryDelayMs?: number;
+  researchPollIntervalMs?: number;
+  researchTimeoutMs?: number;
+  researchMaxConsecutivePollErrors?: number;
+}
+
 export interface WebProvidersConfig {
   tools?: ToolProviderMapping;
   toolSettings?: ToolSettingsConfig;
+  genericSettings?: GenericSettingsConfig;
   providers?: {
     claude?: ClaudeProviderConfig;
     codex?: CodexProviderConfig;

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,7 +97,6 @@ export interface CodexProviderNativeConfig {
 export interface GeminiProviderNativeConfig {
   apiVersion?: string;
   searchModel?: string;
-  contentsModel?: string;
   answerModel?: string;
   researchAgent?: string;
 }
@@ -159,7 +158,6 @@ export interface GeminiProviderConfig {
   enabled?: boolean;
   tools?: {
     search?: boolean;
-    contents?: boolean;
     answer?: boolean;
     research?: boolean;
   };

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -116,6 +116,31 @@ describe("config parsing", () => {
     });
   });
 
+  it("accepts shared generic execution settings", () => {
+    const parsed = parseConfig(
+      JSON.stringify({
+        genericSettings: {
+          requestTimeoutMs: 45000,
+          retryCount: 5,
+          retryDelayMs: 4000,
+          researchPollIntervalMs: 6000,
+          researchTimeoutMs: 28800000,
+          researchMaxConsecutivePollErrors: 12,
+        },
+      }),
+      "test-config.json",
+    );
+
+    expect(parsed.genericSettings).toEqual({
+      requestTimeoutMs: 45000,
+      retryCount: 5,
+      retryDelayMs: 4000,
+      researchPollIntervalMs: 6000,
+      researchTimeoutMs: 28800000,
+      researchMaxConsecutivePollErrors: 12,
+    });
+  });
+
   it("rejects unknown tool-specific settings", () => {
     expect(() =>
       parseConfig(
@@ -241,12 +266,12 @@ describe("config parsing", () => {
 
   it("maps legacy defaults into native and policy config blocks", () => {
     const loaded = parseConfig(
-        JSON.stringify({
-          version: 2,
-          providers: {
-            gemini: {
-              apiKey: "GOOGLE_API_KEY",
-              defaults: {
+      JSON.stringify({
+        version: 2,
+        providers: {
+          gemini: {
+            apiKey: "GOOGLE_API_KEY",
+            defaults: {
               searchModel: "gemini-2.5-flash",
               requestTimeoutMs: 45000,
               retryCount: 5,
@@ -265,20 +290,10 @@ describe("config parsing", () => {
     expect(loaded.providers?.gemini).not.toHaveProperty("defaults");
   });
 
-  it("seeds managed execution policy defaults for every provider template", () => {
+  it("seeds shared generic defaults and only keeps provider-specific overrides", () => {
     const config = createDefaultConfig();
 
-    expect(config.providers?.claude?.policy).toEqual({
-      requestTimeoutMs: 30000,
-      retryCount: 3,
-      retryDelayMs: 2000,
-    });
-    expect(config.providers?.codex?.policy).toEqual({
-      requestTimeoutMs: 30000,
-      retryCount: 3,
-      retryDelayMs: 2000,
-    });
-    expect(config.providers?.exa?.policy).toEqual({
+    expect(config.genericSettings).toEqual({
       requestTimeoutMs: 30000,
       retryCount: 3,
       retryDelayMs: 2000,
@@ -286,35 +301,18 @@ describe("config parsing", () => {
       researchTimeoutMs: 21600000,
       researchMaxConsecutivePollErrors: 3,
     });
+    expect(config.providers?.claude?.policy).toBeUndefined();
+    expect(config.providers?.codex?.policy).toBeUndefined();
+    expect(config.providers?.exa?.policy).toBeUndefined();
     expect(config.providers?.gemini?.policy).toEqual({
-      requestTimeoutMs: 30000,
-      retryCount: 3,
-      retryDelayMs: 2000,
-      researchPollIntervalMs: 3000,
-      researchTimeoutMs: 21600000,
       researchMaxConsecutivePollErrors: 10,
     });
-    expect(config.providers?.perplexity?.policy).toEqual({
-      requestTimeoutMs: 30000,
-      retryCount: 3,
-      retryDelayMs: 2000,
-    });
-    expect(config.providers?.parallel?.policy).toEqual({
-      requestTimeoutMs: 30000,
-      retryCount: 3,
-      retryDelayMs: 2000,
-    });
-    expect(config.providers?.valyu?.policy).toEqual({
-      requestTimeoutMs: 30000,
-      retryCount: 3,
-      retryDelayMs: 2000,
-      researchPollIntervalMs: 3000,
-      researchTimeoutMs: 21600000,
-      researchMaxConsecutivePollErrors: 3,
-    });
+    expect(config.providers?.perplexity?.policy).toBeUndefined();
+    expect(config.providers?.parallel?.policy).toBeUndefined();
+    expect(config.providers?.valyu?.policy).toBeUndefined();
   });
 
-  it("keeps provider templates aligned with the default config policy blocks", () => {
+  it("keeps provider templates aligned with provider-specific default config blocks", () => {
     const config = createDefaultConfig();
 
     expect(PROVIDER_MAP.claude.createTemplate().policy).toEqual(

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -93,6 +93,44 @@ describe("config parsing", () => {
     ).toThrow(/providers\.valyu\.tools/);
   });
 
+  it("accepts search tool settings for persisted prefetch defaults", () => {
+    const parsed = parseConfig(
+      JSON.stringify({
+        toolSettings: {
+          search: {
+            prefetch: {
+              provider: "exa",
+              maxUrls: 3,
+              ttlMs: 60000,
+            },
+          },
+        },
+      }),
+      "test-config.json",
+    );
+
+    expect(parsed.toolSettings?.search?.prefetch).toEqual({
+      provider: "exa",
+      maxUrls: 3,
+      ttlMs: 60000,
+    });
+  });
+
+  it("rejects unknown tool-specific settings", () => {
+    expect(() =>
+      parseConfig(
+        JSON.stringify({
+          toolSettings: {
+            search: {
+              caching: true,
+            },
+          },
+        }),
+        "test-config.json",
+      ),
+    ).toThrow(/Unknown search tool settings/);
+  });
+
   it("loads the global config", async () => {
     const root = await mkdtemp(join(tmpdir(), "pi-web-providers-config-"));
     cleanupDirs.push(root);
@@ -156,6 +194,15 @@ describe("config parsing", () => {
 
     config.providers!.codex!.native!.webSearchMode = "cached";
     config.providers!.codex!.native!.additionalDirectories = ["notes"];
+    config.toolSettings = {
+      search: {
+        prefetch: {
+          provider: "exa",
+          maxUrls: 2,
+          ttlMs: 60000,
+        },
+      },
+    };
 
     await writeFile(getConfigPath(), serializeConfig(config), "utf-8");
 
@@ -185,6 +232,11 @@ describe("config parsing", () => {
       "sonar-deep-research",
     );
     expect(loaded.providers?.parallel?.native?.search?.mode).toBe("one-shot");
+    expect(loaded.toolSettings?.search?.prefetch).toEqual({
+      provider: "exa",
+      maxUrls: 2,
+      ttlMs: 60000,
+    });
   });
 
   it("maps legacy defaults into native and policy config blocks", () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -122,7 +122,6 @@ describe("config parsing", () => {
       native: {
         apiVersion: "v1alpha",
         searchModel: "gemini-2.5-flash",
-        contentsModel: "gemini-2.5-pro",
       },
       policy: {
         requestTimeoutMs: 45000,
@@ -167,9 +166,6 @@ describe("config parsing", () => {
     ]);
     expect(loaded.providers?.exa?.enabled).toBe(true);
     expect(loaded.providers?.gemini?.native?.apiVersion).toBe("v1alpha");
-    expect(loaded.providers?.gemini?.native?.contentsModel).toBe(
-      "gemini-2.5-pro",
-    );
     expect(loaded.providers?.gemini?.policy?.requestTimeoutMs).toBe(45000);
     expect(loaded.providers?.gemini?.policy?.retryCount).toBe(5);
     expect(loaded.providers?.gemini?.policy?.retryDelayMs).toBe(4000);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -36,7 +36,6 @@ describe("config parsing", () => {
     expect(() =>
       parseConfig(
         JSON.stringify({
-          version: 2,
           providers: {
             searxng: {},
           },
@@ -50,7 +49,6 @@ describe("config parsing", () => {
     expect(() =>
       parseConfig(
         JSON.stringify({
-          version: 2,
           tools: {
             summarize: "codex",
           },
@@ -79,7 +77,6 @@ describe("config parsing", () => {
     expect(() =>
       parseConfig(
         JSON.stringify({
-          version: 2,
           providers: {
             valyu: {
               tools: {
@@ -267,7 +264,6 @@ describe("config parsing", () => {
   it("maps legacy defaults into native and policy config blocks", () => {
     const loaded = parseConfig(
       JSON.stringify({
-        version: 2,
         providers: {
           gemini: {
             apiKey: "GOOGLE_API_KEY",

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -36,7 +36,7 @@ describe("config parsing", () => {
     expect(() =>
       parseConfig(
         JSON.stringify({
-          version: 1,
+          version: 2,
           providers: {
             searxng: {},
           },
@@ -46,40 +46,52 @@ describe("config parsing", () => {
     ).toThrow(/Unknown providers/);
   });
 
-  it("rejects unknown provider tools", () => {
+  it("rejects unknown top-level tool mappings", () => {
     expect(() =>
       parseConfig(
         JSON.stringify({
-          version: 1,
+          version: 2,
+          tools: {
+            summarize: "codex",
+          },
+        }),
+        "test-config.json",
+      ),
+    ).toThrow(/Unknown tools in test-config.json: summarize/);
+  });
+
+  it("rejects legacy provider enablement", () => {
+    expect(() =>
+      parseConfig(
+        JSON.stringify({
+          version: 2,
           providers: {
             codex: {
-              tools: {
-                answer: true,
-              },
+              enabled: true,
             },
           },
         }),
         "test-config.json",
       ),
-    ).toThrow(/Unknown tools for codex/);
+    ).toThrow(/providers\.codex\.enabled/);
   });
 
-  it("rejects removed provider tool aliases", () => {
+  it("rejects legacy provider-local tool toggles", () => {
     expect(() =>
       parseConfig(
         JSON.stringify({
-          version: 1,
+          version: 2,
           providers: {
             valyu: {
               tools: {
-                deepResearch: true,
+                research: true,
               },
             },
           },
         }),
         "test-config.json",
       ),
-    ).toThrow(/Unknown tools for valyu/);
+    ).toThrow(/providers\.valyu\.tools/);
   });
 
   it("loads the global config", async () => {
@@ -91,7 +103,6 @@ describe("config parsing", () => {
 
     const config = createDefaultConfig();
     config.providers!.claude = {
-      enabled: false,
       pathToClaudeCodeExecutable: "/tmp/claude-code",
       native: {
         model: "claude-sonnet-4-5",
@@ -101,14 +112,12 @@ describe("config parsing", () => {
     };
     config.providers!.codex!.native!.additionalDirectories = ["docs"];
     config.providers!.exa = {
-      enabled: true,
       apiKey: "EXA_API_KEY",
       native: {
         type: "auto",
       },
     };
     config.providers!.parallel = {
-      enabled: false,
       apiKey: "PARALLEL_API_KEY",
       native: {
         search: {
@@ -117,7 +126,6 @@ describe("config parsing", () => {
       },
     };
     config.providers!.gemini = {
-      enabled: false,
       apiKey: "GOOGLE_API_KEY",
       native: {
         apiVersion: "v1alpha",
@@ -133,7 +141,6 @@ describe("config parsing", () => {
       },
     };
     config.providers!.perplexity = {
-      enabled: true,
       apiKey: "PERPLEXITY_API_KEY",
       native: {
         search: {
@@ -164,7 +171,7 @@ describe("config parsing", () => {
     expect(loaded.providers?.codex?.native?.additionalDirectories).toEqual([
       "notes",
     ]);
-    expect(loaded.providers?.exa?.enabled).toBe(true);
+    expect(loaded.providers?.exa?.apiKey).toBe("EXA_API_KEY");
     expect(loaded.providers?.gemini?.native?.apiVersion).toBe("v1alpha");
     expect(loaded.providers?.gemini?.policy?.requestTimeoutMs).toBe(45000);
     expect(loaded.providers?.gemini?.policy?.retryCount).toBe(5);
@@ -183,13 +190,12 @@ describe("config parsing", () => {
 
   it("maps legacy defaults into native and policy config blocks", () => {
     const loaded = parseConfig(
-      JSON.stringify({
-        version: 1,
-        providers: {
-          gemini: {
-            enabled: true,
-            apiKey: "GOOGLE_API_KEY",
-            defaults: {
+        JSON.stringify({
+          version: 2,
+          providers: {
+            gemini: {
+              apiKey: "GOOGLE_API_KEY",
+              defaults: {
               searchModel: "gemini-2.5-flash",
               requestTimeoutMs: 45000,
               retryCount: 5,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -60,20 +60,19 @@ describe("config parsing", () => {
     ).toThrow(/Unknown tools in test-config.json: summarize/);
   });
 
-  it("rejects legacy provider enablement", () => {
-    expect(() =>
-      parseConfig(
-        JSON.stringify({
-          version: 2,
-          providers: {
-            codex: {
-              enabled: true,
-            },
+  it("accepts provider enablement", () => {
+    const parsed = parseConfig(
+      JSON.stringify({
+        providers: {
+          codex: {
+            enabled: true,
           },
-        }),
-        "test-config.json",
-      ),
-    ).toThrow(/providers\.codex\.enabled/);
+        },
+      }),
+      "test-config.json",
+    );
+
+    expect(parsed.providers?.codex?.enabled).toBe(true);
   });
 
   it("rejects legacy provider-local tool toggles", () => {

--- a/test/contents-providers.test.ts
+++ b/test/contents-providers.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from "vitest";
+
+const {
+  exaCtorMock,
+  exaGetContentsMock,
+  parallelCtorMock,
+  parallelExtractMock,
+  valyuCtorMock,
+  valyuContentsMock,
+  valyuWaitForJobMock,
+} = vi.hoisted(() => ({
+  exaCtorMock: vi.fn(),
+  exaGetContentsMock: vi.fn(),
+  parallelCtorMock: vi.fn(),
+  parallelExtractMock: vi.fn(),
+  valyuCtorMock: vi.fn(),
+  valyuContentsMock: vi.fn(),
+  valyuWaitForJobMock: vi.fn(),
+}));
+
+vi.mock("exa-js", () => ({
+  Exa: exaCtorMock.mockImplementation(function MockExa() {
+    return {
+      search: vi.fn(),
+      getContents: exaGetContentsMock,
+      answer: vi.fn(),
+      research: {
+        create: vi.fn(),
+        get: vi.fn(),
+      },
+    };
+  }),
+}));
+
+vi.mock("parallel-web", () => ({
+  default: parallelCtorMock.mockImplementation(function MockParallel() {
+    return {
+      beta: {
+        search: vi.fn(),
+        extract: parallelExtractMock,
+      },
+    };
+  }),
+}));
+
+vi.mock("valyu-js", () => ({
+  Valyu: valyuCtorMock.mockImplementation(function MockValyu() {
+    return {
+      search: vi.fn(),
+      contents: valyuContentsMock,
+      waitForJob: valyuWaitForJobMock,
+      answer: vi.fn(),
+      deepresearch: {
+        create: vi.fn(),
+        status: vi.fn(),
+      },
+    };
+  }),
+}));
+
+describe("contents providers", () => {
+  it("keeps full Exa page text instead of collapsing to a snippet", async () => {
+    const { ExaProvider } = await import("../src/providers/exa.js");
+    const provider = new ExaProvider();
+    const longParagraph = "x".repeat(420);
+
+    exaGetContentsMock.mockResolvedValue({
+      results: [
+        {
+          title: "Example",
+          url: "https://example.com",
+          text: `Heading\n\n${longParagraph}`,
+          summary: "short summary",
+        },
+      ],
+    });
+
+    const result = await provider.contents(
+      ["https://example.com"],
+      undefined,
+      {
+        enabled: true,
+        apiKey: "literal-key",
+      },
+      { cwd: process.cwd() },
+    );
+
+    expect(result.text).toContain(longParagraph);
+    expect(result.text).toContain("   Heading");
+    expect(result.text).not.toContain("short summary");
+    expect((result.metadata as any)?.contentsEntries?.[0]?.body).toContain(
+      longParagraph,
+    );
+  });
+
+  it("requests full Parallel page contents by default and prefers full_content", async () => {
+    const { ParallelProvider } = await import("../src/providers/parallel.js");
+    const provider = new ParallelProvider();
+    const config = provider.createTemplate();
+    config.enabled = true;
+    config.apiKey = "literal-key";
+
+    parallelExtractMock.mockResolvedValue({
+      results: [
+        {
+          title: "Parallel Docs",
+          url: "https://parallel.ai/docs",
+          excerpts: ["short excerpt"],
+          full_content: "Section 1\n\nSection 2",
+        },
+      ],
+      errors: [],
+    });
+
+    const result = await provider.contents(
+      ["https://parallel.ai/docs"],
+      undefined,
+      config,
+      { cwd: process.cwd() },
+    );
+
+    expect(parallelExtractMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        urls: ["https://parallel.ai/docs"],
+        full_content: true,
+        excerpts: false,
+      }),
+      undefined,
+    );
+    expect(result.text).toContain("Section 1");
+    expect(result.text).toContain("Section 2");
+    expect(result.text).not.toContain("short excerpt");
+  });
+
+  it("prefers Valyu content over summaries and preserves line breaks", async () => {
+    const { ValyuProvider } = await import("../src/providers/valyu.js");
+    const provider = new ValyuProvider();
+
+    valyuContentsMock.mockResolvedValue({
+      success: true,
+      results: [
+        {
+          url: "https://valyu.ai/docs",
+          title: "Valyu Docs",
+          summary: "summary only",
+          content: "Intro\n\n- Item 1\n- Item 2",
+        },
+      ],
+    });
+
+    const result = await provider.contents(
+      ["https://valyu.ai/docs"],
+      undefined,
+      {
+        enabled: true,
+        apiKey: "literal-key",
+      },
+      { cwd: process.cwd() },
+    );
+
+    expect(result.text).toContain("Intro");
+    expect(result.text).toContain("- Item 1");
+    expect(result.text).toContain("- Item 2");
+    expect(result.text).not.toContain("summary only");
+    expect((result.metadata as any)?.contentsEntries?.[0]?.body).toBe(
+      "Intro\n\n- Item 1\n- Item 2",
+    );
+  });
+});

--- a/test/gemini-provider.test.ts
+++ b/test/gemini-provider.test.ts
@@ -583,33 +583,6 @@ describe("GeminiProvider contents", () => {
     });
   });
 
-  it("uses custom contentsModel from config", async () => {
-    const generateContent = vi.fn().mockResolvedValue({
-      text: "Extracted content.",
-      candidates: [],
-    });
-
-    const provider = createProvider({ models: { generateContent } });
-    const config: GeminiProviderConfig = {
-      enabled: true,
-      apiKey: "literal-key",
-      defaults: {
-        contentsModel: "gemini-2.5-pro",
-      },
-    };
-
-    await provider.contents(
-      ["https://example.com"],
-      undefined,
-      config,
-      createContext(),
-    );
-
-    expect(generateContent).toHaveBeenCalledWith(
-      expect.objectContaining({ model: "gemini-2.5-pro" }),
-    );
-  });
-
   it("passes provider-native generateContent config for contents", async () => {
     const generateContent = vi.fn().mockResolvedValue({
       text: "Result.",
@@ -674,11 +647,28 @@ describe("GeminiProvider contents", () => {
     });
   });
 
-  it("returns fallback text when response is empty", async () => {
-    const generateContent = vi.fn().mockResolvedValue({
-      text: "",
-      candidates: [],
-    });
+  it("falls back to the legacy prompt when the structured prompt returns nothing", async () => {
+    const generateContent = vi
+      .fn()
+      .mockResolvedValueOnce({
+        text: "",
+        candidates: [],
+      })
+      .mockResolvedValueOnce({
+        text: "# Example Page\n\nThis is the main content of the page.",
+        candidates: [
+          {
+            urlContextMetadata: {
+              urlMetadata: [
+                {
+                  retrievedUrl: "https://example.com",
+                  urlRetrievalStatus: "URL_RETRIEVAL_STATUS_SUCCESS",
+                },
+              ],
+            },
+          },
+        ],
+      });
 
     const provider = createProvider({ models: { generateContent } });
     const response = await provider.contents(
@@ -688,7 +678,94 @@ describe("GeminiProvider contents", () => {
       createContext(),
     );
 
-    expect(response.text).toBe("No contents extracted.");
+    expect(generateContent).toHaveBeenCalledTimes(2);
+    expect(response.text).toContain("This is the main content of the page.");
+    expect(response.summary).toBe("1 of 1 URL(s) extracted via Gemini");
+  });
+
+  it("throws on an empty response so the caller can retry", async () => {
+    const generateContent = vi.fn().mockResolvedValue({
+      text: "",
+      candidates: [],
+    });
+
+    const provider = createProvider({ models: { generateContent } });
+
+    await expect(
+      provider.contents(
+        ["https://example.com"],
+        undefined,
+        createConfig(),
+        createContext(),
+      ),
+    ).rejects.toThrow(
+      "Gemini returned an empty URL Context response. Retrying may succeed.",
+    );
+    expect(generateContent).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws on empty text even when urlContext reports a successful retrieval", async () => {
+    const generateContent = vi.fn().mockResolvedValue({
+      text: "",
+      candidates: [
+        {
+          urlContextMetadata: {
+            urlMetadata: [
+              {
+                retrievedUrl: "https://example.com",
+                urlRetrievalStatus: "URL_RETRIEVAL_STATUS_SUCCESS",
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const provider = createProvider({ models: { generateContent } });
+
+    await expect(
+      provider.contents(
+        ["https://example.com"],
+        undefined,
+        createConfig(),
+        createContext(),
+      ),
+    ).rejects.toThrow(
+      "Gemini returned an empty URL Context response. Retrying may succeed.",
+    );
+    expect(generateContent).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps surfacing retrieval failures when Gemini returns no text", async () => {
+    const generateContent = vi.fn().mockResolvedValue({
+      text: "",
+      candidates: [
+        {
+          urlContextMetadata: {
+            urlMetadata: [
+              {
+                retrievedUrl: "https://paywall.example.com",
+                urlRetrievalStatus: "URL_RETRIEVAL_STATUS_PAYWALL",
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const provider = createProvider({ models: { generateContent } });
+    const response = await provider.contents(
+      ["https://paywall.example.com"],
+      undefined,
+      createConfig(),
+      createContext(),
+    );
+
+    expect(response.text).toContain("Retrieval issues:");
+    expect(response.text).toContain(
+      "https://paywall.example.com: URL_RETRIEVAL_STATUS_PAYWALL",
+    );
+    expect(response.summary).toBe("0 of 1 URL(s) extracted via Gemini");
   });
 });
 

--- a/test/provider-resolution.test.ts
+++ b/test/provider-resolution.test.ts
@@ -172,7 +172,6 @@ function createConfig(
   overrides: Partial<WebProvidersConfig> = {},
 ): WebProvidersConfig {
   return {
-    version: 2,
     tools: overrides.tools,
     providers: overrides.providers,
   };

--- a/test/provider-resolution.test.ts
+++ b/test/provider-resolution.test.ts
@@ -60,184 +60,107 @@ describe("provider resolution", () => {
   it("uses the explicit provider when it is configured", () => {
     process.env.EXA_API_KEY = "test-key";
 
-    const config: WebProvidersConfig = {
-      version: 1,
+    const config = createConfig({
       providers: {
         exa: {
-          enabled: true,
           apiKey: "EXA_API_KEY",
         },
       },
-    };
+    });
 
     const provider = resolveProviderChoice(config, "exa", process.cwd());
     expect(provider.id).toBe("exa");
   });
 
-  it("rejects Claude when it is explicitly enabled without local auth", () => {
-    const config: WebProvidersConfig = {
-      version: 1,
+  it("rejects Claude when it is explicitly selected without local auth", () => {
+    const config = createConfig({
       providers: {
-        claude: {
-          enabled: true,
-        },
+        claude: {},
       },
-    };
+    });
 
     expect(() =>
       resolveProviderChoice(config, "claude", process.cwd()),
     ).toThrow(/Provider 'claude' is not available: missing Claude auth/);
   });
 
-  it("prefers explicitly enabled providers in alphabetical order", () => {
+  it("uses the mapped search provider", () => {
     process.env.EXA_API_KEY = "test-key";
-    process.env.GOOGLE_API_KEY = "test-key";
 
-    const config: WebProvidersConfig = {
-      version: 1,
+    const config = createConfig({
+      tools: {
+        search: "exa",
+      },
       providers: {
-        codex: {
-          enabled: false,
-        },
         exa: {
-          enabled: true,
           apiKey: "EXA_API_KEY",
         },
-        gemini: {
-          enabled: true,
-          apiKey: "GOOGLE_API_KEY",
-        },
-        valyu: {
-          enabled: true,
-          apiKey: "VALYU_API_KEY",
-        },
       },
-    };
+    });
 
-    const provider = resolveProviderChoice(config, undefined, process.cwd());
+    const provider = resolveProviderChoice(config, process.cwd());
     expect(provider.id).toBe("exa");
   });
 
-  it("falls back to implicit Codex search when no provider is explicitly enabled", () => {
+  it("does not fall back when search is unmapped", () => {
     process.env.CODEX_API_KEY = "test-key";
 
-    const config: WebProvidersConfig = {
-      version: 1,
-      providers: {
-        exa: {
-          enabled: false,
-          apiKey: "EXA_API_KEY",
-        },
-      },
-    };
-
-    const provider = resolveProviderChoice(config, undefined, process.cwd());
-    expect(provider.id).toBe("codex");
+    expect(() =>
+      resolveProviderChoice(createConfig(), process.cwd()),
+    ).toThrow(/No provider is configured for 'search'/);
   });
 
-  it("allows explicit Codex search without a config file entry", () => {
-    process.env.CODEX_API_KEY = "test-key";
+  it("rejects an unavailable mapped provider", () => {
+    const config = createConfig({
+      tools: {
+        search: "codex",
+      },
+      providers: {
+        codex: {},
+      },
+    });
 
-    const provider = resolveProviderChoice(
-      { version: 1 },
-      "codex",
-      process.cwd(),
+    expect(() => resolveProviderChoice(config, process.cwd())).toThrow(
+      /Provider 'codex' is not available: missing Codex auth/,
     );
-    expect(provider.id).toBe("codex");
   });
 
-  it("respects an explicitly enabled non-Codex provider over the implicit Codex fallback", () => {
-    process.env.CODEX_API_KEY = "test-key";
-    process.env.EXA_API_KEY = "test-key";
-
-    const config: WebProvidersConfig = {
-      version: 1,
-      providers: {
-        exa: {
-          enabled: true,
-          apiKey: "EXA_API_KEY",
-        },
-      },
-    };
-
-    const provider = resolveProviderChoice(config, undefined, process.cwd());
-    expect(provider.id).toBe("exa");
-  });
-
-  it("rejects Codex fallback when the CLI has no configured auth", () => {
-    expect(() =>
-      resolveProviderChoice({ version: 1 }, undefined, process.cwd()),
-    ).toThrow(/No provider is configured for 'search'/);
-  });
-
-  it("does not implicitly fall back to Claude when Codex auth is missing", () => {
-    mockClaudeWithoutQueryAccess();
-
-    expect(() =>
-      resolveProviderChoice({ version: 1 }, undefined, process.cwd()),
-    ).toThrow(/No provider is configured for 'search'/);
-  });
-
-  it("skips providers that have the requested tool disabled", () => {
-    process.env.EXA_API_KEY = "test-key";
+  it("uses the mapped contents provider", () => {
     process.env.PARALLEL_API_KEY = "test-key";
-    process.env.VALYU_API_KEY = "test-key";
 
-    const config: WebProvidersConfig = {
-      version: 1,
+    const config = createConfig({
+      tools: {
+        contents: "parallel",
+      },
       providers: {
-        exa: {
-          enabled: true,
-          apiKey: "EXA_API_KEY",
-          tools: {
-            contents: false,
-          },
-        },
         parallel: {
-          enabled: true,
           apiKey: "PARALLEL_API_KEY",
-          tools: {
-            contents: true,
-          },
-        },
-        valyu: {
-          enabled: true,
-          apiKey: "VALYU_API_KEY",
-          tools: {
-            contents: true,
-          },
         },
       },
-    };
+    });
 
     const provider = resolveProviderForCapability(
       config,
-      undefined,
       process.cwd(),
       "contents",
     );
     expect(provider.id).toBe("parallel");
   });
 
-  it("treats Perplexity research as an explicit blocking-provider exception", () => {
+  it("treats Perplexity research as a direct explicit-provider selection", () => {
     process.env.PERPLEXITY_API_KEY = "test-key";
 
-    const config: WebProvidersConfig = {
-      version: 1,
+    const config = createConfig({
       providers: {
         perplexity: {
-          enabled: true,
           apiKey: "PERPLEXITY_API_KEY",
-          tools: {
-            research: true,
-          },
         },
       },
-    };
+    });
 
     const provider = resolveProviderForCapability(
       config,
-      undefined,
+      "perplexity",
       process.cwd(),
       "research",
     );
@@ -245,20 +168,12 @@ describe("provider resolution", () => {
   });
 });
 
-function mockClaudeAvailable(): void {
-  execFileSyncMock.mockImplementation((_command, args: string[]) => {
-    if (args.includes("auth") && args.includes("status")) {
-      return '{"loggedIn":true,"authMethod":"claude.ai"}';
-    }
-    throw new Error(`Unexpected Claude command: ${args.join(" ")}`);
-  });
-}
-
-function mockClaudeWithoutQueryAccess(): void {
-  execFileSyncMock.mockImplementation((_command, args: string[]) => {
-    if (args.includes("auth") && args.includes("status")) {
-      return '{"loggedIn":true,"authMethod":"claude.ai"}';
-    }
-    throw new Error(`Unexpected Claude command: ${args.join(" ")}`);
-  });
+function createConfig(
+  overrides: Partial<WebProvidersConfig> = {},
+): WebProvidersConfig {
+  return {
+    version: 2,
+    tools: overrides.tools,
+    providers: overrides.providers,
+  };
 }

--- a/test/provider-resolution.test.ts
+++ b/test/provider-resolution.test.ts
@@ -19,6 +19,7 @@ vi.mock("node:child_process", async () => {
 });
 
 import {
+  getEffectiveProviderConfig,
   resolveProviderChoice,
   resolveProviderForCapability,
 } from "../src/provider-resolution.js";
@@ -105,9 +106,9 @@ describe("provider resolution", () => {
   it("does not fall back when search is unmapped", () => {
     process.env.CODEX_API_KEY = "test-key";
 
-    expect(() =>
-      resolveProviderChoice(createConfig(), process.cwd()),
-    ).toThrow(/No provider is configured for 'search'/);
+    expect(() => resolveProviderChoice(createConfig(), process.cwd())).toThrow(
+      /No provider is configured for 'search'/,
+    );
   });
 
   it("rejects an unavailable mapped provider", () => {
@@ -166,6 +167,36 @@ describe("provider resolution", () => {
     );
     expect(provider.id).toBe("perplexity");
   });
+
+  it("merges shared generic settings into the effective provider policy", () => {
+    const config = createConfig({
+      genericSettings: {
+        requestTimeoutMs: 30000,
+        retryCount: 3,
+        retryDelayMs: 2000,
+        researchPollIntervalMs: 3000,
+        researchTimeoutMs: 21600000,
+        researchMaxConsecutivePollErrors: 3,
+      },
+      providers: {
+        exa: {
+          policy: {
+            retryCount: 5,
+            researchPollIntervalMs: 4000,
+          },
+        },
+      },
+    });
+
+    expect(getEffectiveProviderConfig(config, "exa")?.policy).toEqual({
+      requestTimeoutMs: 30000,
+      retryCount: 5,
+      retryDelayMs: 2000,
+      researchPollIntervalMs: 4000,
+      researchTimeoutMs: 21600000,
+      researchMaxConsecutivePollErrors: 3,
+    });
+  });
 });
 
 function createConfig(
@@ -173,6 +204,7 @@ function createConfig(
 ): WebProvidersConfig {
   return {
     tools: overrides.tools,
+    genericSettings: overrides.genericSettings,
     providers: overrides.providers,
   };
 }

--- a/test/provider-resolution.test.ts
+++ b/test/provider-resolution.test.ts
@@ -69,7 +69,7 @@ describe("provider resolution", () => {
       },
     });
 
-    const provider = resolveProviderChoice(config, "exa", process.cwd());
+    const provider = resolveProviderChoice(config, process.cwd(), "exa");
     expect(provider.id).toBe("exa");
   });
 
@@ -81,7 +81,7 @@ describe("provider resolution", () => {
     });
 
     expect(() =>
-      resolveProviderChoice(config, "claude", process.cwd()),
+      resolveProviderChoice(config, process.cwd(), "claude"),
     ).toThrow(/Provider 'claude' is not available: missing Claude auth/);
   });
 
@@ -161,9 +161,9 @@ describe("provider resolution", () => {
 
     const provider = resolveProviderForCapability(
       config,
-      "perplexity",
       process.cwd(),
       "research",
+      "perplexity",
     );
     expect(provider.id).toBe("perplexity");
   });

--- a/test/provider-tool-output.test.ts
+++ b/test/provider-tool-output.test.ts
@@ -796,7 +796,7 @@ describe("provider tool output", () => {
       "Provider-specific extraction options. Local execution controls: requestTimeoutMs, retryCount, retryDelayMs.",
     );
     expect(__test__.describeOptionsField("search", ["exa"])).toBe(
-      "Provider-specific search options. Local execution controls: requestTimeoutMs, retryCount, retryDelayMs. Local orchestration options may include prefetch={ enabled, maxUrls, provider, ttlMs, contentsOptions }.",
+      "Provider-specific search options. Local execution controls: requestTimeoutMs, retryCount, retryDelayMs. Local orchestration options may include prefetch={ provider, maxUrls, ttlMs, contentsOptions }. Prefetch runs only when prefetch.provider is set.",
     );
     expect(
       __test__.describeOptionsField("research", [

--- a/test/provider-tool-output.test.ts
+++ b/test/provider-tool-output.test.ts
@@ -18,7 +18,6 @@ afterEach(async () => {
 describe("provider tool output", () => {
   it("groups multi-query search output into per-query sections", async () => {
     const config: WebProvidersConfig = {
-      version: 1,
       providers: {
         exa: {
           enabled: true,
@@ -96,7 +95,6 @@ describe("provider tool output", () => {
 
   it("preserves successful search results when one query in a batch fails", async () => {
     const config: WebProvidersConfig = {
-      version: 1,
       providers: {
         exa: {
           enabled: true,
@@ -160,7 +158,6 @@ describe("provider tool output", () => {
 
   it("fails the batch when every query fails", async () => {
     const config: WebProvidersConfig = {
-      version: 1,
       providers: {
         exa: {
           enabled: true,
@@ -207,7 +204,6 @@ describe("provider tool output", () => {
 
   it("rejects a whitespace-only query in the array", async () => {
     const config: WebProvidersConfig = {
-      version: 1,
       providers: {
         exa: {
           enabled: true,
@@ -232,7 +228,6 @@ describe("provider tool output", () => {
 
   it("rejects an empty queries array", async () => {
     const config: WebProvidersConfig = {
-      version: 1,
       providers: {
         exa: {
           enabled: true,
@@ -257,7 +252,6 @@ describe("provider tool output", () => {
 
   it("groups multi-query answer output into per-question sections", async () => {
     const config: WebProvidersConfig = {
-      version: 1,
       providers: {
         gemini: {
           enabled: true,
@@ -327,7 +321,6 @@ describe("provider tool output", () => {
 
   it("preserves successful answers when one query in a batch fails", async () => {
     const config: WebProvidersConfig = {
-      version: 1,
       providers: {
         gemini: {
           enabled: true,
@@ -390,7 +383,6 @@ describe("provider tool output", () => {
 
   it("fails the answer batch when every query fails", async () => {
     const config: WebProvidersConfig = {
-      version: 1,
       providers: {
         gemini: {
           enabled: true,
@@ -439,7 +431,6 @@ describe("provider tool output", () => {
 
   it("supports a single-question batch for web_answer", async () => {
     const config: WebProvidersConfig = {
-      version: 1,
       providers: {
         gemini: {
           enabled: true,
@@ -487,7 +478,6 @@ describe("provider tool output", () => {
 
   it("truncates oversized non-search output and saves the full response", async () => {
     const config: WebProvidersConfig = {
-      version: 1,
       providers: {
         exa: {
           enabled: true,
@@ -537,7 +527,6 @@ describe("provider tool output", () => {
 
     try {
       const config: WebProvidersConfig = {
-        version: 1,
         providers: {
           perplexity: {
             enabled: true,
@@ -593,7 +582,6 @@ describe("provider tool output", () => {
 
   it("rejects lifecycle-only options for streaming foreground Perplexity research", async () => {
     const config: WebProvidersConfig = {
-      version: 1,
       providers: {
         perplexity: {
           enabled: true,
@@ -626,7 +614,6 @@ describe("provider tool output", () => {
 
     try {
       const config: WebProvidersConfig = {
-        version: 1,
         providers: {
           perplexity: {
             enabled: true,
@@ -689,7 +676,6 @@ describe("provider tool output", () => {
 
   it("rejects requestTimeoutMs for research providers that cannot safely enforce it", async () => {
     const config: WebProvidersConfig = {
-      version: 1,
       providers: {
         exa: {
           enabled: true,
@@ -732,7 +718,6 @@ describe("provider tool output", () => {
 
   it("rejects malformed local execution control fields", async () => {
     const config: WebProvidersConfig = {
-      version: 1,
       providers: {
         exa: {
           enabled: true,
@@ -769,7 +754,6 @@ describe("provider tool output", () => {
 
   it("rejects research-only execution controls on non-research tools", async () => {
     const config: WebProvidersConfig = {
-      version: 1,
       providers: {
         exa: {
           enabled: true,
@@ -827,7 +811,6 @@ describe("provider tool output", () => {
 
   it("rejects removed resumeInteractionId compatibility for research", async () => {
     const config: WebProvidersConfig = {
-      version: 1,
       providers: {
         gemini: {
           enabled: true,

--- a/test/provider-tool-output.test.ts
+++ b/test/provider-tool-output.test.ts
@@ -79,8 +79,12 @@ describe("provider tool output", () => {
 
     expect(result.content[0]?.text).toContain('Query 1: "exa sdk"');
     expect(result.content[0]?.text).toContain('Query 2: "exa pricing"');
-    expect(result.content[0]?.text).toContain("1. Exa SDK");
-    expect(result.content[0]?.text).toContain("2. Exa API Plans");
+    expect(result.content[0]?.text).toContain(
+      "1. [Exa SDK](<https://exa.ai/sdk>)",
+    );
+    expect(result.content[0]?.text).toContain(
+      "2. [Exa API Plans](<https://exa.ai/plans>)",
+    );
     expect(result.details).toEqual({
       tool: "web_search",
       provider: "exa",
@@ -140,7 +144,9 @@ describe("provider tool output", () => {
     });
 
     expect(result.content[0]?.text).toContain('Query 1: "exa sdk"');
-    expect(result.content[0]?.text).toContain("1. Exa SDK");
+    expect(result.content[0]?.text).toContain(
+      "1. [Exa SDK](<https://exa.ai/sdk>)",
+    );
     expect(result.content[0]?.text).toContain('Query 2: "exa pricing"');
     expect(result.content[0]?.text).toContain("Search failed: rate limited");
     expect(result.details).toEqual({
@@ -467,7 +473,7 @@ describe("provider tool output", () => {
     });
 
     expect(result.content[0]?.text).toBe(
-      "Tenzir is used for detection engineering and SIEM migration.",
+      '## "What are common Tenzir use cases?"\n\nTenzir is used for detection engineering and SIEM migration.',
     );
     expect(result.details).toEqual({
       tool: "web_answer",

--- a/test/rendering.test.ts
+++ b/test/rendering.test.ts
@@ -8,7 +8,6 @@ describe("web_search renderer", () => {
       __test__.renderCallHeader(
         {
           queries: ["latest exa typescript sdk docs"],
-          provider: "codex",
           maxResults: 5,
         },
         createTheme(),
@@ -27,7 +26,6 @@ describe("web_search renderer", () => {
       __test__.renderCallHeader(
         {
           queries: ["latest exa typescript sdk docs"],
-          provider: "codex",
           maxResults: 7,
         },
         createTheme(),
@@ -49,7 +47,6 @@ describe("web_search renderer", () => {
           queries: [
             "What are the main use cases of Tenzir, the security data pipeline platform? Include modern SOC and AI workflows.",
           ],
-          provider: "gemini",
           maxResults: 10,
         },
         createTheme(),
@@ -67,7 +64,6 @@ describe("web_search renderer", () => {
       __test__.renderCallHeader(
         {
           queries: ["exa sdk", "exa pricing", "exa api"],
-          provider: "exa",
           maxResults: 4,
         },
         createTheme(),
@@ -151,7 +147,6 @@ describe("web_answer renderer", () => {
       __test__.renderQuestionCallHeader(
         {
           queries: ["What are common Tenzir use cases?"],
-          provider: "gemini",
         },
         createTheme(),
       ),
@@ -172,7 +167,6 @@ describe("web_answer renderer", () => {
             "What are common Tenzir use cases?",
             "How does Tenzir help with SIEM migration?",
           ],
-          provider: "gemini",
         },
         createTheme(),
       ),
@@ -193,7 +187,6 @@ describe("web_research renderer", () => {
         {
           input:
             "Tenzir use cases: what problems does Tenzir solve, who uses it, and in what scenarios?",
-          provider: "gemini",
         },
         createTheme(),
       ),

--- a/test/rendering.test.ts
+++ b/test/rendering.test.ts
@@ -3,7 +3,26 @@ import { describe, expect, it } from "vitest";
 import { __test__ } from "../src/index.js";
 
 describe("web_search renderer", () => {
-  it("shows a compact call header with a single query and call details", () => {
+  it("shows a compact single-query header and hides default details", () => {
+    const rendered = renderComponentText(
+      __test__.renderCallHeader(
+        {
+          queries: ["latest exa typescript sdk docs"],
+          provider: "codex",
+          maxResults: 5,
+        },
+        createTheme(),
+      ),
+      120,
+    );
+
+    expect(rendered).toContain('web_search "latest exa typescript sdk docs"');
+    expect(rendered).not.toContain("provider=");
+    expect(rendered).not.toContain("maxResults=");
+    expect(rendered).not.toContain("(max");
+  });
+
+  it("shows non-default maxResults as a compact header suffix", () => {
     const rendered = renderComponentText(
       __test__.renderCallHeader(
         {
@@ -16,8 +35,11 @@ describe("web_search renderer", () => {
       120,
     );
 
-    expect(rendered).toContain('web_search "latest exa typescript sdk docs"');
-    expect(rendered).toContain("provider=codex maxResults=7");
+    expect(rendered).toContain(
+      'web_search "latest exa typescript sdk docs" (max 7)',
+    );
+    expect(rendered).not.toContain("provider=");
+    expect(rendered).not.toContain("maxResults=");
   });
 
   it("shows an ellipsis when the single-query preview is truncated", () => {
@@ -53,15 +75,15 @@ describe("web_search renderer", () => {
       120,
     );
 
-    expect(rendered).toContain("web_search");
+    expect(rendered).toContain("web_search (max 4)");
     expect(rendered).toContain("  exa sdk");
     expect(rendered).toContain("  exa pricing");
     expect(rendered).toContain("  exa api");
-    expect(rendered).not.toContain("3 queries");
-    expect(rendered).toContain("provider=exa maxResults=4");
+    expect(rendered).not.toContain("provider=");
+    expect(rendered).not.toContain("maxResults=");
   });
 
-  it("collapses search results to the first line until expanded", () => {
+  it("summarizes single-query search results with the resolved provider", () => {
     const summary = renderComponentText(
       __test__.renderCollapsedSearchSummary(
         {
@@ -77,7 +99,7 @@ describe("web_search renderer", () => {
       120,
     );
 
-    expect(summary).toContain("1. Exa TypeScript SDK");
+    expect(summary).toContain("3 results via exa");
     expect(summary).toContain("to expand");
     expect(summary).not.toContain("https://exa.ai/docs");
   });
@@ -124,7 +146,7 @@ describe("web_search renderer", () => {
 });
 
 describe("web_answer renderer", () => {
-  it("renders a single question on its own line below the tool name", () => {
+  it("renders a single question on the same line as the tool name", () => {
     const rendered = renderComponentText(
       __test__.renderQuestionCallHeader(
         {
@@ -136,15 +158,13 @@ describe("web_answer renderer", () => {
       120,
     );
 
-    expect(rendered).toContain("web_answer");
-    expect(rendered).toContain("  What are common Tenzir use cases?");
-    expect(rendered).toContain("provider=gemini");
-    expect(rendered).not.toContain(
+    expect(rendered).toContain(
       'web_answer "What are common Tenzir use cases?"',
     );
+    expect(rendered).not.toContain("provider=");
   });
 
-  it("renders multiple questions on separate lines", () => {
+  it("renders multiple questions on separate lines without provider noise", () => {
     const rendered = renderComponentText(
       __test__.renderQuestionCallHeader(
         {
@@ -162,7 +182,172 @@ describe("web_answer renderer", () => {
     expect(rendered).toContain("web_answer");
     expect(rendered).toContain("  What are common Tenzir use cases?");
     expect(rendered).toContain("  How does Tenzir help with SIEM migration?");
-    expect(rendered).toContain("provider=gemini");
+    expect(rendered).not.toContain("provider=");
+  });
+});
+
+describe("web_research renderer", () => {
+  it("renders the research brief on its own line", () => {
+    const rendered = renderComponentText(
+      __test__.renderResearchCallHeader(
+        {
+          input:
+            "Tenzir use cases: what problems does Tenzir solve, who uses it, and in what scenarios?",
+          provider: "gemini",
+        },
+        createTheme(),
+      ),
+      120,
+    );
+
+    expect(rendered.startsWith("web_research")).toBe(true);
+    expect(rendered).toContain(
+      "  Tenzir use cases: what problems does Tenzir solve, who uses it, and in what scenarios?",
+    );
+    expect(rendered).not.toContain('web_research "');
+    expect(rendered).not.toContain("provider=");
+  });
+});
+
+describe("partial tool rendering", () => {
+  it("shows web_search progress updates in warning text", () => {
+    const rendered = renderComponentText(
+      __test__.renderSearchToolResult(
+        {
+          content: [{ type: "text", text: "Searching Exa for: exa sdk" }],
+          details: {},
+        },
+        false,
+        true,
+        createTheme(),
+      )!,
+      120,
+    );
+
+    expect(rendered).toContain("Searching Exa for: exa sdk");
+  });
+
+  it("shows provider tool progress updates in warning text", () => {
+    const rendered = renderComponentText(
+      __test__.renderProviderToolResult(
+        {
+          content: [
+            { type: "text", text: "Fetching contents from Exa for 2 URL(s)" },
+          ],
+          details: {},
+        },
+        false,
+        true,
+        "web_contents failed",
+        createTheme(),
+      )!,
+      120,
+    );
+
+    expect(rendered).toContain("Fetching contents from Exa for 2 URL(s)");
+  });
+});
+
+describe("provider tool summaries", () => {
+  it("uses shorter collapsed wording for contents summaries", () => {
+    const summary = __test__.renderCollapsedProviderToolSummary(
+      {
+        tool: "web_contents",
+        provider: "gemini",
+        itemCount: 2,
+        summary: "2 pages extracted",
+      },
+      undefined,
+    );
+
+    expect(summary).toBe("2 pages via gemini");
+  });
+
+  it("keeps the dedicated multi-question answer summary format", () => {
+    const summary = __test__.renderCollapsedProviderToolSummary(
+      {
+        tool: "web_answer",
+        provider: "gemini",
+        queryCount: 3,
+        failedQueryCount: 1,
+      },
+      undefined,
+    );
+
+    expect(summary).toBe("3 questions via gemini, 1 failed");
+  });
+
+  it("normalizes research summaries without duplicating the provider", () => {
+    const summary = __test__.renderCollapsedProviderToolSummary(
+      {
+        tool: "web_research",
+        provider: "gemini",
+        summary: "Research via Gemini",
+      },
+      undefined,
+    );
+
+    expect(summary).toBe("Research via Gemini");
+  });
+});
+
+describe("web_search markdown formatting", () => {
+  it("formats each query as an H2 with proper spacing", () => {
+    const rendered = __test__.formatSearchResponses([
+      {
+        query: "site:tenzir.com/blog Tenzir use cases",
+        response: {
+          provider: "gemini",
+          results: [
+            {
+              title: "tenzir.com",
+              url: "https://tenzir.com/",
+              snippet: "Security data pipelines for detection and response.",
+            },
+          ],
+        },
+      },
+      {
+        query: "site:tenzir.com/product integrations",
+        error: "Gemini search request timed out after 12s.",
+      },
+    ]);
+
+    expect(rendered).toContain(
+      '## Query 1: "site:tenzir.com/blog Tenzir use cases"\n\n1. [tenzir.com](<https://tenzir.com/>)',
+    );
+    expect(rendered).toContain(
+      "Security data pipelines for detection and response.",
+    );
+    expect(rendered).toContain(
+      '## Query 2: "site:tenzir.com/product integrations"\n\nSearch failed: Gemini search request timed out after 12s.',
+    );
+  });
+});
+
+describe("web_answer markdown formatting", () => {
+  it("formats each question as an H2 with proper spacing", () => {
+    const rendered = __test__.formatAnswerResponses([
+      {
+        query: "What are the main use cases for Tenzir?",
+        response: {
+          provider: "gemini",
+          text: "Tenzir helps route, normalize, and enrich security data.\n\n- Reduce SIEM cost\n- Improve detections",
+        },
+      },
+      {
+        query: "What problems does Tenzir solve?",
+        error: "Gemini answer request timed out after 12s.",
+      },
+    ]);
+
+    expect(rendered).toContain(
+      '## Question 1: "What are the main use cases for Tenzir?"\n\nTenzir helps route, normalize, and enrich security data.',
+    );
+    expect(rendered).toContain("- Reduce SIEM cost");
+    expect(rendered).toContain(
+      '## Question 2: "What problems does Tenzir solve?"\n\nAnswer failed: Gemini answer request timed out after 12s.',
+    );
   });
 });
 

--- a/test/research-lifecycle-providers.test.ts
+++ b/test/research-lifecycle-providers.test.ts
@@ -68,7 +68,6 @@ describe("research lifecycle providers", () => {
     const promise = __test__.executeProviderTool({
       capability: "research",
       config: {
-        version: 1,
         providers: {
           exa: {
             enabled: true,
@@ -117,7 +116,6 @@ describe("research lifecycle providers", () => {
     const promise = __test__.executeProviderTool({
       capability: "research",
       config: {
-        version: 1,
         providers: {
           exa: {
             enabled: true,
@@ -163,7 +161,6 @@ describe("research lifecycle providers", () => {
     const promise = __test__.executeProviderTool({
       capability: "research",
       config: {
-        version: 1,
         providers: {
           exa: {
             enabled: true,
@@ -211,7 +208,6 @@ describe("research lifecycle providers", () => {
     const promise = __test__.executeProviderTool({
       capability: "research",
       config: {
-        version: 1,
         providers: {
           exa: {
             enabled: true,
@@ -268,7 +264,6 @@ describe("research lifecycle providers", () => {
     const promise = __test__.executeProviderTool({
       capability: "research",
       config: {
-        version: 1,
         providers: {
           valyu: {
             enabled: true,

--- a/test/search-prefetch.test.ts
+++ b/test/search-prefetch.test.ts
@@ -41,7 +41,6 @@ describe("search contents prefetch", () => {
     const { __test__ } = await import("../src/index.js");
     const { getPrefetchStatus } = await import("../src/prefetch-manager.js");
     const config = {
-      version: 2,
       tools: {
         contents: "exa",
       },
@@ -178,7 +177,6 @@ describe("search contents prefetch", () => {
   it("reuses partial cache hits and fetches only the missing URLs", async () => {
     const { __test__ } = await import("../src/index.js");
     const config = {
-      version: 2,
       tools: {
         contents: "exa",
       },
@@ -239,7 +237,6 @@ describe("search contents prefetch", () => {
   it("reuses earlier live reads without refetching and re-renders them in the current request order", async () => {
     const { __test__ } = await import("../src/index.js");
     const config = {
-      version: 2,
       tools: {
         contents: "exa",
       },
@@ -300,7 +297,6 @@ describe("search contents prefetch", () => {
       const { __test__ } = await import("../src/index.js");
       const { getPrefetchStatus } = await import("../src/prefetch-manager.js");
       const config = {
-        version: 2,
         tools: {
           contents: "exa",
         },

--- a/test/search-prefetch.test.ts
+++ b/test/search-prefetch.test.ts
@@ -41,10 +41,12 @@ describe("search contents prefetch", () => {
     const { __test__ } = await import("../src/index.js");
     const { getPrefetchStatus } = await import("../src/prefetch-manager.js");
     const config = {
-      version: 1,
+      version: 2,
+      tools: {
+        contents: "exa",
+      },
       providers: {
         exa: {
-          enabled: true,
           apiKey: "literal-key",
         },
       },
@@ -176,10 +178,12 @@ describe("search contents prefetch", () => {
   it("reuses partial cache hits and fetches only the missing URLs", async () => {
     const { __test__ } = await import("../src/index.js");
     const config = {
-      version: 1,
+      version: 2,
+      tools: {
+        contents: "exa",
+      },
       providers: {
         exa: {
-          enabled: true,
           apiKey: "literal-key",
         },
       },
@@ -235,10 +239,12 @@ describe("search contents prefetch", () => {
   it("reuses earlier live reads without refetching and re-renders them in the current request order", async () => {
     const { __test__ } = await import("../src/index.js");
     const config = {
-      version: 1,
+      version: 2,
+      tools: {
+        contents: "exa",
+      },
       providers: {
         exa: {
-          enabled: true,
           apiKey: "literal-key",
         },
       },
@@ -294,10 +300,12 @@ describe("search contents prefetch", () => {
       const { __test__ } = await import("../src/index.js");
       const { getPrefetchStatus } = await import("../src/prefetch-manager.js");
       const config = {
-        version: 1,
+        version: 2,
+        tools: {
+          contents: "exa",
+        },
         providers: {
           exa: {
-            enabled: true,
             apiKey: "literal-key",
           },
         },

--- a/test/search-prefetch.test.ts
+++ b/test/search-prefetch.test.ts
@@ -37,7 +37,7 @@ afterEach(async () => {
 });
 
 describe("search contents prefetch", () => {
-  it("starts background contents prefetching, reuses prefetched per-URL entries, and works without an explicit provider", async () => {
+  it("starts background contents prefetching and reuses prefetched per-URL entries when prefetch.provider is set", async () => {
     const { __test__ } = await import("../src/index.js");
     const { getPrefetchStatus } = await import("../src/prefetch-manager.js");
     const config = {
@@ -81,8 +81,8 @@ describe("search contents prefetch", () => {
       onUpdate: undefined,
       options: {
         prefetch: {
-          enabled: true,
           maxUrls: 2,
+          provider: "exa",
         },
       },
       maxResults: 2,
@@ -128,7 +128,7 @@ describe("search contents prefetch", () => {
     );
 
     // A second web_contents call should be able to reuse a prefetched subset
-    // even when no explicit provider is supplied.
+    // through the configured contents provider.
     const cachedResult = await __test__.executeProviderTool({
       capability: "contents",
       config,
@@ -172,6 +172,158 @@ describe("search contents prefetch", () => {
         }),
       ]);
     });
+  });
+
+  it("does not start prefetching without an explicit prefetch.provider", async () => {
+    const { __test__ } = await import("../src/index.js");
+    const config = {
+      tools: {
+        contents: "exa",
+      },
+      providers: {
+        exa: {
+          apiKey: "literal-key",
+        },
+      },
+    } as const;
+
+    exaSearchMock.mockResolvedValue({
+      results: [
+        {
+          title: "Exa SDK",
+          url: "https://exa.ai/sdk",
+          text: "SDK docs",
+        },
+      ],
+    });
+
+    const searchResult = await __test__.executeSearchTool({
+      config,
+      explicitProvider: "exa",
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: {
+        prefetch: {
+          maxUrls: 1,
+        },
+      },
+      maxResults: 1,
+      queries: ["exa docs"],
+    });
+
+    expect(searchResult.content[0]?.text ?? "").not.toContain(
+      "Background contents prefetch started via",
+    );
+    expect(exaGetContentsMock).not.toHaveBeenCalled();
+  });
+
+  it("uses persisted search prefetch defaults when no per-call prefetch override is provided", async () => {
+    const { __test__ } = await import("../src/index.js");
+    const config = {
+      tools: {
+        contents: "exa",
+      },
+      toolSettings: {
+        search: {
+          prefetch: {
+            provider: "exa",
+            maxUrls: 1,
+          },
+        },
+      },
+      providers: {
+        exa: {
+          apiKey: "literal-key",
+        },
+      },
+    } as const;
+
+    exaSearchMock.mockResolvedValue({
+      results: [
+        {
+          title: "Exa SDK",
+          url: "https://exa.ai/sdk",
+          text: "SDK docs",
+        },
+      ],
+    });
+    exaGetContentsMock.mockResolvedValue({
+      results: [
+        {
+          title: "Exa SDK",
+          url: "https://exa.ai/sdk",
+          text: "Fetched body for https://exa.ai/sdk",
+        },
+      ],
+    });
+
+    const searchResult = await __test__.executeSearchTool({
+      config,
+      explicitProvider: "exa",
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: undefined,
+      maxResults: 1,
+      queries: ["exa docs"],
+    });
+
+    expect(searchResult.content[0]?.text ?? "").toContain(
+      "Background contents prefetch started via exa for 1 URL(s). Prefetch id:",
+    );
+  });
+
+  it("allows per-call prefetch.provider=null to disable persisted search prefetch defaults", async () => {
+    const { __test__ } = await import("../src/index.js");
+    const config = {
+      tools: {
+        contents: "exa",
+      },
+      toolSettings: {
+        search: {
+          prefetch: {
+            provider: "exa",
+            maxUrls: 1,
+          },
+        },
+      },
+      providers: {
+        exa: {
+          apiKey: "literal-key",
+        },
+      },
+    } as const;
+
+    exaSearchMock.mockResolvedValue({
+      results: [
+        {
+          title: "Exa SDK",
+          url: "https://exa.ai/sdk",
+          text: "SDK docs",
+        },
+      ],
+    });
+
+    const searchResult = await __test__.executeSearchTool({
+      config,
+      explicitProvider: "exa",
+      ctx: { cwd: process.cwd() },
+      signal: undefined,
+      onUpdate: undefined,
+      options: {
+        prefetch: {
+          provider: null,
+        },
+      },
+      maxResults: 1,
+      queries: ["exa docs"],
+    });
+
+    expect(searchResult.content[0]?.text ?? "").not.toContain(
+      "Background contents prefetch started via",
+    );
+    expect(exaGetContentsMock).not.toHaveBeenCalled();
   });
 
   it("reuses partial cache hits and fetches only the missing URLs", async () => {
@@ -332,8 +484,8 @@ describe("search contents prefetch", () => {
         onUpdate: undefined,
         options: {
           prefetch: {
-            enabled: true,
             maxUrls: 1,
+            provider: "exa",
             ttlMs: 1000,
           },
         },

--- a/test/search-prefetch.test.ts
+++ b/test/search-prefetch.test.ts
@@ -89,7 +89,7 @@ describe("search contents prefetch", () => {
     });
 
     const searchText = searchResult.content[0]?.text ?? "";
-    expect(searchText).toContain("1. Exa SDK");
+    expect(searchText).toContain("1. [Exa SDK](<https://exa.ai/sdk>)");
     expect(searchText).toContain(
       "Background contents prefetch started via exa for 2 URL(s). Prefetch id:",
     );

--- a/test/session-cache-reset.test.ts
+++ b/test/session-cache-reset.test.ts
@@ -74,7 +74,6 @@ describe("session cache reset", () => {
     } as unknown as ExtensionAPI);
 
     const config = {
-      version: 1,
       providers: {
         exa: {
           enabled: true,
@@ -141,7 +140,6 @@ describe("session cache reset", () => {
     } as unknown as ExtensionAPI);
 
     const config = {
-      version: 1,
       providers: {
         exa: {
           enabled: true,
@@ -242,7 +240,6 @@ describe("session cache reset", () => {
     } as unknown as ExtensionAPI);
 
     const config = {
-      version: 1,
       providers: {
         exa: {
           enabled: true,

--- a/test/tool-availability.test.ts
+++ b/test/tool-availability.test.ts
@@ -188,6 +188,29 @@ describe("managed tool availability", () => {
     ).toEqual([]);
   });
 
+  it("does not expose web_contents for Gemini", () => {
+    const config: WebProvidersConfig = {
+      version: 1,
+      providers: {
+        gemini: {
+          enabled: true,
+          apiKey: "literal-key",
+        },
+      },
+    };
+
+    expect(
+      __test__.getAvailableManagedToolNames(config, process.cwd()),
+    ).toEqual(["web_search", "web_answer", "web_research"]);
+    expect(
+      __test__.getAvailableProviderIdsForCapability(
+        config,
+        process.cwd(),
+        "contents",
+      ),
+    ).toEqual([]);
+  });
+
   it("respects provider tool capability toggles", () => {
     process.env.EXA_API_KEY = "test-key";
 
@@ -248,7 +271,7 @@ describe("managed tool availability", () => {
     expect(Array.from(activeTools)).toEqual(["web_search"]);
   });
 
-  it("suppresses noisy partial foreground tool text in the pending tool box", () => {
+  it("shows partial foreground tool text in the pending tool box", () => {
     process.env.EXA_API_KEY = "test-key";
 
     const tools: Array<{
@@ -294,8 +317,8 @@ describe("managed tool availability", () => {
       createTheme(),
     );
 
-    expect(partialSearchRender).toBeUndefined();
-    expect(partialContentsRender).toBeUndefined();
+    expect(partialSearchRender).toBeDefined();
+    expect(partialContentsRender).toBeDefined();
   });
 
   it("clears the contents cache when saved contents-capable provider settings change", () => {

--- a/test/tool-availability.test.ts
+++ b/test/tool-availability.test.ts
@@ -84,6 +84,7 @@ describe("managed tool availability", () => {
     expect(webSearch?.parameters?.properties).not.toHaveProperty("query");
     expect(webSearch?.parameters?.properties).toHaveProperty("queries");
     expect(webSearch?.parameters?.properties).toHaveProperty("options");
+    expect(webSearch?.parameters?.properties).not.toHaveProperty("provider");
     expect(webContents?.description).toBe(
       "Read and extract the main contents of one or more web pages.",
     );
@@ -93,26 +94,27 @@ describe("managed tool availability", () => {
     );
     expect(webAnswer?.parameters?.properties).not.toHaveProperty("query");
     expect(webAnswer?.parameters?.properties).toHaveProperty("queries");
+    expect(webAnswer?.parameters?.properties).not.toHaveProperty("provider");
     expect(webResearch?.description).toBe(
       "Investigate a topic across web sources and produce a longer report.",
     );
+    expect(webResearch?.parameters?.properties).not.toHaveProperty("provider");
   });
 
-  it("only exposes available provider overrides to the model", () => {
+  it("only exposes the mapped available provider to internal capability resolution", () => {
     process.env.CODEX_API_KEY = "test-key";
 
-    const config: WebProvidersConfig = {
-      version: 1,
+    const config = createConfig({
+      tools: {
+        search: "codex",
+      },
       providers: {
-        codex: {
-          enabled: true,
-        },
+        codex: {},
         exa: {
-          enabled: false,
           apiKey: "EXA_API_KEY",
         },
       },
-    };
+    });
 
     expect(
       __test__.getAvailableProviderIdsForCapability(
@@ -123,143 +125,69 @@ describe("managed tool availability", () => {
     ).toEqual(["codex"]);
   });
 
-  it("keeps web_search available via implicit Codex fallback", () => {
-    process.env.CODEX_API_KEY = "test-key";
-
-    const config: WebProvidersConfig = { version: 1 };
-
-    expect(
-      __test__.getAvailableManagedToolNames(config, process.cwd()),
-    ).toEqual(["web_search"]);
-  });
-
-  it("does not expose Claude-managed tools via implicit fallback", () => {
-    mockClaudeAvailable();
-
-    const config: WebProvidersConfig = { version: 1 };
-
-    expect(
-      __test__.getAvailableManagedToolNames(config, process.cwd()),
-    ).toEqual([]);
-  });
-
-  it("hides managed tools when no provider is available", () => {
-    const config: WebProvidersConfig = {
-      version: 1,
-      providers: {
-        codex: {
-          enabled: false,
-        },
-        exa: {
-          enabled: false,
-          apiKey: "EXA_API_KEY",
-        },
-      },
-    };
-
-    expect(
-      __test__.getAvailableManagedToolNames(config, process.cwd()),
-    ).toEqual([]);
-  });
-
-  it("hides Claude-managed tools when Claude auth is missing", () => {
-    const config: WebProvidersConfig = {
-      version: 1,
-      providers: {
-        claude: {
-          enabled: true,
-        },
-        codex: {
-          enabled: false,
-        },
-      },
-    };
-
-    expect(
-      __test__.getAvailableManagedToolNames(config, process.cwd()),
-    ).toEqual([]);
-  });
-
-  it("hides the implicit Codex fallback when Codex auth is missing", () => {
-    const config: WebProvidersConfig = { version: 1 };
-
-    expect(
-      __test__.getAvailableManagedToolNames(config, process.cwd()),
-    ).toEqual([]);
-  });
-
-  it("does not expose web_contents for Gemini", () => {
-    const config: WebProvidersConfig = {
-      version: 1,
-      providers: {
-        gemini: {
-          enabled: true,
-          apiKey: "literal-key",
-        },
-      },
-    };
-
-    expect(
-      __test__.getAvailableManagedToolNames(config, process.cwd()),
-    ).toEqual(["web_search", "web_answer", "web_research"]);
-    expect(
-      __test__.getAvailableProviderIdsForCapability(
-        config,
-        process.cwd(),
-        "contents",
-      ),
-    ).toEqual([]);
-  });
-
-  it("respects provider tool capability toggles", () => {
+  it("only exposes tools whose mapped providers are available", () => {
     process.env.EXA_API_KEY = "test-key";
 
-    const config: WebProvidersConfig = {
-      version: 1,
+    const config = createConfig({
+      tools: {
+        search: null,
+        contents: "exa",
+        answer: null,
+        research: "exa",
+      },
       providers: {
-        codex: {
-          enabled: false,
-        },
         exa: {
-          enabled: true,
           apiKey: "EXA_API_KEY",
-          tools: {
-            search: false,
-            contents: true,
-            answer: false,
-            research: true,
-          },
         },
       },
-    };
+    });
 
     expect(
       __test__.getAvailableManagedToolNames(config, process.cwd()),
     ).toEqual(["web_contents", "web_research"]);
   });
 
+  it("does not expose any managed tools when nothing is mapped", () => {
+    process.env.CODEX_API_KEY = "test-key";
+
+    expect(
+      __test__.getAvailableManagedToolNames(createConfig(), process.cwd()),
+    ).toEqual([]);
+  });
+
+  it("hides tools when the mapped provider is unavailable", () => {
+    const config = createConfig({
+      tools: {
+        search: "claude",
+      },
+      providers: {
+        claude: {},
+      },
+    });
+
+    expect(
+      __test__.getAvailableManagedToolNames(config, process.cwd()),
+    ).toEqual([]);
+  });
+
   it("does not activate unavailable tools before agent start", () => {
     process.env.CODEX_API_KEY = "test-key";
     process.env.EXA_API_KEY = "test-key";
 
-    const config: WebProvidersConfig = {
-      version: 1,
+    const config = createConfig({
+      tools: {
+        search: "codex",
+        contents: "exa",
+        answer: "exa",
+        research: "exa",
+      },
       providers: {
-        codex: {
-          enabled: true,
-        },
+        codex: {},
         exa: {
-          enabled: true,
           apiKey: "EXA_API_KEY",
-          tools: {
-            search: false,
-            contents: true,
-            answer: true,
-            research: true,
-          },
         },
       },
-    };
+    });
 
     const activeTools = __test__.getSyncedActiveTools(
       config,
@@ -322,11 +250,9 @@ describe("managed tool availability", () => {
   });
 
   it("clears the contents cache when saved contents-capable provider settings change", () => {
-    const previous: WebProvidersConfig = {
-      version: 1,
+    const previous = createConfig({
       providers: {
         exa: {
-          enabled: true,
           apiKey: "EXA_API_KEY",
           native: {
             type: "auto",
@@ -336,13 +262,11 @@ describe("managed tool availability", () => {
           },
         },
       },
-    };
+    });
 
-    const next: WebProvidersConfig = {
-      version: 1,
+    const next = createConfig({
       providers: {
         exa: {
-          enabled: true,
           apiKey: "EXA_API_KEY",
           native: {
             type: "auto",
@@ -352,51 +276,49 @@ describe("managed tool availability", () => {
           },
         },
       },
-    };
+    });
 
     expect(__test__.didContentsCacheInputsChange(previous, next)).toBe(true);
   });
 
   it("keeps the contents cache when only non-contents providers change", () => {
-    const previous: WebProvidersConfig = {
-      version: 1,
+    const previous = createConfig({
       providers: {
         codex: {
-          enabled: true,
           native: {
             webSearchEnabled: true,
           },
         },
       },
-    };
+    });
 
-    const next: WebProvidersConfig = {
-      version: 1,
+    const next = createConfig({
       providers: {
         codex: {
-          enabled: true,
           native: {
             webSearchEnabled: false,
           },
         },
       },
-    };
+    });
 
     expect(__test__.didContentsCacheInputsChange(previous, next)).toBe(false);
   });
 
-  it("surfaces Perplexity overrides when Perplexity is available", () => {
+  it("surfaces mapped Perplexity tools when Perplexity is available", () => {
     process.env.PERPLEXITY_API_KEY = "test-key";
 
-    const config: WebProvidersConfig = {
-      version: 1,
+    const config = createConfig({
+      tools: {
+        answer: "perplexity",
+        research: "perplexity",
+      },
       providers: {
         perplexity: {
-          enabled: true,
           apiKey: "PERPLEXITY_API_KEY",
         },
       },
-    };
+    });
 
     expect(
       __test__.getAvailableProviderIdsForCapability(
@@ -415,18 +337,19 @@ describe("managed tool availability", () => {
   });
 });
 
+function createConfig(
+  overrides: Partial<WebProvidersConfig> = {},
+): WebProvidersConfig {
+  return {
+    version: 2,
+    tools: overrides.tools,
+    providers: overrides.providers,
+  };
+}
+
 function createTheme(): Theme {
   return {
     fg: (_color: string, text: string) => text,
     bold: (text: string) => text,
   } as unknown as Theme;
-}
-
-function mockClaudeAvailable(): void {
-  execFileSyncMock.mockImplementation((_command, args: string[]) => {
-    if (args.includes("auth") && args.includes("status")) {
-      return '{"loggedIn":true,"authMethod":"claude.ai"}';
-    }
-    throw new Error(`Unexpected Claude command: ${args.join(" ")}`);
-  });
 }

--- a/test/tool-availability.test.ts
+++ b/test/tool-availability.test.ts
@@ -341,7 +341,6 @@ function createConfig(
   overrides: Partial<WebProvidersConfig> = {},
 ): WebProvidersConfig {
   return {
-    version: 2,
     tools: overrides.tools,
     providers: overrides.providers,
   };


### PR DESCRIPTION
**Breaking:** The config format switches from enabling a single provider with per-tool toggles to explicit per-tool provider mappings via a top-level `tools` block. The `version` field and per-provider `tools` objects are removed.

### Review

- The `tools` mapping in the config is the new source of truth for which provider handles each capability—there is no longer an implicit Codex fallback or provider priority order.
- The `/web-providers` TUI now has a dedicated tool-mapping section alongside provider settings.
- Existing config files are incompatible and must be recreated.

### Details

<details>
<summary>⁉️ Motivation</summary>

The old model conflated provider enablement with tool routing: you enabled one provider and toggled its individual tools. With multiple providers, users had to mentally track which enabled provider "won" for each tool. The new model makes the mapping explicit and unambiguous.

</details>

<details>
<summary>🧪 Testing</summary>

- All 126 existing tests pass, updated to use the new config shape.
- Config parsing tests cover rejection of legacy `providers.*.tools` toggles and unknown top-level tool names.
- Provider resolution tests verify mapped lookups and correct errors for unmapped/unavailable providers.

</details>

<details>
<summary>📌 References</summary>

N/A

</details>