### PR TITLE
Add Firecrawl provider for search and contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ off entirely.
 
 ## ✨ Features
 
-- **Multiple providers**: Claude, Cloudflare, Codex, Exa, Gemini,
-  Perplexity, Parallel, [Tavily](https://tavily.com), Valyu
+- **Multiple providers**: Claude, Cloudflare, Codex, Exa, Firecrawl,
+  Gemini, Perplexity, Parallel, [Tavily](https://tavily.com), Valyu
 - **Batched search and answers**: run several related queries in a single
   `web_search` or `web_answer` call and get grouped results back in one response
 - **Async contents prefetch**: optionally start background `web_contents`
@@ -44,6 +44,7 @@ Each tool can be routed to any compatible provider:
 | **Cloudflare** |        |    ✔     |        |          | `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` |
 | **Codex**      |   ✔    |          |        |          | Local Codex CLI auth                             |
 | **Exa**        |   ✔    |    ✔     |   ✔    |    ✔     | `EXA_API_KEY`                                    |
+| **Firecrawl**  |   ✔    |    ✔     |        |          | `FIRECRAWL_API_KEY`                              |
 | **Gemini**     |   ✔    |          |   ✔    |    ✔     | `GOOGLE_API_KEY`                                 |
 | **Perplexity** |   ✔    |          |   ✔    |    ✔     | `PERPLEXITY_API_KEY`                             |
 | **Parallel**   |   ✔    |    ✔     |        |          | `PARALLEL_API_KEY`                               |
@@ -232,6 +233,21 @@ scope, or account ID is usually wrong.
 - `web_research` is exposed through pi's async research workflow
 - Neural, keyword, hybrid, and deep-research search modes
 - Inline text-content extraction on search results
+
+</details>
+
+<details>
+<summary><strong>Firecrawl</strong></summary>
+
+- SDK: `@mendable/firecrawl-js`
+- Supports `web_search` and `web_contents`
+- Search can optionally include Firecrawl scrape-backed result enrichment
+- Contents extraction uses Firecrawl scrape with markdown-first defaults
+- Supports provider-specific `options.search` such as `sources`, `categories`,
+  `location`, `timeout`, and `scrapeOptions`
+- Supports provider-specific `options.scrape` such as `formats`,
+  `onlyMainContent`, `waitFor`, `headers`, `location`, `mobile`, `proxy`, and
+  cache controls
 
 </details>
 

--- a/changelog/unreleased/firecrawl-provider-for-web-search-and-contents.md
+++ b/changelog/unreleased/firecrawl-provider-for-web-search-and-contents.md
@@ -1,0 +1,37 @@
+---
+title: Firecrawl provider for web search and contents
+type: feature
+authors:
+  - mavam
+  - codex
+pr: 11
+created: 2026-04-01T04:50:55.401198Z
+---
+
+The new `firecrawl` provider adds `web_search` and `web_contents`
+support via Firecrawl's official JavaScript SDK.
+
+Configure it with a Firecrawl API key:
+
+```json
+{
+  "tools": {
+    "search": "firecrawl",
+    "contents": "firecrawl"
+  },
+  "providers": {
+    "firecrawl": {
+      "apiKey": "FIRECRAWL_API_KEY"
+    }
+  }
+}
+```
+
+You can pass Firecrawl search options such as `sources`, `categories`,
+`location`, `timeout`, and `scrapeOptions` through
+`providers.firecrawl.options.search` or per-call `web_search.options`.
+
+You can pass Firecrawl scrape options such as `formats`,
+`onlyMainContent`, `waitFor`, `headers`, `location`, `mobile`,
+`proxy`, and cache controls through
+`providers.firecrawl.options.scrape` or per-call `web_contents.options`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.71",
         "@google/genai": "^1.44.0",
+        "@mendable/firecrawl-js": "^4.18.1",
         "@openai/codex-sdk": "^0.111.0",
         "@perplexity-ai/perplexity_ai": "^0.26.1",
         "@tavily/core": "^0.7.2",
@@ -2200,6 +2201,31 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/@mendable/firecrawl-js": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/@mendable/firecrawl-js/-/firecrawl-js-4.18.1.tgz",
+      "integrity": "sha512-NfmJv+xcHoZthj8I3NP/8KAgO8EWcvOcTvCAvszxqs7/6sCs1CRss6Tum6RycZNSwJkr5RzQossN89IlixRfng==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "1.14.0",
+        "firecrawl": "4.16.0",
+        "typescript-event-target": "^1.1.1",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.23.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@mendable/firecrawl-js/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@mistralai/mistralai": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.14.1.tgz",
@@ -3781,14 +3807,23 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/balanced-match": {
@@ -4575,6 +4610,30 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/firecrawl": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/firecrawl/-/firecrawl-4.16.0.tgz",
+      "integrity": "sha512-7SJ/FWhZBtW2gTCE/BsvU+gbfIpfTq+D9IH82l9MacauLVptaY6EdYAhrK3YSMC9yr5NxvxRcpZKcXG/nqjiiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.13.5",
+        "typescript-event-target": "^1.1.1",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.23.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/firecrawl/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/follow-redirects": {
@@ -5895,6 +5954,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pump": {
@@ -6297,6 +6357,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/typescript-event-target": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/typescript-event-target/-/typescript-event-target-1.1.2.tgz",
+      "integrity": "sha512-TvkrTUpv7gCPlcnSoEwUVUBwsdheKm+HF5u2tPAKubkIGMfovdSizCTaZRY/NhR8+Ijy8iZZUapbVQAsNrkFrw==",
+      "license": "MIT"
     },
     "node_modules/uint8array-extras": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "codex",
     "custom",
     "exa",
+    "firecrawl",
     "gemini",
     "perplexity",
     "parallel",
@@ -44,7 +45,7 @@
     ]
   },
   "scripts": {
-    "build": "rm -rf dist && esbuild src/index.ts --bundle --format=esm --platform=node --outfile=dist/index.js --external:@mariozechner/pi-coding-agent --external:@mariozechner/pi-ai --external:@mariozechner/pi-tui --external:@sinclair/typebox --external:@anthropic-ai/claude-agent-sdk --external:@google/genai --external:@openai/codex-sdk --external:@perplexity-ai/perplexity_ai --external:@tavily/core --external:cloudflare --external:exa-js --external:parallel-web --external:valyu-js",
+    "build": "rm -rf dist && esbuild src/index.ts --bundle --format=esm --platform=node --outfile=dist/index.js --external:@mariozechner/pi-coding-agent --external:@mariozechner/pi-ai --external:@mariozechner/pi-tui --external:@sinclair/typebox --external:@anthropic-ai/claude-agent-sdk --external:@google/genai --external:@mendable/firecrawl-js --external:@openai/codex-sdk --external:@perplexity-ai/perplexity_ai --external:@tavily/core --external:cloudflare --external:exa-js --external:parallel-web --external:valyu-js",
     "prepare": "npm run build",
     "prepack": "npm run build",
     "check": "tsc --noEmit",
@@ -57,6 +58,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.71",
     "@google/genai": "^1.44.0",
+    "@mendable/firecrawl-js": "^4.18.1",
     "@openai/codex-sdk": "^0.111.0",
     "@perplexity-ai/perplexity_ai": "^0.26.1",
     "@tavily/core": "^0.7.2",

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ import type {
   CustomCommandConfig,
   Exa,
   ExecutionSettings,
+  Firecrawl,
   Gemini,
   Parallel,
   Perplexity,
@@ -144,6 +145,20 @@ const parallelProviderSchema = z
     settings: executionSettingsSchema.optional(),
   })
   .strict();
+const firecrawlOptionsSchema = z
+  .object({
+    search: jsonObjectSchema.optional(),
+    scrape: jsonObjectSchema.optional(),
+  })
+  .strict();
+const firecrawlProviderSchema = z
+  .object({
+    apiKey: stringSchema.optional(),
+    baseUrl: stringSchema.optional(),
+    options: firecrawlOptionsSchema.optional(),
+    settings: executionSettingsSchema.optional(),
+  })
+  .strict();
 const tavilyOptionsSchema = z
   .object({
     search: jsonObjectSchema.optional(),
@@ -250,8 +265,10 @@ export function parseProviderConfig(
 ):
   | Claude
   | Codex
+  | Cloudflare
   | Custom
   | Exa
+  | Firecrawl
   | Gemini
   | Perplexity
   | Parallel
@@ -380,6 +397,7 @@ function normalizeConfig(raw: unknown, source: string): WebProviders {
       codex: normalizeCodexProvider,
       custom: normalizeCustomProvider,
       exa: normalizeExaProvider,
+      firecrawl: normalizeFirecrawlProvider,
       gemini: normalizeGeminiProvider,
       perplexity: normalizePerplexityProvider,
       parallel: normalizeParallelProvider,
@@ -425,6 +443,15 @@ function normalizeCodexProvider(raw: unknown, source: string): Codex {
 
 function normalizeExaProvider(raw: unknown, source: string): Exa {
   return parseProviderWithSchema(raw, source, "exa", simpleApiProviderSchema);
+}
+
+function normalizeFirecrawlProvider(raw: unknown, source: string): Firecrawl {
+  return parseProviderWithSchema(
+    raw,
+    source,
+    "firecrawl",
+    firecrawlProviderSchema,
+  );
 }
 
 function normalizeValyuProvider(raw: unknown, source: string): Valyu {

--- a/src/provider-config-manifests.ts
+++ b/src/provider-config-manifests.ts
@@ -9,6 +9,7 @@ import type {
   CustomOptions,
   Exa,
   ExecutionSettings,
+  Firecrawl,
   Gemini,
   GeminiOptions,
   Parallel,
@@ -443,6 +444,9 @@ export const PROVIDER_CONFIG_MANIFESTS = {
         },
       }),
     ],
+  },
+  firecrawl: {
+    settings: [apiKeySetting<Firecrawl>(), baseUrlSetting<Firecrawl>()],
   },
   gemini: {
     settings: [

--- a/src/provider-tools.ts
+++ b/src/provider-tools.ts
@@ -11,6 +11,7 @@ export const PROVIDER_TOOLS_BY_ID: Record<ProviderId, readonly Tool[]> = {
   codex: ["search"],
   custom: ["search", "contents", "answer", "research"],
   exa: ["search", "contents", "answer", "research"],
+  firecrawl: ["search", "contents"],
   gemini: ["search", "answer", "research"],
   perplexity: ["search", "answer", "research"],
   parallel: ["search", "contents"],

--- a/src/providers/firecrawl.ts
+++ b/src/providers/firecrawl.ts
@@ -1,0 +1,251 @@
+import FirecrawlClient, {
+  type Document,
+  type SearchData,
+} from "@mendable/firecrawl-js";
+import { resolveConfigValue } from "../config.js";
+import type { ContentsResponse } from "../contents.js";
+import { stripLocalExecutionOptions } from "../execution-policy.js";
+import type {
+  Firecrawl,
+  ProviderAdapter,
+  ProviderCapabilityStatus,
+  ProviderContext,
+  ProviderRequest,
+  SearchResponse,
+  SearchResult,
+} from "../types.js";
+import { buildProviderPlan } from "./framework.js";
+import { asJsonObject, getApiKeyStatus, trimSnippet } from "./shared.js";
+
+type FirecrawlAdapter = ProviderAdapter<Firecrawl> & {
+  search(
+    query: string,
+    maxResults: number,
+    config: Firecrawl,
+    context: ProviderContext,
+    options?: Record<string, unknown>,
+  ): Promise<SearchResponse>;
+  contents(
+    urls: string[],
+    config: Firecrawl,
+    context: ProviderContext,
+    options?: Record<string, unknown>,
+  ): Promise<ContentsResponse>;
+};
+
+export const firecrawlAdapter: FirecrawlAdapter = {
+  id: "firecrawl",
+  label: "Firecrawl",
+  docsUrl: "https://docs.firecrawl.dev/sdks/node",
+  tools: ["search", "contents"] as const,
+
+  createTemplate(): Firecrawl {
+    return {
+      apiKey: "FIRECRAWL_API_KEY",
+      options: {
+        scrape: {
+          formats: ["markdown"],
+          onlyMainContent: true,
+        },
+      },
+    };
+  },
+
+  getCapabilityStatus(config: Firecrawl | undefined): ProviderCapabilityStatus {
+    return getApiKeyStatus(config?.apiKey);
+  },
+
+  buildPlan(request: ProviderRequest, config: Firecrawl) {
+    return buildProviderPlan({
+      request,
+      config,
+      providerId: firecrawlAdapter.id,
+      providerLabel: firecrawlAdapter.label,
+      handlers: {
+        search: {
+          execute: (
+            searchRequest,
+            providerConfig: Firecrawl,
+            context: ProviderContext,
+          ) =>
+            firecrawlAdapter.search(
+              searchRequest.query,
+              searchRequest.maxResults,
+              providerConfig,
+              context,
+              searchRequest.options,
+            ),
+        },
+        contents: {
+          execute: (
+            contentsRequest,
+            providerConfig: Firecrawl,
+            context: ProviderContext,
+          ) =>
+            firecrawlAdapter.contents(
+              contentsRequest.urls,
+              providerConfig,
+              context,
+              contentsRequest.options,
+            ),
+        },
+      },
+    });
+  },
+
+  async search(
+    query: string,
+    maxResults: number,
+    config: Firecrawl,
+    _context: ProviderContext,
+    options?: Record<string, unknown>,
+  ): Promise<SearchResponse> {
+    const client = createClient(config);
+    const defaults =
+      stripLocalExecutionOptions(asJsonObject(config.options?.search)) ?? {};
+    const response = await client.search(query, {
+      ...defaults,
+      ...(options ?? {}),
+      limit: maxResults,
+    });
+
+    return {
+      provider: firecrawlAdapter.id,
+      results: flattenSearchResults(response).slice(0, maxResults),
+    };
+  },
+
+  async contents(
+    urls: string[],
+    config: Firecrawl,
+    _context: ProviderContext,
+    options?: Record<string, unknown>,
+  ): Promise<ContentsResponse> {
+    const client = createClient(config);
+    const defaults =
+      stripLocalExecutionOptions(asJsonObject(config.options?.scrape)) ?? {};
+    const scrapeOptions = {
+      formats: ["markdown"],
+      onlyMainContent: true,
+      ...defaults,
+      ...(options ?? {}),
+    };
+
+    return {
+      provider: firecrawlAdapter.id,
+      answers: await Promise.all(
+        urls.map(async (url) => {
+          try {
+            const document = await client.scrape(url, scrapeOptions as never);
+            const content = getDocumentContent(document);
+            return content
+              ? {
+                  url,
+                  content,
+                  ...(document.metadata
+                    ? {
+                        metadata: document.metadata as Record<string, unknown>,
+                      }
+                    : {}),
+                }
+              : {
+                  url,
+                  error: "No content returned for this URL.",
+                };
+          } catch (error) {
+            return {
+              url,
+              error: error instanceof Error ? error.message : String(error),
+            };
+          }
+        }),
+      ),
+    };
+  },
+};
+
+function createClient(config: Firecrawl): FirecrawlClient {
+  const apiKey = resolveConfigValue(config.apiKey);
+  if (!apiKey) {
+    throw new Error("is missing an API key");
+  }
+
+  return new FirecrawlClient({
+    apiKey,
+    apiUrl: resolveConfigValue(config.baseUrl),
+  });
+}
+
+function flattenSearchResults(response: SearchData): SearchResult[] {
+  return (["web", "news", "images"] as const).flatMap((source) =>
+    (response[source] ?? [])
+      .map((entry) => toSearchResult(source, entry))
+      .filter((entry): entry is SearchResult => entry !== null),
+  );
+}
+
+function toSearchResult(
+  source: "web" | "news" | "images",
+  value: unknown,
+): SearchResult | null {
+  const entry = asRecord(value);
+  if (!entry) {
+    return null;
+  }
+
+  const metadata = asRecord(entry.metadata);
+  const url =
+    readString(entry.url) ??
+    readString(metadata?.sourceURL) ??
+    readString(entry.imageUrl) ??
+    "";
+  const title = readString(entry.title) ?? readString(metadata?.title) ?? url;
+  const snippet = trimSnippet(
+    readString(entry.description) ??
+      readString(entry.snippet) ??
+      readString(entry.markdown) ??
+      readString(metadata?.description) ??
+      "",
+  );
+  const resultMetadata = {
+    source,
+    ...(readString(entry.category) ? { category: entry.category } : {}),
+    ...(readString(entry.date) ? { date: entry.date } : {}),
+    ...(readString(entry.imageUrl) ? { imageUrl: entry.imageUrl } : {}),
+    ...(typeof entry.position === "number" ? { position: entry.position } : {}),
+    ...(metadata ?? {}),
+  };
+
+  return {
+    title: title || "Untitled",
+    url,
+    snippet,
+    metadata:
+      Object.keys(resultMetadata).length > 1 ? resultMetadata : undefined,
+  };
+}
+
+function getDocumentContent(document: Document): string | undefined {
+  if (typeof document.markdown === "string" && document.markdown.trim()) {
+    return document.markdown;
+  }
+  if (typeof document.html === "string" && document.html.trim()) {
+    return document.html;
+  }
+  if (typeof document.rawHtml === "string" && document.rawHtml.trim()) {
+    return document.rawHtml;
+  }
+  return document.json !== undefined
+    ? JSON.stringify(document.json, null, 2)
+    : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -4,6 +4,7 @@ import { cloudflareAdapter } from "./cloudflare.js";
 import { codexAdapter } from "./codex.js";
 import { customAdapter } from "./custom.js";
 import { exaAdapter } from "./exa.js";
+import { firecrawlAdapter } from "./firecrawl.js";
 import { geminiAdapter } from "./gemini.js";
 import { parallelAdapter } from "./parallel.js";
 import { perplexityAdapter } from "./perplexity.js";
@@ -19,6 +20,7 @@ export const ADAPTERS_BY_ID: Record<
   codex: codexAdapter,
   custom: customAdapter,
   exa: exaAdapter,
+  firecrawl: firecrawlAdapter,
   gemini: geminiAdapter,
   perplexity: perplexityAdapter,
   parallel: parallelAdapter,

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export const PROVIDER_IDS = [
   "codex",
   "custom",
   "exa",
+  "firecrawl",
   "gemini",
   "perplexity",
   "parallel",
@@ -123,6 +124,11 @@ export interface ParallelOptions {
   extract?: Record<string, unknown>;
 }
 
+export interface FirecrawlOptions {
+  search?: Record<string, unknown>;
+  scrape?: Record<string, unknown>;
+}
+
 export interface TavilyOptions {
   search?: Record<string, unknown>;
   extract?: Record<string, unknown>;
@@ -168,6 +174,11 @@ export interface Exa extends Provider<Record<string, unknown>> {
   baseUrl?: string;
 }
 
+export interface Firecrawl extends Provider<FirecrawlOptions> {
+  apiKey?: string;
+  baseUrl?: string;
+}
+
 export interface Gemini extends Provider<GeminiOptions> {
   apiKey?: string;
 }
@@ -204,6 +215,7 @@ export interface Providers {
   codex?: Codex;
   custom?: Custom;
   exa?: Exa;
+  firecrawl?: Firecrawl;
   gemini?: Gemini;
   perplexity?: Perplexity;
   parallel?: Parallel;
@@ -217,6 +229,7 @@ export type AnyProvider =
   | Codex
   | Custom
   | Exa
+  | Firecrawl
   | Gemini
   | Perplexity
   | Parallel

--- a/test/firecrawl-provider.test.ts
+++ b/test/firecrawl-provider.test.ts
@@ -1,0 +1,252 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { firecrawlCtorMock, firecrawlScrapeMock, firecrawlSearchMock } =
+  vi.hoisted(() => ({
+    firecrawlCtorMock: vi.fn(),
+    firecrawlScrapeMock: vi.fn(),
+    firecrawlSearchMock: vi.fn(),
+  }));
+
+vi.mock("@mendable/firecrawl-js", () => ({
+  default: firecrawlCtorMock.mockImplementation(function MockFirecrawl() {
+    return {
+      search: firecrawlSearchMock,
+      scrape: firecrawlScrapeMock,
+    };
+  }),
+}));
+
+import { firecrawlAdapter } from "../src/providers/firecrawl.js";
+
+afterEach(() => {
+  delete process.env.FIRECRAWL_API_KEY;
+  firecrawlCtorMock.mockClear();
+  firecrawlSearchMock.mockReset();
+  firecrawlScrapeMock.mockReset();
+});
+
+describe("firecrawlAdapter", () => {
+  it("merges search options, strips local execution settings, and maps results", async () => {
+    process.env.FIRECRAWL_API_KEY = "test-key";
+
+    firecrawlSearchMock.mockResolvedValue({
+      web: [
+        {
+          title: "Firecrawl Docs",
+          url: "https://docs.firecrawl.dev",
+          description: "Official documentation",
+          category: "research",
+        },
+        {
+          markdown: "# Deep scrape\n\n" + "A".repeat(400),
+          metadata: {
+            title: "Scraped result",
+            sourceURL: "https://example.com/scraped",
+            description: "Structured scrape",
+          },
+        },
+      ],
+      news: [
+        {
+          title: "Firecrawl launches feature",
+          url: "https://news.example.com/firecrawl",
+          snippet: "Launch coverage",
+          date: "2026-04-01",
+        },
+      ],
+      images: [
+        {
+          title: "Firecrawl logo",
+          imageUrl: "https://example.com/logo.png",
+          position: 1,
+        },
+      ],
+    });
+
+    const response = await firecrawlAdapter.search(
+      "firecrawl sdk",
+      4,
+      {
+        apiKey: "FIRECRAWL_API_KEY",
+        baseUrl: "https://api.firecrawl.test",
+        options: {
+          search: {
+            sources: ["web", "news"],
+            timeout: 15,
+            requestTimeoutMs: 999,
+          },
+        },
+      },
+      { cwd: process.cwd() },
+      {
+        location: "us",
+        limit: 99,
+      },
+    );
+
+    expect(firecrawlCtorMock).toHaveBeenCalledWith({
+      apiKey: "test-key",
+      apiUrl: "https://api.firecrawl.test",
+    });
+    expect(firecrawlSearchMock).toHaveBeenCalledWith("firecrawl sdk", {
+      sources: ["web", "news"],
+      timeout: 15,
+      location: "us",
+      limit: 4,
+    });
+    expect(response.results).toHaveLength(4);
+    expect(response.results[0]).toEqual({
+      title: "Firecrawl Docs",
+      url: "https://docs.firecrawl.dev",
+      snippet: "Official documentation",
+      metadata: {
+        source: "web",
+        category: "research",
+      },
+    });
+    expect(response.results[1]).toMatchObject({
+      title: "Scraped result",
+      url: "https://example.com/scraped",
+      metadata: {
+        source: "web",
+        title: "Scraped result",
+        sourceURL: "https://example.com/scraped",
+        description: "Structured scrape",
+      },
+    });
+    expect(response.results[1]?.snippet).toMatch(/^# Deep scrape A+/);
+    expect(response.results[1]?.snippet.endsWith("…")).toBe(true);
+    expect(response.results[2]).toEqual({
+      title: "Firecrawl launches feature",
+      url: "https://news.example.com/firecrawl",
+      snippet: "Launch coverage",
+      metadata: {
+        source: "news",
+        date: "2026-04-01",
+      },
+    });
+    expect(response.results[3]).toEqual({
+      title: "Firecrawl logo",
+      url: "https://example.com/logo.png",
+      snippet: "",
+      metadata: {
+        source: "images",
+        imageUrl: "https://example.com/logo.png",
+        position: 1,
+      },
+    });
+  });
+
+  it("preserves URL order for contents, merges scrape options, and surfaces per-URL failures", async () => {
+    firecrawlScrapeMock.mockImplementation(async (url: string) => {
+      if (url === "https://example.com/a") {
+        return {
+          markdown: "# Page A\n\nBody A",
+          metadata: {
+            title: "Page A",
+            sourceURL: "https://example.com/a?ref=firecrawl",
+          },
+          links: ["https://example.com/a/child"],
+        };
+      }
+      if (url === "https://example.com/b") {
+        throw new Error("blocked by robots");
+      }
+      return {
+        json: {
+          title: "Page C",
+          items: [1, 2, 3],
+        },
+        metadata: {
+          title: "Page C",
+        },
+      };
+    });
+
+    const response = await firecrawlAdapter.contents(
+      [
+        "https://example.com/a",
+        "https://example.com/b",
+        "https://example.com/c",
+      ],
+      {
+        apiKey: "literal-key",
+        options: {
+          scrape: {
+            formats: ["markdown"],
+            waitFor: 500,
+            requestTimeoutMs: 999,
+          },
+        },
+      },
+      { cwd: process.cwd() },
+      {
+        formats: ["html"],
+        mobile: true,
+      },
+    );
+
+    expect(firecrawlCtorMock).toHaveBeenCalledWith({
+      apiKey: "literal-key",
+      apiUrl: undefined,
+    });
+    expect(firecrawlScrapeMock).toHaveBeenNthCalledWith(
+      1,
+      "https://example.com/a",
+      {
+        formats: ["html"],
+        onlyMainContent: true,
+        waitFor: 500,
+        mobile: true,
+      },
+    );
+    expect(firecrawlScrapeMock).toHaveBeenNthCalledWith(
+      2,
+      "https://example.com/b",
+      {
+        formats: ["html"],
+        onlyMainContent: true,
+        waitFor: 500,
+        mobile: true,
+      },
+    );
+    expect(firecrawlScrapeMock).toHaveBeenNthCalledWith(
+      3,
+      "https://example.com/c",
+      {
+        formats: ["html"],
+        onlyMainContent: true,
+        waitFor: 500,
+        mobile: true,
+      },
+    );
+    expect(response.answers).toEqual([
+      {
+        url: "https://example.com/a",
+        content: "# Page A\n\nBody A",
+        metadata: {
+          title: "Page A",
+          sourceURL: "https://example.com/a?ref=firecrawl",
+        },
+      },
+      {
+        url: "https://example.com/b",
+        error: "blocked by robots",
+      },
+      {
+        url: "https://example.com/c",
+        content: JSON.stringify(
+          {
+            title: "Page C",
+            items: [1, 2, 3],
+          },
+          null,
+          2,
+        ),
+        metadata: {
+          title: "Page C",
+        },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add Firecrawl as a built-in provider for `web_search` and `web_contents`
- wire Firecrawl through config parsing, provider registries, prefetch validation, docs, and package metadata
- add a `v1.2.0` changelog release stub and Firecrawl feature entry

## Testing
- npm run check
- npm test
