### PR TITLE
Streamline in-flight progress messages

### DIFF
--- a/changelog/unreleased/consistent-provider-names-and-progress-messages.md
+++ b/changelog/unreleased/consistent-provider-names-and-progress-messages.md
@@ -1,0 +1,30 @@
+---
+title: Consistent provider names and progress messages
+type: bugfix
+authors:
+  - mavam
+  - claude
+created: 2026-03-17T18:22:55.14456Z
+---
+
+In-flight progress messages now use consistent capitalization and a
+uniform structure across all providers and tools.
+
+Previously, the provider name was shown in lowercase in collapsed
+result summaries (e.g. `3 results via exa`) while the same provider
+appeared capitalized in in-flight messages (e.g. `Searching Exa
+for: …`). All collapsed summaries now use the same capitalized
+provider label.
+
+The in-flight messages themselves have also been unified into a
+common pattern:
+
+- Search: `Searching <Provider> for: <query>`
+- Contents: `Fetching contents from <Provider> for N URL(s)`
+- Answer: `Getting <Provider> answer for: <query>`
+- Research: `Starting <Provider> research`
+- Research heartbeat: `Researching via <Provider> (N elapsed)`
+
+Previously, research messages used inconsistent phrasing such as
+`Creating Exa research task`, `Creating Valyu deep research task`,
+and `web_research still running via exa (30s elapsed)`.

--- a/changelog/unreleased/consistent-provider-names-and-progress-messages.md
+++ b/changelog/unreleased/consistent-provider-names-and-progress-messages.md
@@ -4,6 +4,7 @@ type: bugfix
 authors:
   - mavam
   - claude
+pr: 7
 created: 2026-03-17T18:22:55.14456Z
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1175,8 +1175,9 @@ function createToolProgressReporter(
         return;
       }
 
+      const providerLabel = PROVIDER_MAP[providerId]?.label ?? providerId;
       const elapsed = formatElapsed(Date.now() - startedAt);
-      emit(`web_research still running via ${providerId} (${elapsed} elapsed)`);
+      emit(`Researching via ${providerLabel} (${elapsed} elapsed)`);
       lastUpdateAt = Date.now();
     }, RESEARCH_HEARTBEAT_MS);
   }
@@ -1369,11 +1370,13 @@ function renderCollapsedProviderToolSummary(
     typeof details.queryCount === "number" &&
     details.queryCount > 1
   ) {
+    const providerLabel =
+      PROVIDER_MAP[details.provider]?.label ?? details.provider;
     const failureSuffix =
       details.failedQueryCount && details.failedQueryCount > 0
         ? `, ${details.failedQueryCount} failed`
         : "";
-    return `${details.queryCount} questions via ${details.provider}${failureSuffix}`;
+    return `${details.queryCount} questions via ${providerLabel}${failureSuffix}`;
   }
 
   const baseSummary =
@@ -2868,21 +2871,24 @@ function renderCollapsedSearchSummary(
   _text: string | undefined,
   theme: Pick<Theme, "fg">,
 ): Text {
+  const providerLabel =
+    PROVIDER_MAP[details.provider]?.label ?? details.provider;
   const count = `${details.resultCount} result${details.resultCount === 1 ? "" : "s"}`;
   const failureSuffix =
     details.failedQueryCount > 0 ? `, ${details.failedQueryCount} failed` : "";
   const base =
     details.queryCount > 1
-      ? `${details.queryCount} queries, ${count} via ${details.provider}${failureSuffix}`
-      : `${count} via ${details.provider}${failureSuffix}`;
+      ? `${details.queryCount} queries, ${count} via ${providerLabel}${failureSuffix}`
+      : `${count} via ${providerLabel}${failureSuffix}`;
   let summary = theme.fg("success", base);
   summary += theme.fg("muted", ` (${getExpandHint()})`);
   return new Text(summary, 0, 0);
 }
 
 function appendProviderSummary(summary: string, provider: ProviderId): string {
-  const providerSuffix = `via ${provider}`;
-  return summary.toLowerCase().includes(providerSuffix)
+  const providerLabel = PROVIDER_MAP[provider]?.label ?? provider;
+  const providerSuffix = `via ${providerLabel}`;
+  return summary.toLowerCase().includes(providerSuffix.toLowerCase())
     ? summary
     : `${summary} ${providerSuffix}`;
 }

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -429,13 +429,13 @@ function handleProgressMessage(
   }
 
   seenToolUseIds.add(message.tool_use_id);
-  onProgress(`Claude ${formatToolName(message.tool_name)}`);
+  onProgress(formatToolProgressMessage(message.tool_name));
 }
 
-function formatToolName(toolName: string): string {
-  if (toolName === "WebSearch") return "web search";
-  if (toolName === "WebFetch") return "web fetch";
-  return toolName;
+function formatToolProgressMessage(toolName: string): string {
+  if (toolName === "WebSearch") return "Searching via Claude";
+  if (toolName === "WebFetch") return "Fetching via Claude";
+  return `Claude: ${toolName}`;
 }
 
 function parseStructuredOutput<T>(result: SDKResultMessage): T {

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -296,7 +296,7 @@ function handleProgressEvent(
     !seenQueries.has(event.item.query)
   ) {
     seenQueries.add(event.item.query);
-    onProgress(`Codex web search ${seenQueries.size}: ${event.item.query}`);
+    onProgress(`Searching Codex for: ${event.item.query}`);
   }
 }
 

--- a/src/providers/exa.ts
+++ b/src/providers/exa.ts
@@ -294,7 +294,6 @@ export class ExaProvider implements WebProvider<ExaProviderConfig> {
     }
 
     const client = new Exa(apiKey, config.baseUrl);
-    context.onProgress?.("Creating Exa research task");
     const task = await client.research.create({
       instructions: input,
       ...(options ?? {}),

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -3,8 +3,8 @@ import type {
   CodexProviderConfig,
   ExaProviderConfig,
   GeminiProviderConfig,
-  PerplexityProviderConfig,
   ParallelProviderConfig,
+  PerplexityProviderConfig,
   ProviderId,
   ValyuProviderConfig,
   WebProvider,
@@ -13,8 +13,8 @@ import { ClaudeProvider } from "./claude.js";
 import { CodexProvider } from "./codex.js";
 import { ExaProvider } from "./exa.js";
 import { GeminiProvider } from "./gemini.js";
-import { PerplexityProvider } from "./perplexity.js";
 import { ParallelProvider } from "./parallel.js";
+import { PerplexityProvider } from "./perplexity.js";
 import { ValyuProvider } from "./valyu.js";
 
 export const PROVIDERS: ReadonlyArray<

--- a/src/providers/valyu.ts
+++ b/src/providers/valyu.ts
@@ -184,7 +184,7 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
         ? await client.waitForJob(response.jobId, {
             onProgress: (status) =>
               context.onProgress?.(
-                `Valyu contents: ${status.urlsProcessed}/${status.urlsTotal} processed`,
+                `Fetching contents from Valyu: ${status.urlsProcessed}/${status.urlsTotal} processed`,
               ),
           })
         : response;
@@ -314,7 +314,6 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
     }
 
     const client = new Valyu(apiKey, config.baseUrl);
-    context.onProgress?.("Creating Valyu deep research task");
     const task = await client.deepresearch.create({
       input,
       ...(options ?? {}),
@@ -348,7 +347,7 @@ export class ValyuProvider implements WebProvider<ValyuProviderConfig> {
     const progress = result.progress;
     if (progress) {
       context.onProgress?.(
-        `Valyu deep research: ${progress.current_step}/${progress.total_steps}`,
+        `Researching via Valyu: step ${progress.current_step}/${progress.total_steps}`,
       );
     }
 

--- a/test/provider-tool-output.test.ts
+++ b/test/provider-tool-output.test.ts
@@ -572,9 +572,7 @@ describe("provider tool output", () => {
 
       expect(result.content[0]?.text).toBe("Research complete");
       expect(updates).toContain("Starting research");
-      expect(updates).toContain(
-        "web_research still running via perplexity (15s elapsed)",
-      );
+      expect(updates).toContain("Researching via Perplexity (15s elapsed)");
     } finally {
       vi.useRealTimers();
     }

--- a/test/rendering.test.ts
+++ b/test/rendering.test.ts
@@ -95,7 +95,7 @@ describe("web_search renderer", () => {
       120,
     );
 
-    expect(summary).toContain("3 results via exa");
+    expect(summary).toContain("3 results via Exa");
     expect(summary).toContain("to expand");
     expect(summary).not.toContain("https://exa.ai/docs");
   });
@@ -116,7 +116,7 @@ describe("web_search renderer", () => {
       120,
     );
 
-    expect(summary).toContain("2 queries, 5 results via exa");
+    expect(summary).toContain("2 queries, 5 results via Exa");
     expect(summary).toContain("to expand");
   });
 
@@ -136,7 +136,7 @@ describe("web_search renderer", () => {
       120,
     );
 
-    expect(summary).toContain("3 queries, 4 results via exa, 1 failed");
+    expect(summary).toContain("3 queries, 4 results via Exa, 1 failed");
     expect(summary).toContain("to expand");
   });
 });
@@ -253,7 +253,7 @@ describe("provider tool summaries", () => {
       undefined,
     );
 
-    expect(summary).toBe("2 pages via gemini");
+    expect(summary).toBe("2 pages via Gemini");
   });
 
   it("keeps the dedicated multi-question answer summary format", () => {
@@ -267,7 +267,7 @@ describe("provider tool summaries", () => {
       undefined,
     );
 
-    expect(summary).toBe("3 questions via gemini, 1 failed");
+    expect(summary).toBe("3 questions via Gemini, 1 failed");
   });
 
   it("normalizes research summaries without duplicating the provider", () => {


### PR DESCRIPTION
Progress messages are now consistent in capitalization and structure across all providers and tools.

### Review

The main areas worth a look:

- **Capitalization fix** — collapsed result summaries (e.g. `3 results via exa`) now use the same capitalized provider label as in-flight messages (`Searching Exa for: …`). Fixed in the three display helpers in `index.ts` that were using the raw lowercase `ProviderId` instead of `PROVIDER_MAP[id].label`.
- **Unified message shape** — all in-flight messages now follow a common verb-provider-detail pattern. The most notable outliers were the research start/poll messages (`Creating Exa research task`, `Creating Valyu deep research task`, `web_research still running via exa`) and the Claude/Codex messages which had inverted or differently structured phrasing.
- **Exa and Valyu start messages removed** — the provider-level `onProgress` call inside `startResearch` was redundant: the execution-policy lifecycle already emits `Starting X research` before calling the provider. The two calls are now collapsed into one.

### Details

<details>
<summary>⁉️ Motivation</summary>

When a tool call was in flight the provider name appeared capitalized (`Searching Exa for: …`), but once the result arrived the collapsed summary showed it in lowercase (`3 results via exa`). The research messages were also structurally different from every other tool, making the UI feel inconsistent.

</details>

<details>
<summary>🧪 Testing</summary>

- Existing rendering tests updated to reflect the new capitalized summaries and heartbeat format.
- `execution-policy.test.ts` (14 tests) passes unchanged — the lifecycle messages from `execution-policy.ts` were not touched.
- Manual review of all `onProgress` call sites across every provider.

</details>

<details>
<summary>📌 References</summary>

No external references.

</details>