### PR TITLE
Add custom CLI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,8 +355,3 @@ providers unless overridden in a provider's `policy` block:
 ## 📄 License
 
 [MIT](LICENSE)
-MaxConsecutivePollErrors`|`3` | Consecutive poll failures before stopping |
-
-## 📄 License
-
-[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ off entirely.
 
 ## ✨ Features
 
-- **Multiple providers** — Claude, Codex, Exa, Gemini, Perplexity, Parallel,
-  Valyu
+- **Multiple providers** — Claude, Codex, Custom CLI, Exa, Gemini,
+  Perplexity, Parallel, Valyu
+- **Bring-your-own wrappers** — route tools through any local command that reads
+  JSON on stdin and writes JSON on stdout
 - **Batched search and answers** — run several related queries in a single
   `web_search` or `web_answer` call and get grouped results back in one response
 - **Async contents prefetch** — optionally start background `web_contents`
@@ -48,6 +50,10 @@ Each tool can be routed to any compatible provider:
 | **Perplexity** |   ✔    |          |   ✔    |    ✔     | `PERPLEXITY_API_KEY`   |
 | **Parallel**   |   ✔    |    ✔     |        |          | `PARALLEL_API_KEY`     |
 | **Valyu**      |   ✔    |    ✔     |   ✔    |    ✔     | `VALYU_API_KEY`        |
+
+Advanced option: `custom-cli` is a configurable adapter provider that can route
+any managed tool through a local wrapper command using a JSON stdin/stdout
+contract.
 
 See [`example-config.json`](example-config.json) for a full default
 configuration.
@@ -174,6 +180,19 @@ shell commands prefixed with `!`.
 </details>
 
 <details>
+<summary><strong>Custom CLI</strong></summary>
+
+- Runs a caller-configured local command per capability
+- Commands read one JSON request from `stdin` and must write one JSON result to
+  `stdout`
+- `stderr` is treated as progress output and streamed into the tool call while
+  the command runs
+- Good for wrapping local agent CLIs, shell scripts, or small adapter programs
+  without adding a first-class provider to this extension
+
+</details>
+
+<details>
 <summary><strong>Exa</strong></summary>
 
 - SDK: `exa-js`
@@ -233,6 +252,57 @@ shell commands prefixed with `!`.
 - Configurable response length for answers and research
 
 </details>
+
+### Custom CLI provider
+
+`custom-cli` lets you bring your own wrapper command for any managed tool. Each
+capability can point at a different local command under
+`providers["custom-cli"].native`:
+
+```json
+{
+  "tools": {
+    "search": "custom-cli",
+    "contents": "custom-cli",
+    "answer": "custom-cli",
+    "research": null
+  },
+  "providers": {
+    "custom-cli": {
+      "enabled": true,
+      "native": {
+        "search": {
+          "argv": ["node", "./wrappers/codex-search.mjs"]
+        },
+        "contents": {
+          "argv": ["node", "./wrappers/gemini-contents.mjs"]
+        },
+        "answer": {
+          "argv": ["node", "./wrappers/claude-answer.mjs"]
+        }
+      }
+    }
+  }
+}
+```
+
+That example uses three different wrappers behind the same provider mapping:
+Codex for `web_search`, Gemini for `web_contents`, and Claude for
+`web_answer`.
+
+Wrapper contract:
+
+- `stdin`: one JSON request object with `capability` plus the per-call managed
+  inputs (`query`, `urls`, `input`, `maxResults`, `options`, `cwd`)
+- `stdout`: one JSON response object
+  - `search`: `{ "results": [{ "title", "url", "snippet" }] }`
+  - `contents` / `answer` / `research`: `{ "text": "...", "summary"?: "...", "itemCount"?: 1, "metadata"?: {} }`
+- `stderr`: optional progress lines
+- exit code `0`: success
+- non-zero exit code: failure
+
+See [`examples/custom-cli/README.md`](examples/custom-cli/README.md) for a
+longer example showing Codex, Claude, and Gemini wrappers.
 
 ### Generic settings
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ off entirely.
 
 - **Multiple providers** — Claude, Codex, Custom CLI, Exa, Gemini,
   Perplexity, Parallel, Valyu
-- **Bring-your-own wrappers** — route tools through any local command that reads
-  JSON on stdin and writes JSON on stdout
 - **Batched search and answers** — run several related queries in a single
   `web_search` or `web_answer` call and get grouped results back in one response
 - **Async contents prefetch** — optionally start background `web_contents`

--- a/README.md
+++ b/README.md
@@ -65,8 +65,11 @@ and that provider is currently available. Tool-specific settings live under
 
 #### `web_search`
 
-Find likely sources on the public web for up to 10 queries in a single call
-and return titles, URLs, and snippets grouped by query.
+Search the public web for up to 10 queries in one call. It returns grouped
+titles, URLs, and snippets for each query.
+
+<details>
+<summary><strong>Parameters and behavior</strong></summary>
 
 | Parameter    | Type     | Default  | Description                                                    |
 | ------------ | -------- | -------- | -------------------------------------------------------------- |
@@ -80,9 +83,15 @@ starts a background page-extraction workflow only when `prefetch.provider` is
 set. `/web-providers` can also persist default search prefetch settings under
 `toolSettings.search.prefetch`.
 
+</details>
+
 #### `web_contents`
 
-Read and extract the main contents of one or more web pages.
+Read the main text from one or more web pages. It reuses cached pages when they
+match and fetches only missing or stale URLs.
+
+<details>
+<summary><strong>Parameters and behavior</strong></summary>
 
 | Parameter | Type     | Default  | Description                          |
 | --------- | -------- | -------- | ------------------------------------ |
@@ -93,20 +102,34 @@ Read and extract the main contents of one or more web pages.
 content store—whether they came from prefetch or an earlier read—and only
 fetches missing or stale URLs.
 
+</details>
+
 #### `web_answer`
 
-Answer one or more questions using web-grounded evidence.
+Answer one or more questions using web-grounded evidence. When you ask more
+than one question, the response is grouped into per-question sections.
+
+<details>
+<summary><strong>Parameters and behavior</strong></summary>
 
 | Parameter | Type     | Default  | Description                                          |
 | --------- | -------- | -------- | ---------------------------------------------------- |
 | `queries` | string[] | required | One or more questions to answer in one call (max 10) |
 | `options` | object   | —        | Provider-specific options                            |
 
-Responses are grouped into per-question sections when more than one question is provided.
+Responses are grouped into per-question sections when more than one question is
+provided.
+
+</details>
 
 #### `web_research`
 
-Investigate a topic across web sources and produce a longer report.
+Investigate a topic across web sources and produce a longer report. The
+provider-specific `options` stay native to each SDK, and runtime options
+override provider configuration when both are set.
+
+<details>
+<summary><strong>Parameters and behavior</strong></summary>
 
 | Parameter | Type   | Default  | Description                |
 | --------- | ------ | -------- | -------------------------- |
@@ -117,6 +140,8 @@ Investigate a topic across web sources and produce a longer report.
 different field names across SDKs—for example Perplexity uses `country`, Exa
 uses `userLocation`, and Valyu uses `countryCode`. Runtime `options` override
 provider-native config, but managed tool inputs and tool wiring stay fixed.
+
+</details>
 
 <details>
 <summary><strong>Timeout, retry, and delivery modes</strong></summary>

--- a/README.md
+++ b/README.md
@@ -169,13 +169,7 @@ Providers deliver results in one of three modes:
 
 ### Providers
 
-Every provider is a thin adapter around an official SDK. Each provider has an
-`enabled` toggle that controls whether it is eligible for tool mappings.
-Provider config is split into `native` settings (forwarded to the SDK) and
-`policy` settings (local overrides that take precedence over generic settings);
-legacy `defaults` blocks are still accepted when reading. Secret-like values
-can be literal strings, environment variable names (e.g., `EXA_API_KEY`), or
-shell commands prefixed with `!`.
+The built-in providers below are thin adapters around official SDKs.
 
 <details>
 <summary><strong>Claude</strong></summary>
@@ -199,22 +193,6 @@ shell commands prefixed with `!`.
 - Supports request-shaping `web_search.options` such as `model`,
   `modelReasoningEffort`, and `webSearchMode`
 - Best if you already use the local Codex CLI and auth flow
-
-</details>
-
-<details>
-<summary><strong>Custom CLI</strong></summary>
-
-- Runs a caller-configured local command per capability
-- Each command can set its own `argv`, `cwd`, and `env`
-- Commands read one JSON request from `stdin` and must write one JSON result to
-  `stdout`
-- `stderr` is treated as progress output and streamed into the tool call while
-  the command runs
-- `web_research` runs as a foreground command, so it supports request timeouts
-  and retries but not polling controls or `resumeId`
-- Good for wrapping local agent CLIs, shell scripts, or small adapter programs
-  without adding a first-class provider to this extension
 
 </details>
 
@@ -281,9 +259,24 @@ shell commands prefixed with `!`.
 
 ### Custom CLI provider
 
-`custom-cli` lets you bring your own wrapper command for any managed tool. Each
-capability can point at a different local command under
-`providers["custom-cli"].native`:
+The `custom-cli` provider lets you bring your own wrapper command for any
+managed tool. Each capability can point at a different local command under
+`providers["custom-cli"].native`.
+
+The repo includes actual wrapper examples under
+[`examples/custom-cli/wrappers/`](examples/custom-cli/wrappers/). They are
+small bash scripts that use `jq` for JSON handling. Each one uses a different
+backend pattern:
+
+- `codex --search exec` for `web_search`
+- Gemini API via `curl` for `web_contents`
+- `claude -p` for `web_answer`
+- Perplexity API via `curl` for `web_research`
+
+<details>
+<summary><strong>Configuration example</strong></summary>
+
+Copy the example wrappers into a local `./wrappers/` directory, then configure:
 
 ```json
 {
@@ -291,20 +284,23 @@ capability can point at a different local command under
     "search": "custom-cli",
     "contents": "custom-cli",
     "answer": "custom-cli",
-    "research": null
+    "research": "custom-cli"
   },
   "providers": {
     "custom-cli": {
       "enabled": true,
       "native": {
         "search": {
-          "argv": ["node", "./wrappers/codex-search.mjs"]
+          "argv": ["bash", "./wrappers/codex-search.sh"]
         },
         "contents": {
-          "argv": ["node", "./wrappers/gemini-contents.mjs"]
+          "argv": ["bash", "./wrappers/gemini-contents.sh"]
         },
         "answer": {
-          "argv": ["node", "./wrappers/claude-answer.mjs"]
+          "argv": ["bash", "./wrappers/claude-answer.sh"]
+        },
+        "research": {
+          "argv": ["bash", "./wrappers/perplexity-research.sh"]
         }
       }
     }
@@ -312,9 +308,8 @@ capability can point at a different local command under
 }
 ```
 
-That example uses three different wrappers behind the same provider mapping:
-Codex for `web_search`, Gemini for `web_contents`, and Claude for
-`web_answer`.
+Those example wrappers deliberately use different local CLIs and APIs so you
+can see several wrapper styles in one setup without extra glue code.
 
 Each capability can also set an optional `cwd` and `env` block. Use `cwd` when
 one wrapper must run from a specific directory. Use `env` for per-command
@@ -336,8 +331,12 @@ Wrapper contract:
 - exit code `0`: success
 - non-zero exit code: failure
 
+</details>
+
 See [`examples/custom-cli/README.md`](examples/custom-cli/README.md) for a
-longer example showing Codex, Claude, and Gemini wrappers.
+copy-and-pasteable setup, and see
+[`examples/custom-cli/wrappers/`](examples/custom-cli/wrappers/) for the actual
+wrapper files.
 
 ### Generic settings
 
@@ -353,12 +352,10 @@ providers unless overridden in a provider's `policy` block:
 | `researchTimeoutMs`                | `21600000` | Overall deadline for research before returning |
 | `researchMaxConsecutivePollErrors` | `3`        | Consecutive poll failures before stopping      |
 
-## 🛠️ Development
+## 📄 License
 
-```bash
-npm run check
-npm test
-```
+[MIT](LICENSE)
+MaxConsecutivePollErrors`|`3` | Consecutive poll failures before stopping |
 
 ## 📄 License
 

--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ and that provider is currently available. Tool-specific settings live under
 Find likely sources on the public web for up to 10 queries in a single call
 and return titles, URLs, and snippets grouped by query.
 
-| Parameter    | Type     | Default  | Description                                                          |
-| ------------ | -------- | -------- | -------------------------------------------------------------------- |
-| `queries`    | string[] | required | One or more search queries to run (max 10)                           |
-| `maxResults` | integer  | `5`      | Result count per query, clamped to `1–20`                            |
-| `options`    | object   | —        | Provider-specific search options plus local `prefetch` orchestration |
+| Parameter    | Type     | Default  | Description                                                    |
+| ------------ | -------- | -------- | -------------------------------------------------------------- |
+| `queries`    | string[] | required | One or more search queries to run (max 10)                     |
+| `maxResults` | integer  | `5`      | Result count per query, clamped to `1–20`                      |
+| `options`    | object   | —        | Provider-specific search options and local `prefetch` settings |
 
 `web_search.options.prefetch` is local-only and not forwarded into the provider
 SDK. It accepts `provider`, `maxUrls`, `ttlMs`, and `contentsOptions`, and
@@ -181,10 +181,13 @@ shell commands prefixed with `!`.
 <summary><strong>Custom CLI</strong></summary>
 
 - Runs a caller-configured local command per capability
+- Each command can set its own `argv`, `cwd`, and `env`
 - Commands read one JSON request from `stdin` and must write one JSON result to
   `stdout`
 - `stderr` is treated as progress output and streamed into the tool call while
   the command runs
+- `web_research` runs as a foreground command, so it supports request timeouts
+  and retries but not polling controls or `resumeId`
 - Good for wrapping local agent CLIs, shell scripts, or small adapter programs
   without adding a first-class provider to this extension
 
@@ -287,6 +290,15 @@ capability can point at a different local command under
 That example uses three different wrappers behind the same provider mapping:
 Codex for `web_search`, Gemini for `web_contents`, and Claude for
 `web_answer`.
+
+Each capability can also set an optional `cwd` and `env` block. Use `cwd` when
+one wrapper must run from a specific directory. Use `env` for per-command
+variables; each value can be a literal string, an environment variable name, or
+`!command`.
+
+`web_research` runs as a foreground wrapper command, so local polling controls
+(`pollIntervalMs`, `timeoutMs`, `maxConsecutivePollErrors`) and `resumeId` do
+not apply to `custom-cli`.
 
 Wrapper contract:
 

--- a/changelog/releases/v1.1.0/entries/custom-cli-provider-for-local-agent-wrappers.md
+++ b/changelog/releases/v1.1.0/entries/custom-cli-provider-for-local-agent-wrappers.md
@@ -1,0 +1,13 @@
+---
+title: Custom CLI provider for local agent wrappers
+type: feature
+authors:
+  - mavam
+created: 2026-03-17T19:38:30Z
+---
+
+`pi-web-providers` now supports a `custom-cli` provider that runs caller-configured local commands for `web_search`, `web_contents`, `web_answer`, and `web_research`.
+
+Each capability can point at its own wrapper command under `providers["custom-cli"].native`. Wrappers read one JSON request from `stdin`, write one JSON response to `stdout`, and can stream progress updates on `stderr`.
+
+This makes it easy to integrate additional local agent SDKs or CLIs without adding a dedicated first-class provider. For example, you can route `web_search` through a Codex wrapper, `web_contents` through a Gemini wrapper, and `web_answer` through a Claude wrapper while keeping the shared managed tool surface unchanged.

--- a/example-config.json
+++ b/example-config.json
@@ -25,6 +25,9 @@
         "webSearchMode": "live"
       }
     },
+    "custom-cli": {
+      "enabled": false
+    },
     "exa": {
       "enabled": false,
       "apiKey": "EXA_API_KEY",

--- a/examples/custom-cli/README.md
+++ b/examples/custom-cli/README.md
@@ -1,12 +1,43 @@
 # Custom CLI wrapper examples
 
-The `custom-cli` provider runs one local command per capability. Each wrapper:
+These examples keep the wrapper logic small. They are bash scripts that use
+`jq` for JSON handling. Each wrapper uses a different backend pattern:
+
+- `wrappers/codex-search.sh` — `codex --search exec`
+- `wrappers/gemini-contents.sh` — Gemini API via `curl`
+- `wrappers/claude-answer.sh` — `claude -p`
+- `wrappers/perplexity-research.sh` — Perplexity API via `curl`
+
+Each wrapper:
 
 - reads one JSON request from `stdin`
 - writes one JSON response to `stdout`
-- may stream progress lines on `stderr`
+- may write progress text to `stderr`
 
-A mixed setup can route different managed tools through different wrappers:
+## Requirements
+
+You need:
+
+- `bash`
+- `jq`
+- `curl`
+- `codex` on your `PATH` and authenticated locally
+- `claude` on your `PATH` and authenticated locally
+- `GOOGLE_API_KEY` for the Gemini example
+- `PERPLEXITY_API_KEY` for the Perplexity example
+
+## Copy the wrappers into your project
+
+```bash
+mkdir -p ./wrappers
+cp examples/custom-cli/wrappers/codex-search.sh ./wrappers/
+cp examples/custom-cli/wrappers/gemini-contents.sh ./wrappers/
+cp examples/custom-cli/wrappers/claude-answer.sh ./wrappers/
+cp examples/custom-cli/wrappers/perplexity-research.sh ./wrappers/
+chmod +x ./wrappers/*.sh
+```
+
+Then configure `custom-cli` like this:
 
 ```json
 {
@@ -14,24 +45,23 @@ A mixed setup can route different managed tools through different wrappers:
     "search": "custom-cli",
     "contents": "custom-cli",
     "answer": "custom-cli",
-    "research": null
+    "research": "custom-cli"
   },
   "providers": {
     "custom-cli": {
       "enabled": true,
       "native": {
         "search": {
-          "argv": ["node", "./wrappers/codex-search.mjs"],
-          "cwd": ".",
-          "env": {
-            "CODEX_PROFILE": "demo"
-          }
+          "argv": ["bash", "./wrappers/codex-search.sh"]
         },
         "contents": {
-          "argv": ["node", "./wrappers/gemini-contents.mjs"]
+          "argv": ["bash", "./wrappers/gemini-contents.sh"]
         },
         "answer": {
-          "argv": ["node", "./wrappers/claude-answer.mjs"]
+          "argv": ["bash", "./wrappers/claude-answer.sh"]
+        },
+        "research": {
+          "argv": ["bash", "./wrappers/perplexity-research.sh"]
         }
       }
     }
@@ -39,87 +69,134 @@ A mixed setup can route different managed tools through different wrappers:
 }
 ```
 
-That example uses:
-
-- Codex for `web_search`
-- Gemini for `web_contents`
-- Claude for `web_answer`
-
-Each capability can also set an optional `cwd` and `env`. Relative `cwd`
-values resolve from the active project directory. `env` must be a JSON object
-of strings. Each value can be a literal string, an environment variable name,
-or `!command`.
-
 `web_research` runs as a foreground wrapper command, so polling controls and
 `resumeId` do not apply to `custom-cli`.
 
-## Request shapes
+## Core command shapes
 
-Every wrapper receives a single request object. The shape depends on the
-capability:
+### Search with Codex
 
-### `search`
+```bash
+codex --search exec \
+  --skip-git-repo-check \
+  --sandbox read-only \
+  --output-schema ./schema.json \
+  "Search the public web and return JSON only"
+```
+
+### Contents with Gemini and `curl`
+
+```bash
+curl -sS -X POST \
+  "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=$GOOGLE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "contents": [{"parts": [{"text": "Extract the main content from https://example.com and return JSON only"}]}],
+    "tools": [{"urlContext": {}}],
+    "generationConfig": {"responseMimeType": "application/json"}
+  }'
+```
+
+### Answers with Claude
+
+```bash
+claude -p \
+  --output-format json \
+  --json-schema "$schema" \
+  --permission-mode dontAsk \
+  --allowedTools "WebSearch,WebFetch" \
+  "Answer this question using current public web information"
+```
+
+### Research with Perplexity and `curl`
+
+```bash
+curl -sS https://api.perplexity.ai/chat/completions \
+  -H "Authorization: Bearer $PERPLEXITY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "sonar-deep-research",
+    "stream": false,
+    "messages": [{"role": "user", "content": "Research this topic and return a long-form answer"}]
+  }'
+```
+
+## Try a wrapper directly
+
+### Search
+
+```bash
+printf '%s' '{
+  "capability": "search",
+  "query": "latest Codex CLI release notes",
+  "maxResults": 5,
+  "options": {},
+  "cwd": "'"$PWD"'"
+}' | bash examples/custom-cli/wrappers/codex-search.sh
+```
+
+### Contents
+
+```bash
+printf '%s' '{
+  "capability": "contents",
+  "urls": ["https://example.com"],
+  "options": {},
+  "cwd": "'"$PWD"'"
+}' | bash examples/custom-cli/wrappers/gemini-contents.sh
+```
+
+### Answer
+
+```bash
+printf '%s' '{
+  "capability": "answer",
+  "query": "What changed in the latest Claude Code release?",
+  "options": {},
+  "cwd": "'"$PWD"'"
+}' | bash examples/custom-cli/wrappers/claude-answer.sh
+```
+
+### Research
+
+```bash
+printf '%s' '{
+  "capability": "research",
+  "input": "Compare current local agent CLIs for web-grounded tasks.",
+  "options": {},
+  "cwd": "'"$PWD"'"
+}' | bash examples/custom-cli/wrappers/perplexity-research.sh
+```
+
+## Request and response contract
+
+### Search request
 
 ```json
 {
   "capability": "search",
-  "query": "latest codex sdk docs",
+  "query": "latest Codex CLI release notes",
   "maxResults": 5,
   "options": {},
   "cwd": "/path/to/project"
 }
 ```
 
-### `contents`
-
-```json
-{
-  "capability": "contents",
-  "urls": ["https://example.com"],
-  "options": {},
-  "cwd": "/path/to/project"
-}
-```
-
-### `answer`
-
-```json
-{
-  "capability": "answer",
-  "query": "What changed in the latest Claude Code release?",
-  "options": {},
-  "cwd": "/path/to/project"
-}
-```
-
-### `research`
-
-```json
-{
-  "capability": "research",
-  "input": "Compare current local agent SDKs for web-grounded tasks.",
-  "options": {},
-  "cwd": "/path/to/project"
-}
-```
-
-## Response shapes
-
-### `search`
+### Search response
 
 ```json
 {
   "results": [
     {
-      "title": "Codex SDK docs",
-      "url": "https://github.com/openai/codex/tree/main/sdk/typescript",
-      "snippet": "TypeScript SDK reference and examples."
+      "title": "Codex CLI docs",
+      "url": "https://github.com/openai/codex",
+      "snippet": "CLI docs, examples, and release information."
     }
   ]
 }
 ```
 
-### `contents`, `answer`, `research`
+### Contents, answer, and research response
 
 ```json
 {
@@ -129,116 +206,3 @@ capability:
   "metadata": {}
 }
 ```
-
-## Wrapper sketch: Codex search
-
-```js
-// codex-search.mjs
-import { Codex } from "@openai/codex-sdk";
-
-const request = await readJsonStdin();
-const codex = new Codex();
-const thread = codex.startThread({
-  approvalPolicy: "never",
-  sandboxMode: "read-only",
-  skipGitRepoCheck: true,
-  webSearchEnabled: true,
-  workingDirectory: request.cwd,
-});
-
-const streamed = await thread.runStreamed(
-  `Search the public web and return JSON with at most ${request.maxResults} results for: ${request.query}`,
-  {
-    outputSchema: {
-      type: "object",
-      properties: {
-        results: {
-          type: "array",
-          items: {
-            type: "object",
-            properties: {
-              title: { type: "string" },
-              url: { type: "string" },
-              snippet: { type: "string" },
-            },
-            required: ["title", "url", "snippet"],
-          },
-        },
-      },
-      required: ["results"],
-    },
-  },
-);
-
-let finalText = "";
-for await (const event of streamed.events) {
-  if (event.type === "item.completed" && event.item.type === "agent_message") {
-    finalText = event.item.text;
-  }
-}
-process.stdout.write(finalText);
-```
-
-## Wrapper sketch: Gemini contents
-
-```js
-// gemini-contents.mjs
-import { GoogleGenAI } from "@google/genai";
-
-const request = await readJsonStdin();
-const ai = new GoogleGenAI({ apiKey: process.env.GOOGLE_API_KEY });
-const prompt = `Extract the main textual content from these URLs:\n${request.urls.join("\n")}`;
-const response = await ai.models.generateContent({
-  model: "gemini-2.5-flash",
-  contents: prompt,
-  config: {
-    tools: [{ urlContext: {} }],
-  },
-});
-process.stdout.write(
-  JSON.stringify({
-    text: response.text ?? "No content returned.",
-    summary: `Contents via Gemini for ${request.urls.length} URL(s)`,
-    itemCount: request.urls.length,
-  }),
-);
-```
-
-## Wrapper sketch: Claude answer
-
-```js
-// claude-answer.mjs
-import { query } from "@anthropic-ai/claude-agent-sdk";
-
-const request = await readJsonStdin();
-const stream = query({
-  prompt: `Answer using current public web information: ${request.query}`,
-  options: {
-    allowedTools: ["WebSearch", "WebFetch"],
-    cwd: request.cwd,
-    outputFormat: {
-      type: "json_schema",
-      schema: {
-        type: "object",
-        properties: {
-          text: { type: "string" },
-        },
-        required: ["text"],
-      },
-    },
-    permissionMode: "dontAsk",
-    persistSession: false,
-  },
-});
-
-let finalText = "";
-for await (const message of stream) {
-  if (message.type === "result") {
-    finalText = message.result;
-  }
-}
-process.stdout.write(finalText);
-```
-
-The wrapper code above is intentionally minimal. In practice you will usually
-add stricter schemas, better error handling, and richer summaries or metadata.

--- a/examples/custom-cli/README.md
+++ b/examples/custom-cli/README.md
@@ -21,7 +21,11 @@ A mixed setup can route different managed tools through different wrappers:
       "enabled": true,
       "native": {
         "search": {
-          "argv": ["node", "./wrappers/codex-search.mjs"]
+          "argv": ["node", "./wrappers/codex-search.mjs"],
+          "cwd": ".",
+          "env": {
+            "CODEX_PROFILE": "demo"
+          }
         },
         "contents": {
           "argv": ["node", "./wrappers/gemini-contents.mjs"]
@@ -40,6 +44,14 @@ That example uses:
 - Codex for `web_search`
 - Gemini for `web_contents`
 - Claude for `web_answer`
+
+Each capability can also set an optional `cwd` and `env`. Relative `cwd`
+values resolve from the active project directory. `env` must be a JSON object
+of strings. Each value can be a literal string, an environment variable name,
+or `!command`.
+
+`web_research` runs as a foreground wrapper command, so polling controls and
+`resumeId` do not apply to `custom-cli`.
 
 ## Request shapes
 

--- a/examples/custom-cli/README.md
+++ b/examples/custom-cli/README.md
@@ -1,0 +1,232 @@
+# Custom CLI wrapper examples
+
+The `custom-cli` provider runs one local command per capability. Each wrapper:
+
+- reads one JSON request from `stdin`
+- writes one JSON response to `stdout`
+- may stream progress lines on `stderr`
+
+A mixed setup can route different managed tools through different wrappers:
+
+```json
+{
+  "tools": {
+    "search": "custom-cli",
+    "contents": "custom-cli",
+    "answer": "custom-cli",
+    "research": null
+  },
+  "providers": {
+    "custom-cli": {
+      "enabled": true,
+      "native": {
+        "search": {
+          "argv": ["node", "./wrappers/codex-search.mjs"]
+        },
+        "contents": {
+          "argv": ["node", "./wrappers/gemini-contents.mjs"]
+        },
+        "answer": {
+          "argv": ["node", "./wrappers/claude-answer.mjs"]
+        }
+      }
+    }
+  }
+}
+```
+
+That example uses:
+
+- Codex for `web_search`
+- Gemini for `web_contents`
+- Claude for `web_answer`
+
+## Request shapes
+
+Every wrapper receives a single request object. The shape depends on the
+capability:
+
+### `search`
+
+```json
+{
+  "capability": "search",
+  "query": "latest codex sdk docs",
+  "maxResults": 5,
+  "options": {},
+  "cwd": "/path/to/project"
+}
+```
+
+### `contents`
+
+```json
+{
+  "capability": "contents",
+  "urls": ["https://example.com"],
+  "options": {},
+  "cwd": "/path/to/project"
+}
+```
+
+### `answer`
+
+```json
+{
+  "capability": "answer",
+  "query": "What changed in the latest Claude Code release?",
+  "options": {},
+  "cwd": "/path/to/project"
+}
+```
+
+### `research`
+
+```json
+{
+  "capability": "research",
+  "input": "Compare current local agent SDKs for web-grounded tasks.",
+  "options": {},
+  "cwd": "/path/to/project"
+}
+```
+
+## Response shapes
+
+### `search`
+
+```json
+{
+  "results": [
+    {
+      "title": "Codex SDK docs",
+      "url": "https://github.com/openai/codex/tree/main/sdk/typescript",
+      "snippet": "TypeScript SDK reference and examples."
+    }
+  ]
+}
+```
+
+### `contents`, `answer`, `research`
+
+```json
+{
+  "text": "Rendered tool output",
+  "summary": "Optional short summary",
+  "itemCount": 1,
+  "metadata": {}
+}
+```
+
+## Wrapper sketch: Codex search
+
+```js
+// codex-search.mjs
+import { Codex } from "@openai/codex-sdk";
+
+const request = await readJsonStdin();
+const codex = new Codex();
+const thread = codex.startThread({
+  approvalPolicy: "never",
+  sandboxMode: "read-only",
+  skipGitRepoCheck: true,
+  webSearchEnabled: true,
+  workingDirectory: request.cwd,
+});
+
+const streamed = await thread.runStreamed(
+  `Search the public web and return JSON with at most ${request.maxResults} results for: ${request.query}`,
+  {
+    outputSchema: {
+      type: "object",
+      properties: {
+        results: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              title: { type: "string" },
+              url: { type: "string" },
+              snippet: { type: "string" },
+            },
+            required: ["title", "url", "snippet"],
+          },
+        },
+      },
+      required: ["results"],
+    },
+  },
+);
+
+let finalText = "";
+for await (const event of streamed.events) {
+  if (event.type === "item.completed" && event.item.type === "agent_message") {
+    finalText = event.item.text;
+  }
+}
+process.stdout.write(finalText);
+```
+
+## Wrapper sketch: Gemini contents
+
+```js
+// gemini-contents.mjs
+import { GoogleGenAI } from "@google/genai";
+
+const request = await readJsonStdin();
+const ai = new GoogleGenAI({ apiKey: process.env.GOOGLE_API_KEY });
+const prompt = `Extract the main textual content from these URLs:\n${request.urls.join("\n")}`;
+const response = await ai.models.generateContent({
+  model: "gemini-2.5-flash",
+  contents: prompt,
+  config: {
+    tools: [{ urlContext: {} }],
+  },
+});
+process.stdout.write(
+  JSON.stringify({
+    text: response.text ?? "No content returned.",
+    summary: `Contents via Gemini for ${request.urls.length} URL(s)`,
+    itemCount: request.urls.length,
+  }),
+);
+```
+
+## Wrapper sketch: Claude answer
+
+```js
+// claude-answer.mjs
+import { query } from "@anthropic-ai/claude-agent-sdk";
+
+const request = await readJsonStdin();
+const stream = query({
+  prompt: `Answer using current public web information: ${request.query}`,
+  options: {
+    allowedTools: ["WebSearch", "WebFetch"],
+    cwd: request.cwd,
+    outputFormat: {
+      type: "json_schema",
+      schema: {
+        type: "object",
+        properties: {
+          text: { type: "string" },
+        },
+        required: ["text"],
+      },
+    },
+    permissionMode: "dontAsk",
+    persistSession: false,
+  },
+});
+
+let finalText = "";
+for await (const message of stream) {
+  if (message.type === "result") {
+    finalText = message.result;
+  }
+}
+process.stdout.write(finalText);
+```
+
+The wrapper code above is intentionally minimal. In practice you will usually
+add stricter schemas, better error handling, and richer summaries or metadata.

--- a/examples/custom-cli/wrappers/claude-answer.sh
+++ b/examples/custom-cli/wrappers/claude-answer.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+request="$(cat)"
+cwd="$(jq -r '.cwd // "."' <<<"$request")"
+query="$(jq -r '.query' <<<"$request")"
+model="$(jq -r '.options.model // empty' <<<"$request")"
+
+schema='{"type":"object","properties":{"text":{"type":"string"},"summary":{"type":"string"},"itemCount":{"type":"integer"},"metadata":{"type":"object"}},"required":["text","summary","itemCount","metadata"],"additionalProperties":false}'
+prompt="$(
+  cat <<EOF
+Answer this question using current public web information:
+$query
+
+Return JSON only with these fields:
+- text: the full grounded answer
+- summary: a one-sentence summary
+- itemCount: use 1
+- metadata: include a short note such as the task type
+
+Use WebSearch and WebFetch when needed.
+EOF
+)"
+
+args=(
+  -p
+  --output-format json
+  --json-schema "$schema"
+  --permission-mode dontAsk
+  --allowedTools "WebSearch,WebFetch"
+  --no-session-persistence
+)
+
+if [[ -n "$model" ]]; then
+  args+=(--model "$model")
+fi
+
+echo "Answering with Claude..." >&2
+(
+  cd "$cwd"
+  claude "${args[@]}" "$prompt"
+)

--- a/examples/custom-cli/wrappers/codex-search.sh
+++ b/examples/custom-cli/wrappers/codex-search.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+request="$(cat)"
+cwd="$(jq -r '.cwd // "."' <<<"$request")"
+query="$(jq -r '.query' <<<"$request")"
+max_results="$(jq -r '.maxResults // 5' <<<"$request")"
+model="$(jq -r '.options.model // empty' <<<"$request")"
+
+schema_file="$(mktemp)"
+output_file="$(mktemp)"
+trap 'rm -f "$schema_file" "$output_file"' EXIT
+
+cat >"$schema_file" <<'JSON'
+{
+  "type": "object",
+  "properties": {
+    "results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "title": { "type": "string" },
+          "url": { "type": "string" },
+          "snippet": { "type": "string" }
+        },
+        "required": ["title", "url", "snippet"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["results"],
+  "additionalProperties": false
+}
+JSON
+
+prompt="$(
+  cat <<EOF
+Search the public web for: $query
+
+Return JSON only.
+Return at most $max_results results.
+Each result must include:
+- title
+- url
+- snippet
+
+Prefer primary or official sources when possible.
+EOF
+)"
+
+args=(
+  --search exec
+  --skip-git-repo-check
+  --sandbox read-only
+  --color never
+  --cd "$cwd"
+  --output-schema "$schema_file"
+  --output-last-message "$output_file"
+)
+
+if [[ -n "$model" ]]; then
+  args+=(--model "$model")
+fi
+
+echo "Searching with Codex..." >&2
+codex "${args[@]}" "$prompt" >/dev/null
+jq . "$output_file"

--- a/examples/custom-cli/wrappers/gemini-contents.sh
+++ b/examples/custom-cli/wrappers/gemini-contents.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GOOGLE_API_KEY:?GOOGLE_API_KEY is required}"
+
+request="$(cat)"
+model="$(jq -r '.options.model // "gemini-2.5-flash"' <<<"$request")"
+url_count="$(jq '.urls | length' <<<"$request")"
+urls="$(jq -r '.urls[]' <<<"$request")"
+
+prompt="$(
+  cat <<EOF
+Extract the main textual content from these URLs:
+$urls
+
+Return JSON only with these fields:
+- text: the extracted content
+- summary: a short summary
+- itemCount: the number of processed URLs ($url_count)
+- metadata: include the input URLs under metadata.urls
+EOF
+)"
+
+body="$(
+  jq -n \
+    --arg prompt "$prompt" \
+    '{
+    contents: [{parts: [{text: $prompt}]}],
+    tools: [{urlContext: {}}],
+    generationConfig: {responseMimeType: "application/json"}
+  }'
+)"
+
+echo "Fetching contents with Gemini..." >&2
+response="$(curl -sS -X POST \
+  "https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${GOOGLE_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "$body")"
+
+error="$(jq -r '.error.message // empty' <<<"$response")"
+if [[ -n "$error" ]]; then
+  echo "$error" >&2
+  exit 1
+fi
+
+text="$(jq -r '[.candidates[]?.content.parts[]?.text // empty] | join("\n")' <<<"$response")"
+json_text="$(printf '%s\n' "$text" | sed -e '1s/^```json[[:space:]]*//' -e '1s/^```[[:space:]]*//' -e '$s/```$//')"
+jq . <<<"$json_text"

--- a/examples/custom-cli/wrappers/perplexity-research.sh
+++ b/examples/custom-cli/wrappers/perplexity-research.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${PERPLEXITY_API_KEY:?PERPLEXITY_API_KEY is required}"
+
+request="$(cat)"
+input="$(jq -r '.input' <<<"$request")"
+model="$(jq -r '.options.model // "sonar-deep-research"' <<<"$request")"
+
+body="$(
+  jq -n \
+    --arg model "$model" \
+    --arg input "$input" \
+    '{
+    model: $model,
+    stream: false,
+    messages: [{role: "user", content: $input}]
+  }'
+)"
+
+echo "Researching with Perplexity..." >&2
+response="$(curl -sS https://api.perplexity.ai/chat/completions \
+  -H "Authorization: Bearer ${PERPLEXITY_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "$body")"
+
+error="$(jq -r '.error.message // empty' <<<"$response")"
+if [[ -n "$error" ]]; then
+  echo "$error" >&2
+  exit 1
+fi
+
+citations="$(jq '.citations // []' <<<"$response")"
+count="$(jq '(.citations // []) | length' <<<"$response")"
+text="$(jq -r '
+  (.choices[0].message.content // "No research returned.") as $text
+  | (.citations // []) as $citations
+  | if ($citations | length) == 0 then
+      $text
+    else
+      $text + "\n\nSources:\n" + ($citations | to_entries | map("\(.key + 1). \(.value)") | join("\n"))
+    end
+' <<<"$response")"
+
+jq -n \
+  --arg text "$text" \
+  --arg summary "Research via Perplexity with $count source(s)" \
+  --argjson itemCount "$count" \
+  --argjson citations "$citations" \
+  '{
+    text: $text,
+    summary: $summary,
+    itemCount: $itemCount,
+    metadata: {citations: $citations}
+  }'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "example-config.json",
+    "examples"
   ],
   "keywords": [
     "pi-package",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-web-providers",
   "version": "1.0.0",
-  "description": "Configurable web access extension for pi with per-tool provider routing for search, contents, answers, and research across Claude, Codex, Exa, Gemini, Perplexity, Parallel, and Valyu.",
+  "description": "Configurable web access extension for pi with per-tool provider routing for search, contents, answers, and research across Claude, Codex, Custom CLI, Exa, Gemini, Perplexity, Parallel, and Valyu.",
   "type": "module",
   "files": [
     "dist",
@@ -15,6 +15,7 @@
     "web-search",
     "claude",
     "codex",
+    "custom-cli",
     "exa",
     "gemini",
     "perplexity",

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,8 @@ import {
 import type {
   ClaudeProviderConfig,
   CodexProviderConfig,
+  CustomCliCommandConfig,
+  CustomCliProviderConfig,
   ExaProviderConfig,
   ExecutionPolicyDefaults,
   GeminiProviderConfig,
@@ -61,6 +63,9 @@ export function createDefaultConfig(): WebProvidersConfig {
           webSearchEnabled: true,
           webSearchMode: "live",
         },
+      },
+      "custom-cli": {
+        enabled: false,
       },
       exa: {
         enabled: false,
@@ -170,6 +175,7 @@ export function parseProviderConfig(
 ):
   | ClaudeProviderConfig
   | CodexProviderConfig
+  | CustomCliProviderConfig
   | ExaProviderConfig
   | GeminiProviderConfig
   | PerplexityProviderConfig
@@ -303,6 +309,12 @@ function normalizeConfig(raw: unknown, source: string): WebProvidersConfig {
         source,
       );
     }
+    if (raw.providers["custom-cli"] !== undefined) {
+      config.providers["custom-cli"] = normalizeCustomCliProvider(
+        raw.providers["custom-cli"],
+        source,
+      );
+    }
     if (raw.providers.exa !== undefined) {
       config.providers.exa = normalizeExaProvider(raw.providers.exa, source);
     }
@@ -335,6 +347,7 @@ function normalizeConfig(raw: unknown, source: string): WebProvidersConfig {
       (key) =>
         key !== "claude" &&
         key !== "codex" &&
+        key !== "custom-cli" &&
         key !== "exa" &&
         key !== "gemini" &&
         key !== "perplexity" &&
@@ -753,6 +766,61 @@ function normalizeParallelProvider(
   };
 }
 
+function normalizeCustomCliProvider(
+  raw: unknown,
+  source: string,
+): CustomCliProviderConfig {
+  const provider = parseProviderObject(raw, source, "custom-cli");
+  rejectLegacyProviderToolFields(provider, source, "custom-cli");
+  const native = parseOptionalJsonObject(
+    stripPolicyFields(getProviderNativeSource(provider)),
+    source,
+    provider.native !== undefined
+      ? "providers.custom-cli.native"
+      : "providers.custom-cli.defaults",
+  );
+
+  return {
+    enabled: parseOptionalBoolean(
+      provider.enabled,
+      source,
+      "providers.custom-cli.enabled",
+    ),
+    native:
+      native === undefined
+        ? undefined
+        : {
+            search: parseOptionalCustomCliCommand(
+              native.search,
+              source,
+              "providers.custom-cli.native.search",
+            ),
+            contents: parseOptionalCustomCliCommand(
+              native.contents,
+              source,
+              "providers.custom-cli.native.contents",
+            ),
+            answer: parseOptionalCustomCliCommand(
+              native.answer,
+              source,
+              "providers.custom-cli.native.answer",
+            ),
+            research: parseOptionalCustomCliCommand(
+              native.research,
+              source,
+              "providers.custom-cli.native.research",
+            ),
+          },
+    policy: parseOptionalExecutionPolicy(
+      getProviderPolicySource(provider),
+      source,
+      provider.policy !== undefined
+        ? "providers.custom-cli.policy"
+        : "providers.custom-cli.defaults",
+    ),
+  };
+}
+
 function getProviderNativeSource(provider: JsonObject): unknown {
   return provider.native ?? provider.defaults;
 }
@@ -1068,6 +1136,28 @@ function inferProviderEnabled(
   return (
     Object.values(config.tools ?? {}) as Array<ProviderId | null | undefined>
   ).some((mappedProviderId) => mappedProviderId === providerId);
+}
+
+function parseOptionalCustomCliCommand(
+  value: unknown,
+  source: string,
+  field: string,
+): CustomCliCommandConfig | undefined {
+  const config = parseOptionalJsonObject(value, source, field);
+  if (!config) {
+    return undefined;
+  }
+
+  const argv = parseOptionalStringArray(config.argv, source, `${field}.argv`);
+  if (argv !== undefined && argv.length === 0) {
+    throw new Error(`'${field}.argv' in ${source} must not be empty.`);
+  }
+
+  return {
+    argv,
+    cwd: parseOptionalString(config.cwd, source, `${field}.cwd`),
+    env: parseOptionalStringMap(config.env, source, `${field}.env`),
+  };
 }
 
 function parseOptionalStringMap(

--- a/src/config.ts
+++ b/src/config.ts
@@ -1149,8 +1149,13 @@ function parseOptionalCustomCliCommand(
   }
 
   const argv = parseOptionalStringArray(config.argv, source, `${field}.argv`);
-  if (argv !== undefined && argv.length === 0) {
-    throw new Error(`'${field}.argv' in ${source} must not be empty.`);
+  if (
+    argv !== undefined &&
+    (argv.length === 0 || argv.some((entry) => entry.trim().length === 0))
+  ) {
+    throw new Error(
+      `'${field}.argv' in ${source} must be a non-empty array of non-empty strings.`,
+    );
   }
 
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1424,13 +1424,22 @@ function getProviderSettings(
 
 function getEnabledCompatibleProvidersForTool(
   config: WebProvidersConfig,
+  cwd: string,
   toolId: ProviderToolId,
 ): ProviderId[] {
-  return getCompatibleProvidersForTool(toolId).filter(
-    (providerId) =>
-      (config.providers?.[providerId] as ProviderConfigUnion | undefined)
-        ?.enabled === true,
-  );
+  return getCompatibleProvidersForTool(toolId).filter((providerId) => {
+    const providerConfig = config.providers?.[providerId] as
+      | ProviderConfigUnion
+      | undefined;
+    if (providerConfig?.enabled !== true) {
+      return false;
+    }
+    return PROVIDER_MAP[providerId].getStatus(
+      providerConfig as never,
+      cwd,
+      toolId,
+    ).available;
+  });
 }
 
 function getSearchToolSettings(
@@ -1737,6 +1746,7 @@ class WebProvidersSettingsView implements Component {
       (toolId) => {
         const enabledCompatibleProviders = getEnabledCompatibleProvidersForTool(
           this.config,
+          this.ctx.cwd,
           toolId,
         );
         const mappedProviderId = getMappedProviderIdForCapability(
@@ -1955,6 +1965,7 @@ class WebProvidersSettingsView implements Component {
         this.tui,
         this.theme,
         toolId,
+        this.ctx.cwd,
         () => this.config,
         async (mutate) => {
           await this.persist(mutate);
@@ -2052,6 +2063,7 @@ class ToolSettingsSubmenu implements Component {
     private readonly tui: TUI,
     private readonly theme: Theme,
     private readonly toolId: ProviderToolId,
+    private readonly cwd: string,
     private readonly getConfig: () => WebProvidersConfig,
     private readonly persist: (
       mutate: (config: WebProvidersConfig) => void,
@@ -2135,6 +2147,7 @@ class ToolSettingsSubmenu implements Component {
     );
     const enabledProviderIds = getEnabledCompatibleProvidersForTool(
       config,
+      this.cwd,
       this.toolId,
     );
     const providerValues = [
@@ -2161,6 +2174,7 @@ class ToolSettingsSubmenu implements Component {
       const prefetch = getSearchPrefetchDefaults(config);
       const prefetchProviderIds = getEnabledCompatibleProvidersForTool(
         config,
+        this.cwd,
         "contents",
       );
       const prefetchValues = [
@@ -2281,7 +2295,11 @@ class ToolSettingsSubmenu implements Component {
           config.tools[this.toolId] =
             value === "off"
               ? null
-              : (getEnabledCompatibleProvidersForTool(config, this.toolId).find(
+              : (getEnabledCompatibleProvidersForTool(
+                  config,
+                  this.cwd,
+                  this.toolId,
+                ).find(
                   (providerId) => PROVIDER_MAP[providerId].label === value,
                 ) ?? null);
           return;
@@ -2289,7 +2307,11 @@ class ToolSettingsSubmenu implements Component {
           const providerId =
             value === "off"
               ? null
-              : (getEnabledCompatibleProvidersForTool(config, "contents").find(
+              : (getEnabledCompatibleProvidersForTool(
+                  config,
+                  this.cwd,
+                  "contents",
+                ).find(
                   (candidate) => PROVIDER_MAP[candidate].label === value,
                 ) ?? null);
           ensureSearchToolSettings(config).prefetch ??= {};
@@ -3043,6 +3065,7 @@ export const __test__ = {
   executeSearchTool,
   extractTextContent,
   getAvailableManagedToolNames,
+  getEnabledCompatibleProvidersForTool,
   describeOptionsField,
   getAvailableProviderIdsForCapability,
   getSyncedActiveTools,

--- a/src/prefetch-manager.ts
+++ b/src/prefetch-manager.ts
@@ -1165,7 +1165,7 @@ function resolveContentsProvider(
   }
 
   const providerConfig = getEffectiveProviderConfig(config, explicitProvider);
-  const status = provider.getStatus(providerConfig as never, cwd);
+  const status = provider.getStatus(providerConfig as never, cwd, "contents");
   if (status.available) {
     return provider;
   }

--- a/src/provider-config-manifests.ts
+++ b/src/provider-config-manifests.ts
@@ -232,6 +232,25 @@ export const PROVIDER_CONFIG_MANIFESTS = {
           setCustomCliArgv(config, "search", value);
         },
       }),
+      stringSetting<CustomCliProviderConfig>({
+        id: "customCliSearchCwd",
+        label: "Search cwd",
+        help: "Optional working directory for the web_search command. Relative paths resolve from the active project directory.",
+        getValue: (config) => getCustomCliNative(config)?.search?.cwd,
+        setValue: (config, value) => {
+          setCustomCliCwd(config, "search", value);
+        },
+      }),
+      stringSetting<CustomCliProviderConfig>({
+        id: "customCliSearchEnv",
+        label: "Search env",
+        help: "Optional JSON object of string environment variables for the web_search command. Values can be literal strings, env var names, or !command.",
+        getValue: (config) =>
+          formatCustomCliEnv(getCustomCliNative(config)?.search?.env),
+        setValue: (config, value) => {
+          setCustomCliEnv(config, "search", value);
+        },
+      }),
       jsonArraySetting<CustomCliProviderConfig>({
         id: "customCliContentsArgv",
         label: "Contents argv",
@@ -242,6 +261,25 @@ export const PROVIDER_CONFIG_MANIFESTS = {
             : undefined,
         setValue: (config, value) => {
           setCustomCliArgv(config, "contents", value);
+        },
+      }),
+      stringSetting<CustomCliProviderConfig>({
+        id: "customCliContentsCwd",
+        label: "Contents cwd",
+        help: "Optional working directory for the web_contents command. Relative paths resolve from the active project directory.",
+        getValue: (config) => getCustomCliNative(config)?.contents?.cwd,
+        setValue: (config, value) => {
+          setCustomCliCwd(config, "contents", value);
+        },
+      }),
+      stringSetting<CustomCliProviderConfig>({
+        id: "customCliContentsEnv",
+        label: "Contents env",
+        help: "Optional JSON object of string environment variables for the web_contents command. Values can be literal strings, env var names, or !command.",
+        getValue: (config) =>
+          formatCustomCliEnv(getCustomCliNative(config)?.contents?.env),
+        setValue: (config, value) => {
+          setCustomCliEnv(config, "contents", value);
         },
       }),
       jsonArraySetting<CustomCliProviderConfig>({
@@ -256,6 +294,25 @@ export const PROVIDER_CONFIG_MANIFESTS = {
           setCustomCliArgv(config, "answer", value);
         },
       }),
+      stringSetting<CustomCliProviderConfig>({
+        id: "customCliAnswerCwd",
+        label: "Answer cwd",
+        help: "Optional working directory for the web_answer command. Relative paths resolve from the active project directory.",
+        getValue: (config) => getCustomCliNative(config)?.answer?.cwd,
+        setValue: (config, value) => {
+          setCustomCliCwd(config, "answer", value);
+        },
+      }),
+      stringSetting<CustomCliProviderConfig>({
+        id: "customCliAnswerEnv",
+        label: "Answer env",
+        help: "Optional JSON object of string environment variables for the web_answer command. Values can be literal strings, env var names, or !command.",
+        getValue: (config) =>
+          formatCustomCliEnv(getCustomCliNative(config)?.answer?.env),
+        setValue: (config, value) => {
+          setCustomCliEnv(config, "answer", value);
+        },
+      }),
       jsonArraySetting<CustomCliProviderConfig>({
         id: "customCliResearchArgv",
         label: "Research argv",
@@ -268,7 +325,26 @@ export const PROVIDER_CONFIG_MANIFESTS = {
           setCustomCliArgv(config, "research", value);
         },
       }),
-      ...lifecyclePolicySettings<CustomCliProviderConfig>(),
+      stringSetting<CustomCliProviderConfig>({
+        id: "customCliResearchCwd",
+        label: "Research cwd",
+        help: "Optional working directory for the web_research command. Relative paths resolve from the active project directory.",
+        getValue: (config) => getCustomCliNative(config)?.research?.cwd,
+        setValue: (config, value) => {
+          setCustomCliCwd(config, "research", value);
+        },
+      }),
+      stringSetting<CustomCliProviderConfig>({
+        id: "customCliResearchEnv",
+        label: "Research env",
+        help: "Optional JSON object of string environment variables for the web_research command. Values can be literal strings, env var names, or !command.",
+        getValue: (config) =>
+          formatCustomCliEnv(getCustomCliNative(config)?.research?.env),
+        setValue: (config, value) => {
+          setCustomCliEnv(config, "research", value);
+        },
+      }),
+      ...requestPolicySettings<CustomCliProviderConfig>(),
     ],
   },
   exa: {
@@ -580,6 +656,65 @@ function baseUrlSetting<TConfig extends { baseUrl?: string }>() {
   });
 }
 
+function requestPolicySettings<
+  TConfig extends { policy?: ExecutionPolicyDefaults },
+>() {
+  return [
+    integerSetting<TConfig>({
+      id: "requestTimeoutMs",
+      label: "Request timeout (ms)",
+      help: "Maximum time to wait for each command before failing that attempt for this provider. Leave empty to inherit the generic setting.",
+      minimum: 1,
+      errorMessage: "Request timeout must be a positive integer.",
+      getValue: (config) => getIntegerString(config?.policy?.requestTimeoutMs),
+      setValue: (config, value) => {
+        assignOptionalInteger(
+          ensurePolicy(config),
+          "requestTimeoutMs",
+          value,
+          "Request timeout must be a positive integer.",
+        );
+        cleanupEmpty(config, "policy");
+      },
+    }),
+    integerSetting<TConfig>({
+      id: "retryCount",
+      label: "Retry count",
+      help: "How many times to retry transient command failures for this provider. Leave empty to inherit the generic setting.",
+      minimum: 0,
+      errorMessage: "Retry count must be a non-negative integer.",
+      getValue: (config) => getIntegerString(config?.policy?.retryCount),
+      setValue: (config, value) => {
+        assignOptionalInteger(
+          ensurePolicy(config),
+          "retryCount",
+          value,
+          "Retry count must be a non-negative integer.",
+          { allowZero: true },
+        );
+        cleanupEmpty(config, "policy");
+      },
+    }),
+    integerSetting<TConfig>({
+      id: "retryDelayMs",
+      label: "Retry delay (ms)",
+      help: "Initial delay before retrying command failures for this provider. Leave empty to inherit the generic setting.",
+      minimum: 1,
+      errorMessage: "Retry delay must be a positive integer.",
+      getValue: (config) => getIntegerString(config?.policy?.retryDelayMs),
+      setValue: (config, value) => {
+        assignOptionalInteger(
+          ensurePolicy(config),
+          "retryDelayMs",
+          value,
+          "Retry delay must be a positive integer.",
+        );
+        cleanupEmpty(config, "policy");
+      },
+    }),
+  ] as const;
+}
+
 function lifecyclePolicySettings<
   TConfig extends { policy?: ExecutionPolicyDefaults },
 >() {
@@ -823,6 +958,12 @@ function ensureCustomCliNative(
   return config.native;
 }
 
+function formatCustomCliEnv(
+  env: Record<string, string> | undefined,
+): string | undefined {
+  return env ? JSON.stringify(env) : undefined;
+}
+
 function setCustomCliArgv(
   config: CustomCliProviderConfig,
   capability: keyof CustomCliProviderNativeConfig,
@@ -860,6 +1001,64 @@ function setCustomCliArgv(
     ...(native[capability] ?? {}),
     argv: parsed,
   };
+  cleanupCustomCliNative(config);
+}
+
+function setCustomCliCwd(
+  config: CustomCliProviderConfig,
+  capability: keyof CustomCliProviderNativeConfig,
+  value: string,
+): void {
+  const native = ensureCustomCliNative(config);
+  const command = { ...(native[capability] ?? {}) };
+  assignOptionalString(
+    command as Record<
+      string,
+      string | number | boolean | JsonObject | undefined
+    >,
+    "cwd",
+    value,
+  );
+  native[capability] = command;
+  cleanupCustomCliNative(config);
+}
+
+function setCustomCliEnv(
+  config: CustomCliProviderConfig,
+  capability: keyof CustomCliProviderNativeConfig,
+  value: string,
+): void {
+  const trimmed = value.trim();
+  const native = ensureCustomCliNative(config);
+  const command = { ...(native[capability] ?? {}) };
+
+  if (!trimmed) {
+    delete command.env;
+  } else {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch (error) {
+      throw new Error(
+        `Custom CLI ${capability} env must be a JSON object of strings: ${(error as Error).message}`,
+      );
+    }
+
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      Array.isArray(parsed) ||
+      Object.values(parsed).some((entry) => typeof entry !== "string")
+    ) {
+      throw new Error(
+        `Custom CLI ${capability} env must be a JSON object of strings.`,
+      );
+    }
+
+    command.env = parsed as Record<string, string>;
+  }
+
+  native[capability] = command;
   cleanupCustomCliNative(config);
 }
 

--- a/src/provider-config-manifests.ts
+++ b/src/provider-config-manifests.ts
@@ -3,6 +3,8 @@ import type {
   ClaudeProviderNativeConfig,
   CodexProviderConfig,
   CodexProviderNativeConfig,
+  CustomCliProviderConfig,
+  CustomCliProviderNativeConfig,
   ExaProviderConfig,
   ExecutionPolicyDefaults,
   GeminiProviderConfig,
@@ -214,6 +216,59 @@ export const PROVIDER_CONFIG_MANIFESTS = {
           cleanupEmpty(config, "native");
         },
       }),
+    ],
+  },
+  "custom-cli": {
+    settings: [
+      jsonArraySetting<CustomCliProviderConfig>({
+        id: "customCliSearchArgv",
+        label: "Search argv",
+        help: `Optional JSON string array for the command to run for web_search, for example ["node","./scripts/codex-search.mjs"].`,
+        getValue: (config) =>
+          getCustomCliNative(config)?.search?.argv
+            ? JSON.stringify(getCustomCliNative(config)?.search?.argv)
+            : undefined,
+        setValue: (config, value) => {
+          setCustomCliArgv(config, "search", value);
+        },
+      }),
+      jsonArraySetting<CustomCliProviderConfig>({
+        id: "customCliContentsArgv",
+        label: "Contents argv",
+        help: "Optional JSON string array for the command to run for web_contents.",
+        getValue: (config) =>
+          getCustomCliNative(config)?.contents?.argv
+            ? JSON.stringify(getCustomCliNative(config)?.contents?.argv)
+            : undefined,
+        setValue: (config, value) => {
+          setCustomCliArgv(config, "contents", value);
+        },
+      }),
+      jsonArraySetting<CustomCliProviderConfig>({
+        id: "customCliAnswerArgv",
+        label: "Answer argv",
+        help: "Optional JSON string array for the command to run for web_answer.",
+        getValue: (config) =>
+          getCustomCliNative(config)?.answer?.argv
+            ? JSON.stringify(getCustomCliNative(config)?.answer?.argv)
+            : undefined,
+        setValue: (config, value) => {
+          setCustomCliArgv(config, "answer", value);
+        },
+      }),
+      jsonArraySetting<CustomCliProviderConfig>({
+        id: "customCliResearchArgv",
+        label: "Research argv",
+        help: "Optional JSON string array for the command to run for web_research.",
+        getValue: (config) =>
+          getCustomCliNative(config)?.research?.argv
+            ? JSON.stringify(getCustomCliNative(config)?.research?.argv)
+            : undefined,
+        setValue: (config, value) => {
+          setCustomCliArgv(config, "research", value);
+        },
+      }),
+      ...lifecyclePolicySettings<CustomCliProviderConfig>(),
     ],
   },
   exa: {
@@ -473,6 +528,15 @@ function valuesSetting<TConfig>(
 ): ProviderValuesSettingDescriptor<TConfig> {
   return {
     kind: "values",
+    ...setting,
+  };
+}
+
+function jsonArraySetting<TConfig>(
+  setting: Omit<ProviderTextSettingDescriptor<TConfig>, "kind">,
+): ProviderTextSettingDescriptor<TConfig> {
+  return {
+    kind: "text",
     ...setting,
   };
 }
@@ -739,6 +803,93 @@ function ensureGeminiNative(
     string,
     string | number | boolean | JsonObject | undefined
   >;
+}
+
+function getCustomCliNative(config: CustomCliProviderConfig | undefined) {
+  return config?.native ?? config?.defaults;
+}
+
+function ensureCustomCliNative(
+  config: CustomCliProviderConfig,
+): CustomCliProviderNativeConfig {
+  const native = getCustomCliNative(config);
+  config.native = {
+    ...(native?.search ? { search: { ...native.search } } : {}),
+    ...(native?.contents ? { contents: { ...native.contents } } : {}),
+    ...(native?.answer ? { answer: { ...native.answer } } : {}),
+    ...(native?.research ? { research: { ...native.research } } : {}),
+  };
+  delete config.defaults;
+  return config.native;
+}
+
+function setCustomCliArgv(
+  config: CustomCliProviderConfig,
+  capability: keyof CustomCliProviderNativeConfig,
+  value: string,
+): void {
+  const trimmed = value.trim();
+  const native = ensureCustomCliNative(config);
+  if (!trimmed) {
+    delete native[capability];
+    cleanupCustomCliNative(config);
+    return;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (error) {
+    throw new Error(
+      `Custom CLI ${capability} argv must be a JSON string array: ${(error as Error).message}`,
+    );
+  }
+
+  if (
+    !Array.isArray(parsed) ||
+    parsed.some(
+      (entry) => typeof entry !== "string" || entry.trim().length === 0,
+    )
+  ) {
+    throw new Error(
+      `Custom CLI ${capability} argv must be a non-empty JSON string array.`,
+    );
+  }
+
+  native[capability] = {
+    ...(native[capability] ?? {}),
+    argv: parsed,
+  };
+  cleanupCustomCliNative(config);
+}
+
+function cleanupCustomCliNative(config: CustomCliProviderConfig): void {
+  const native = config.native;
+  if (!native) {
+    return;
+  }
+
+  for (const capability of [
+    "search",
+    "contents",
+    "answer",
+    "research",
+  ] as const) {
+    const entry = native[capability];
+    if (!entry) {
+      continue;
+    }
+
+    if (
+      entry.argv === undefined &&
+      entry.cwd === undefined &&
+      (entry.env === undefined || Object.keys(entry.env).length === 0)
+    ) {
+      delete native[capability];
+    }
+  }
+
+  cleanupEmpty(config, "native");
 }
 
 function getParallelNative(config: ParallelProviderConfig | undefined) {

--- a/src/provider-config-manifests.ts
+++ b/src/provider-config-manifests.ts
@@ -988,6 +988,7 @@ function setCustomCliArgv(
 
   if (
     !Array.isArray(parsed) ||
+    parsed.length === 0 ||
     parsed.some(
       (entry) => typeof entry !== "string" || entry.trim().length === 0,
     )

--- a/src/provider-resolution.ts
+++ b/src/provider-resolution.ts
@@ -102,7 +102,7 @@ export function resolveProviderForCapability(
   }
 
   const providerConfig = getEffectiveProviderConfig(config, providerId);
-  const status = provider.getStatus(providerConfig as never, cwd);
+  const status = provider.getStatus(providerConfig as never, cwd, capability);
   if (!status.available) {
     throw new Error(
       `Provider '${providerId}' is not available: ${status.summary}.`,

--- a/src/provider-tools.ts
+++ b/src/provider-tools.ts
@@ -1,6 +1,7 @@
 import type {
   ClaudeProviderConfig,
   CodexProviderConfig,
+  CustomCliProviderConfig,
   ExaProviderConfig,
   GeminiProviderConfig,
   ParallelProviderConfig,
@@ -23,6 +24,7 @@ export type ProviderToolId = (typeof PROVIDER_TOOL_IDS)[number];
 export const PROVIDER_TOOLS: Record<ProviderId, readonly ProviderToolId[]> = {
   claude: ["search", "answer"],
   codex: ["search"],
+  "custom-cli": ["search", "contents", "answer", "research"],
   exa: ["search", "contents", "answer", "research"],
   gemini: ["search", "answer", "research"],
   perplexity: ["search", "answer", "research"],
@@ -55,6 +57,7 @@ export const PROVIDER_TOOL_META: Record<
 export type ProviderConfigUnion =
   | ClaudeProviderConfig
   | CodexProviderConfig
+  | CustomCliProviderConfig
   | ExaProviderConfig
   | GeminiProviderConfig
   | PerplexityProviderConfig

--- a/src/providers/cli-json.ts
+++ b/src/providers/cli-json.ts
@@ -1,0 +1,177 @@
+import { spawn } from "node:child_process";
+import { isAbsolute, resolve } from "node:path";
+import { resolveEnvMap } from "../config.js";
+import type {
+  CustomCliCommandConfig,
+  JsonObject,
+  ProviderContext,
+} from "../types.js";
+
+export async function runCliJsonCommand<TOutput>({
+  command,
+  payload,
+  context,
+  label,
+}: {
+  command: CustomCliCommandConfig;
+  payload: JsonObject;
+  context: ProviderContext;
+  label: string;
+}): Promise<TOutput> {
+  const argv = normalizeArgv(command);
+  const cwd = resolveCommandCwd(command.cwd, context.cwd);
+  const env = {
+    ...process.env,
+    ...(resolveEnvMap(command.env) ?? {}),
+  };
+
+  return await new Promise<TOutput>((resolvePromise, rejectPromise) => {
+    let settled = false;
+    let stdout = "";
+    let stderr = "";
+    let stderrBuffer = "";
+    let abortTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const child = spawn(argv[0], argv.slice(1), {
+      cwd,
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const rejectOnce = (error: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (abortTimer) {
+        clearTimeout(abortTimer);
+      }
+      context.signal?.removeEventListener("abort", onAbort);
+      rejectPromise(error);
+    };
+
+    const resolveOnce = (value: TOutput) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (abortTimer) {
+        clearTimeout(abortTimer);
+      }
+      context.signal?.removeEventListener("abort", onAbort);
+      resolvePromise(value);
+    };
+
+    const emitProgressLine = (line: string) => {
+      const message = line.trim();
+      if (message.length > 0) {
+        context.onProgress?.(message);
+      }
+    };
+
+    const flushStderrBuffer = () => {
+      if (stderrBuffer.trim().length > 0) {
+        emitProgressLine(stderrBuffer);
+      }
+      stderrBuffer = "";
+    };
+
+    const onAbort = () => {
+      child.kill("SIGTERM");
+      abortTimer = setTimeout(() => {
+        child.kill("SIGKILL");
+      }, 1000);
+    };
+
+    if (context.signal?.aborted) {
+      onAbort();
+    } else {
+      context.signal?.addEventListener("abort", onAbort, { once: true });
+    }
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+      stderrBuffer += chunk;
+      const lines = stderrBuffer.split(/\r?\n/);
+      stderrBuffer = lines.pop() ?? "";
+      for (const line of lines) {
+        emitProgressLine(line);
+      }
+    });
+
+    child.on("error", (error) => {
+      rejectOnce(
+        new Error(
+          `${label} failed to start: ${error.message || String(error)}`,
+        ),
+      );
+    });
+
+    child.on("close", (code, signal) => {
+      flushStderrBuffer();
+
+      if (context.signal?.aborted) {
+        rejectOnce(new Error(`${label} was aborted.`));
+        return;
+      }
+
+      if (code !== 0) {
+        const detail = stderr.trim() || `exit code ${code ?? "unknown"}`;
+        rejectOnce(
+          new Error(
+            signal
+              ? `${label} exited via signal ${signal}: ${detail}`
+              : `${label} failed with exit code ${code}: ${detail}`,
+          ),
+        );
+        return;
+      }
+
+      const trimmed = stdout.trim();
+      if (!trimmed) {
+        rejectOnce(new Error(`${label} did not write JSON to stdout.`));
+        return;
+      }
+
+      try {
+        resolveOnce(JSON.parse(trimmed) as TOutput);
+      } catch (error) {
+        rejectOnce(
+          new Error(
+            `${label} returned invalid JSON: ${(error as Error).message}`,
+          ),
+        );
+      }
+    });
+
+    child.stdin.on("error", () => {
+      // Ignore EPIPE and other shutdown races; close/exit handlers report them.
+    });
+    child.stdin.end(`${JSON.stringify(payload)}\n`);
+  });
+}
+
+function normalizeArgv(command: CustomCliCommandConfig): string[] {
+  const argv = command.argv?.filter((entry) => entry.trim().length > 0) ?? [];
+  if (argv.length === 0) {
+    throw new Error("Custom CLI command is missing argv.");
+  }
+  return argv;
+}
+
+function resolveCommandCwd(
+  commandCwd: string | undefined,
+  fallbackCwd: string,
+): string {
+  if (!commandCwd || commandCwd.trim().length === 0) {
+    return fallbackCwd;
+  }
+
+  return isAbsolute(commandCwd) ? commandCwd : resolve(fallbackCwd, commandCwd);
+}

--- a/src/providers/custom-cli.ts
+++ b/src/providers/custom-cli.ts
@@ -1,0 +1,345 @@
+import { createSilentForegroundPlan } from "../provider-plans.js";
+import type {
+  CustomCliCommandConfig,
+  CustomCliProviderConfig,
+  JsonObject,
+  JsonValue,
+  ProviderCapability,
+  ProviderContext,
+  ProviderOperationRequest,
+  ProviderStatus,
+  ProviderToolOutput,
+  SearchResponse,
+  WebProvider,
+} from "../types.js";
+import { runCliJsonCommand } from "./cli-json.js";
+
+export class CustomCliProvider implements WebProvider<CustomCliProviderConfig> {
+  readonly id: "custom-cli" = "custom-cli";
+  readonly label = "Custom CLI";
+  readonly docsUrl =
+    "https://github.com/mavam/pi-web-providers#custom-cli-provider";
+  readonly capabilities = ["search", "contents", "answer", "research"] as const;
+
+  createTemplate(): CustomCliProviderConfig {
+    return {
+      enabled: false,
+    };
+  }
+
+  getStatus(
+    config: CustomCliProviderConfig | undefined,
+    _cwd: string,
+    capability?: ProviderCapability,
+  ): ProviderStatus {
+    if (!config) {
+      return { available: false, summary: "not configured" };
+    }
+    if (config.enabled === false) {
+      return { available: false, summary: "disabled" };
+    }
+
+    if (capability) {
+      return hasCommandForCapability(config, capability)
+        ? { available: true, summary: "enabled" }
+        : {
+            available: false,
+            summary: `no command configured for ${capability}`,
+          };
+    }
+
+    return hasAnyCommand(config)
+      ? { available: true, summary: "enabled" }
+      : { available: false, summary: "no commands configured" };
+  }
+
+  buildPlan(
+    request: ProviderOperationRequest,
+    config: CustomCliProviderConfig,
+  ) {
+    switch (request.capability) {
+      case "search":
+        return createSilentForegroundPlan({
+          config,
+          capability: request.capability,
+          providerId: this.id,
+          providerLabel: this.label,
+          execute: (context: ProviderContext) =>
+            this.search(
+              request.query,
+              request.maxResults,
+              request.options,
+              config,
+              context,
+            ),
+        });
+      case "contents":
+        return createSilentForegroundPlan({
+          config,
+          capability: request.capability,
+          providerId: this.id,
+          providerLabel: this.label,
+          execute: (context: ProviderContext) =>
+            this.contents(request.urls, request.options, config, context),
+        });
+      case "answer":
+        return createSilentForegroundPlan({
+          config,
+          capability: request.capability,
+          providerId: this.id,
+          providerLabel: this.label,
+          execute: (context: ProviderContext) =>
+            this.answer(request.query, request.options, config, context),
+        });
+      case "research":
+        return createSilentForegroundPlan({
+          config,
+          capability: request.capability,
+          providerId: this.id,
+          providerLabel: this.label,
+          execute: (context: ProviderContext) =>
+            this.research(request.input, request.options, config, context),
+        });
+      default:
+        return null;
+    }
+  }
+
+  async search(
+    query: string,
+    maxResults: number,
+    options: JsonObject | undefined,
+    config: CustomCliProviderConfig,
+    context: ProviderContext,
+  ): Promise<SearchResponse> {
+    const output = await this.runCommand<unknown>({
+      capability: "search",
+      payload: {
+        capability: "search",
+        query,
+        maxResults,
+        ...(options ? { options } : {}),
+      },
+      config,
+      context,
+    });
+
+    return parseSearchResponse(output, this.id);
+  }
+
+  async contents(
+    urls: string[],
+    options: JsonObject | undefined,
+    config: CustomCliProviderConfig,
+    context: ProviderContext,
+  ): Promise<ProviderToolOutput> {
+    const output = await this.runCommand<unknown>({
+      capability: "contents",
+      payload: {
+        capability: "contents",
+        urls,
+        ...(options ? { options } : {}),
+      },
+      config,
+      context,
+    });
+
+    return parseProviderToolOutput(output, this.id);
+  }
+
+  async answer(
+    query: string,
+    options: JsonObject | undefined,
+    config: CustomCliProviderConfig,
+    context: ProviderContext,
+  ): Promise<ProviderToolOutput> {
+    const output = await this.runCommand<unknown>({
+      capability: "answer",
+      payload: {
+        capability: "answer",
+        query,
+        ...(options ? { options } : {}),
+      },
+      config,
+      context,
+    });
+
+    return parseProviderToolOutput(output, this.id);
+  }
+
+  async research(
+    input: string,
+    options: JsonObject | undefined,
+    config: CustomCliProviderConfig,
+    context: ProviderContext,
+  ): Promise<ProviderToolOutput> {
+    const output = await this.runCommand<unknown>({
+      capability: "research",
+      payload: {
+        capability: "research",
+        input,
+        ...(options ? { options } : {}),
+      },
+      config,
+      context,
+    });
+
+    return parseProviderToolOutput(output, this.id);
+  }
+
+  private async runCommand<TOutput>({
+    capability,
+    payload,
+    config,
+    context,
+  }: {
+    capability: ProviderCapability;
+    payload: JsonObject;
+    config: CustomCliProviderConfig;
+    context: ProviderContext;
+  }): Promise<TOutput> {
+    const command = getCommandConfig(config, capability);
+    if (!command) {
+      throw new Error(
+        `Custom CLI has no command configured for ${capability}.`,
+      );
+    }
+
+    context.onProgress?.(`Running Custom CLI ${capability}`);
+    return await runCliJsonCommand<TOutput>({
+      command,
+      payload: {
+        ...payload,
+        cwd: context.cwd,
+      },
+      context,
+      label: `Custom CLI ${capability}`,
+    });
+  }
+}
+
+function getCommandConfig(
+  config: CustomCliProviderConfig,
+  capability: ProviderCapability,
+): CustomCliCommandConfig | undefined {
+  return config.native?.[capability] ?? config.defaults?.[capability];
+}
+
+function hasCommandForCapability(
+  config: CustomCliProviderConfig,
+  capability: ProviderCapability,
+): boolean {
+  return (
+    normalizeConfiguredArgv(getCommandConfig(config, capability)).length > 0
+  );
+}
+
+function hasAnyCommand(config: CustomCliProviderConfig): boolean {
+  return (
+    hasCommandForCapability(config, "search") ||
+    hasCommandForCapability(config, "contents") ||
+    hasCommandForCapability(config, "answer") ||
+    hasCommandForCapability(config, "research")
+  );
+}
+
+function normalizeConfiguredArgv(
+  command: CustomCliCommandConfig | undefined,
+): string[] {
+  return command?.argv?.filter((entry) => entry.trim().length > 0) ?? [];
+}
+
+function parseSearchResponse(
+  value: unknown,
+  providerId: SearchResponse["provider"],
+): SearchResponse {
+  if (!isJsonObject(value)) {
+    throw new Error("Custom CLI search output must be a JSON object.");
+  }
+
+  if (!Array.isArray(value.results)) {
+    throw new Error("Custom CLI search output must include a 'results' array.");
+  }
+
+  return {
+    provider: providerId,
+    results: value.results.map((entry, index) =>
+      parseSearchResult(entry, index),
+    ),
+  };
+}
+
+function parseSearchResult(entry: unknown, index: number) {
+  if (!isJsonObject(entry)) {
+    throw new Error(
+      `Custom CLI search result at index ${index} must be a JSON object.`,
+    );
+  }
+
+  return {
+    title: readRequiredString(entry.title, `results[${index}].title`),
+    url: readRequiredString(entry.url, `results[${index}].url`),
+    snippet: readRequiredString(entry.snippet, `results[${index}].snippet`),
+    ...(typeof entry.score === "number" ? { score: entry.score } : {}),
+    ...(isJsonObject(entry.metadata) ? { metadata: entry.metadata } : {}),
+  };
+}
+
+function parseProviderToolOutput(
+  value: unknown,
+  providerId: ProviderToolOutput["provider"],
+): ProviderToolOutput {
+  if (!isJsonObject(value)) {
+    throw new Error("Custom CLI output must be a JSON object.");
+  }
+
+  return {
+    provider: providerId,
+    text: readRequiredString(value.text, "text"),
+    ...(typeof value.summary === "string" ? { summary: value.summary } : {}),
+    ...(isNonNegativeInteger(value.itemCount)
+      ? { itemCount: value.itemCount }
+      : {}),
+    ...(isJsonObject(value.metadata) ? { metadata: value.metadata } : {}),
+  };
+}
+
+function readRequiredString(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`Custom CLI output field '${field}' must be a string.`);
+  }
+  return value;
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  return Object.values(value as Record<string, unknown>).every(isJsonValue);
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.every(isJsonValue);
+  }
+
+  if (typeof value === "object") {
+    return Object.values(value as Record<string, unknown>).every(isJsonValue);
+  }
+
+  return false;
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,6 +1,7 @@
 import type {
   ClaudeProviderConfig,
   CodexProviderConfig,
+  CustomCliProviderConfig,
   ExaProviderConfig,
   GeminiProviderConfig,
   PerplexityProviderConfig,
@@ -11,6 +12,7 @@ import type {
 } from "../types.js";
 import { ClaudeProvider } from "./claude.js";
 import { CodexProvider } from "./codex.js";
+import { CustomCliProvider } from "./custom-cli.js";
 import { ExaProvider } from "./exa.js";
 import { GeminiProvider } from "./gemini.js";
 import { PerplexityProvider } from "./perplexity.js";
@@ -21,6 +23,7 @@ export const PROVIDERS: ReadonlyArray<
   WebProvider<
     | ClaudeProviderConfig
     | CodexProviderConfig
+    | CustomCliProviderConfig
     | ExaProviderConfig
     | GeminiProviderConfig
     | PerplexityProviderConfig
@@ -30,6 +33,7 @@ export const PROVIDERS: ReadonlyArray<
 > = [
   new ClaudeProvider(),
   new CodexProvider(),
+  new CustomCliProvider(),
   new ExaProvider(),
   new GeminiProvider(),
   new PerplexityProvider(),
@@ -42,6 +46,7 @@ export const PROVIDER_MAP: Record<
   WebProvider<
     | ClaudeProviderConfig
     | CodexProviderConfig
+    | CustomCliProviderConfig
     | ExaProviderConfig
     | GeminiProviderConfig
     | PerplexityProviderConfig
@@ -51,9 +56,10 @@ export const PROVIDER_MAP: Record<
 > = {
   claude: PROVIDERS[0],
   codex: PROVIDERS[1],
-  exa: PROVIDERS[2],
-  gemini: PROVIDERS[3],
-  perplexity: PROVIDERS[4],
-  parallel: PROVIDERS[5],
-  valyu: PROVIDERS[6],
+  "custom-cli": PROVIDERS[2],
+  exa: PROVIDERS[3],
+  gemini: PROVIDERS[4],
+  perplexity: PROVIDERS[5],
+  parallel: PROVIDERS[6],
+  valyu: PROVIDERS[7],
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import type { ModelReasoningEffort, WebSearchMode } from "@openai/codex-sdk";
 export const PROVIDER_IDS = [
   "claude",
   "codex",
+  "custom-cli",
   "exa",
   "gemini",
   "perplexity",
@@ -129,6 +130,19 @@ export interface ParallelProviderNativeConfig {
   extract?: JsonObject;
 }
 
+export interface CustomCliCommandConfig {
+  argv?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+}
+
+export interface CustomCliProviderNativeConfig {
+  search?: CustomCliCommandConfig;
+  contents?: CustomCliCommandConfig;
+  answer?: CustomCliCommandConfig;
+  research?: CustomCliCommandConfig;
+}
+
 // Legacy routing fields are tolerated in TypeScript shapes for internal tests,
 // but config parsing rejects them in persisted config files.
 export interface LegacyProviderRoutingConfig {
@@ -185,6 +199,12 @@ export interface ParallelProviderConfig extends LegacyProviderRoutingConfig {
   defaults?: ParallelProviderNativeConfig;
 }
 
+export interface CustomCliProviderConfig extends LegacyProviderRoutingConfig {
+  native?: CustomCliProviderNativeConfig;
+  policy?: ExecutionPolicyDefaults;
+  defaults?: CustomCliProviderNativeConfig;
+}
+
 export interface ValyuProviderConfig extends LegacyProviderRoutingConfig {
   apiKey?: string;
   baseUrl?: string;
@@ -209,6 +229,7 @@ export interface WebProvidersConfig {
   providers?: {
     claude?: ClaudeProviderConfig;
     codex?: CodexProviderConfig;
+    "custom-cli"?: CustomCliProviderConfig;
     exa?: ExaProviderConfig;
     gemini?: GeminiProviderConfig;
     perplexity?: PerplexityProviderConfig;
@@ -341,7 +362,11 @@ export interface WebProvider<TConfig> {
   readonly capabilities: readonly ProviderCapability[];
 
   createTemplate(): TConfig;
-  getStatus(config: TConfig | undefined, cwd: string): ProviderStatus;
+  getStatus(
+    config: TConfig | undefined,
+    cwd: string,
+    capability?: ProviderCapability,
+  ): ProviderStatus;
   buildPlan(
     request: ProviderOperationRequest,
     config: TConfig,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -138,6 +138,45 @@ describe("config parsing", () => {
     });
   });
 
+  it("parses custom CLI command config", () => {
+    const parsed = parseConfig(
+      JSON.stringify({
+        providers: {
+          "custom-cli": {
+            enabled: true,
+            native: {
+              search: {
+                argv: ["node", "./scripts/search-wrapper.mjs"],
+                cwd: ".",
+                env: {
+                  DEMO_TOKEN: "EXAMPLE_TOKEN",
+                },
+              },
+            },
+          },
+        },
+      }),
+      "test-config.json",
+    );
+
+    expect(parsed.providers?.["custom-cli"]).toEqual({
+      enabled: true,
+      native: {
+        search: {
+          argv: ["node", "./scripts/search-wrapper.mjs"],
+          cwd: ".",
+          env: {
+            DEMO_TOKEN: "EXAMPLE_TOKEN",
+          },
+        },
+        contents: undefined,
+        answer: undefined,
+        research: undefined,
+      },
+      policy: undefined,
+    });
+  });
+
   it("rejects unknown tool-specific settings", () => {
     expect(() =>
       parseConfig(

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -177,6 +177,25 @@ describe("config parsing", () => {
     });
   });
 
+  it("rejects blank custom CLI argv entries", () => {
+    expect(() =>
+      parseConfig(
+        JSON.stringify({
+          providers: {
+            "custom-cli": {
+              native: {
+                search: {
+                  argv: ["node", "   "],
+                },
+              },
+            },
+          },
+        }),
+        "test-config.json",
+      ),
+    ).toThrow(/non-empty array of non-empty strings/);
+  });
+
   it("rejects unknown tool-specific settings", () => {
     expect(() =>
       parseConfig(

--- a/test/custom-cli-provider.test.ts
+++ b/test/custom-cli-provider.test.ts
@@ -1,0 +1,167 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { CustomCliProvider } from "../src/providers/custom-cli.js";
+
+const cleanupDirs: string[] = [];
+
+afterEach(async () => {
+  while (cleanupDirs.length > 0) {
+    const dir = cleanupDirs.pop();
+    if (dir) {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("CustomCliProvider", () => {
+  it("executes a configured search command and parses structured JSON", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pi-web-providers-custom-cli-"));
+    cleanupDirs.push(root);
+
+    const scriptPath = join(root, "search.mjs");
+    await writeFile(
+      scriptPath,
+      [
+        'let input = "";',
+        'process.stdin.setEncoding("utf8");',
+        'process.stdin.on("data", (chunk) => (input += chunk));',
+        'process.stdin.on("end", () => {',
+        "  const request = JSON.parse(input);",
+        "  process.stderr.write(`searching ${request.query}\\n`);",
+        "  process.stdout.write(JSON.stringify({",
+        "    results: [{",
+        "      title: `Result for ${request.query}` ,",
+        '      url: "https://example.com",',
+        '      snippet: "example snippet",',
+        "      score: 0.9,",
+        "      metadata: { echoedMaxResults: request.maxResults }",
+        "    }]",
+        "  }));",
+        "});",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const provider = new CustomCliProvider();
+    const progress: string[] = [];
+    const result = await provider.search(
+      "custom query",
+      3,
+      { mode: "demo" },
+      {
+        enabled: true,
+        native: {
+          search: {
+            argv: [process.execPath, scriptPath],
+          },
+        },
+      },
+      {
+        cwd: process.cwd(),
+        onProgress: (message) => progress.push(message),
+      },
+    );
+
+    expect(result).toEqual({
+      provider: "custom-cli",
+      results: [
+        {
+          title: "Result for custom query",
+          url: "https://example.com",
+          snippet: "example snippet",
+          score: 0.9,
+          metadata: { echoedMaxResults: 3 },
+        },
+      ],
+    });
+    expect(progress).toContain("Running Custom CLI search");
+    expect(progress).toContain("searching custom query");
+  });
+
+  it("parses provider tool output for non-search capabilities", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pi-web-providers-custom-cli-"));
+    cleanupDirs.push(root);
+
+    const scriptPath = join(root, "answer.mjs");
+    await writeFile(
+      scriptPath,
+      [
+        'let input = "";',
+        'process.stdin.setEncoding("utf8");',
+        'process.stdin.on("data", (chunk) => (input += chunk));',
+        'process.stdin.on("end", () => {',
+        "  const request = JSON.parse(input);",
+        "  process.stdout.write(JSON.stringify({",
+        "    text: `Answer for: ${request.query}` ,",
+        '    summary: "answered via wrapper",',
+        "    itemCount: 2,",
+        '    metadata: { source: "fixture" }',
+        "  }));",
+        "});",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const provider = new CustomCliProvider();
+    const result = await provider.answer(
+      "what is this?",
+      undefined,
+      {
+        enabled: true,
+        native: {
+          answer: {
+            argv: [process.execPath, scriptPath],
+          },
+        },
+      },
+      {
+        cwd: process.cwd(),
+      },
+    );
+
+    expect(result).toEqual({
+      provider: "custom-cli",
+      text: "Answer for: what is this?",
+      summary: "answered via wrapper",
+      itemCount: 2,
+      metadata: { source: "fixture" },
+    });
+  });
+
+  it("rejects invalid search payloads from the wrapped command", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pi-web-providers-custom-cli-"));
+    cleanupDirs.push(root);
+
+    const scriptPath = join(root, "invalid.mjs");
+    await writeFile(
+      scriptPath,
+      [
+        'process.stdout.write(JSON.stringify({ results: [{ title: "Missing fields" }] }));',
+      ].join("\n"),
+      "utf8",
+    );
+
+    const provider = new CustomCliProvider();
+
+    await expect(
+      provider.search(
+        "broken",
+        1,
+        undefined,
+        {
+          enabled: true,
+          native: {
+            search: {
+              argv: [process.execPath, scriptPath],
+            },
+          },
+        },
+        {
+          cwd: process.cwd(),
+        },
+      ),
+    ).rejects.toThrow(/results\[0\]\.url/);
+  });
+});

--- a/test/provider-config-manifests.test.ts
+++ b/test/provider-config-manifests.test.ts
@@ -68,6 +68,14 @@ describe("provider config manifests", () => {
     getTextSetting("customCliAnswerEnv").setValue(config, "");
     expect(config.native?.answer).toBeUndefined();
   });
+
+  it("rejects empty custom-cli argv arrays in the settings manifest", () => {
+    const config: CustomCliProviderConfig = { enabled: true };
+
+    expect(() =>
+      getTextSetting("customCliSearchArgv").setValue(config, "[]"),
+    ).toThrow(/non-empty JSON string array/);
+  });
 });
 
 function getTextSetting(

--- a/test/provider-config-manifests.test.ts
+++ b/test/provider-config-manifests.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  getProviderConfigManifest,
+  type ProviderTextSettingDescriptor,
+} from "../src/provider-config-manifests.js";
+import type { CustomCliProviderConfig } from "../src/types.js";
+
+describe("provider config manifests", () => {
+  it("exposes custom-cli argv, cwd, env, and request policy settings", () => {
+    const manifest = getProviderConfigManifest("custom-cli");
+    const ids = manifest.settings.map((setting) => setting.id);
+
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        "customCliSearchArgv",
+        "customCliSearchCwd",
+        "customCliSearchEnv",
+        "customCliContentsArgv",
+        "customCliContentsCwd",
+        "customCliContentsEnv",
+        "customCliAnswerArgv",
+        "customCliAnswerCwd",
+        "customCliAnswerEnv",
+        "customCliResearchArgv",
+        "customCliResearchCwd",
+        "customCliResearchEnv",
+        "requestTimeoutMs",
+        "retryCount",
+        "retryDelayMs",
+      ]),
+    );
+    expect(ids).not.toContain("researchPollIntervalMs");
+    expect(ids).not.toContain("researchTimeoutMs");
+    expect(ids).not.toContain("researchMaxConsecutivePollErrors");
+  });
+
+  it("round-trips custom-cli cwd and env settings and cleans up empty commands", () => {
+    const config: CustomCliProviderConfig = { enabled: true };
+
+    getTextSetting("customCliSearchArgv").setValue(
+      config,
+      '["node","./wrappers/search.mjs"]',
+    );
+    getTextSetting("customCliSearchCwd").setValue(config, "./wrappers");
+    getTextSetting("customCliSearchEnv").setValue(
+      config,
+      '{"TOKEN":"DEMO_TOKEN","MODE":"!print-mode"}',
+    );
+
+    expect(config.native?.search).toEqual({
+      argv: ["node", "./wrappers/search.mjs"],
+      cwd: "./wrappers",
+      env: {
+        TOKEN: "DEMO_TOKEN",
+        MODE: "!print-mode",
+      },
+    });
+    expect(getTextSetting("customCliSearchCwd").getValue(config)).toBe(
+      "./wrappers",
+    );
+    expect(getTextSetting("customCliSearchEnv").getValue(config)).toBe(
+      '{"TOKEN":"DEMO_TOKEN","MODE":"!print-mode"}',
+    );
+
+    getTextSetting("customCliAnswerEnv").setValue(config, '{"TOKEN":"DEMO"}');
+    expect(config.native?.answer?.env).toEqual({ TOKEN: "DEMO" });
+
+    getTextSetting("customCliAnswerEnv").setValue(config, "");
+    expect(config.native?.answer).toBeUndefined();
+  });
+});
+
+function getTextSetting(
+  id: string,
+): ProviderTextSettingDescriptor<CustomCliProviderConfig> {
+  const setting = getProviderConfigManifest("custom-cli").settings.find(
+    (candidate) => candidate.id === id,
+  );
+  if (!setting || setting.kind !== "text") {
+    throw new Error(`Missing text setting '${id}'.`);
+  }
+  return setting as ProviderTextSettingDescriptor<CustomCliProviderConfig>;
+}

--- a/test/provider-resolution.test.ts
+++ b/test/provider-resolution.test.ts
@@ -148,6 +148,30 @@ describe("provider resolution", () => {
     expect(provider.id).toBe("parallel");
   });
 
+  it("rejects Custom CLI when the mapped capability has no command configured", () => {
+    const config = createConfig({
+      tools: {
+        search: "custom-cli",
+      },
+      providers: {
+        "custom-cli": {
+          enabled: true,
+          native: {
+            answer: {
+              argv: [process.execPath, "./answer-wrapper.mjs"],
+            },
+          },
+        },
+      },
+    });
+
+    expect(() =>
+      resolveProviderForCapability(config, process.cwd(), "search"),
+    ).toThrow(
+      /Provider 'custom-cli' is not available: no command configured for search/,
+    );
+  });
+
   it("treats Perplexity research as a direct explicit-provider selection", () => {
     process.env.PERPLEXITY_API_KEY = "test-key";
 

--- a/test/tool-availability.test.ts
+++ b/test/tool-availability.test.ts
@@ -170,6 +170,28 @@ describe("managed tool availability", () => {
     ).toEqual([]);
   });
 
+  it("hides Custom CLI tools when the mapped capability has no command configured", () => {
+    const config = createConfig({
+      tools: {
+        search: "custom-cli",
+      },
+      providers: {
+        "custom-cli": {
+          enabled: true,
+          native: {
+            answer: {
+              argv: [process.execPath, "./answer-wrapper.mjs"],
+            },
+          },
+        },
+      },
+    });
+
+    expect(
+      __test__.getAvailableManagedToolNames(config, process.cwd()),
+    ).toEqual([]);
+  });
+
   it("does not activate unavailable tools before agent start", () => {
     process.env.CODEX_API_KEY = "test-key";
     process.env.EXA_API_KEY = "test-key";

--- a/test/tool-availability.test.ts
+++ b/test/tool-availability.test.ts
@@ -192,6 +192,36 @@ describe("managed tool availability", () => {
     ).toEqual([]);
   });
 
+  it("only lists Custom CLI as selectable for capabilities with a configured command", () => {
+    const config = createConfig({
+      providers: {
+        "custom-cli": {
+          enabled: true,
+          native: {
+            answer: {
+              argv: [process.execPath, "./answer-wrapper.mjs"],
+            },
+          },
+        },
+      },
+    });
+
+    expect(
+      __test__.getEnabledCompatibleProvidersForTool(
+        config,
+        process.cwd(),
+        "search",
+      ),
+    ).toEqual([]);
+    expect(
+      __test__.getEnabledCompatibleProvidersForTool(
+        config,
+        process.cwd(),
+        "answer",
+      ),
+    ).toEqual(["custom-cli"]);
+  });
+
   it("does not activate unavailable tools before agent start", () => {
     process.env.CODEX_API_KEY = "test-key";
     process.env.EXA_API_KEY = "test-key";


### PR DESCRIPTION
Add a configurable `custom-cli` provider that runs structured JSON wrapper commands for search, contents, answer, and research. This makes it easy to integrate additional local agent CLIs without adding a dedicated first-class provider for each one.

### Review

- Check whether the JSON stdin/stdout contract is the right long-term abstraction for wrapper-based providers.
- Check the README positioning of `custom-cli` as an advanced adapter rather than a built-in backend.
- Check whether capability-aware availability for partially configured wrappers behaves as expected.

### Details

<details>
<summary>🧪 Testing</summary>

- `npm run check`
- `npm test`
- Added unit coverage for config parsing, provider resolution, tool availability, and wrapper execution

</details>

<details>
<summary>📌 References</summary>

- Includes changelog entry: `changelog/releases/v1.1.0/entries/custom-cli-provider-for-local-agent-wrappers.md`

</details>
