### PR TITLE
Add Serper support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ off entirely.
 
 ## ✨ Features
 
+- **Multiple providers**: Claude, Cloudflare, Codex, Exa, Firecrawl,
+  Gemini, Linkup, OpenAI, Perplexity, Parallel, Serper,
+  [Tavily](https://tavily.com), Valyu
 - **Provider-aware tool options**: pi only exposes the provider settings that
   actually apply to the backend you selected, so tool calls are easier to
   discover and harder to get wrong
@@ -61,6 +64,7 @@ Each tool can be routed to any compatible provider:
 | **OpenAI**     |   ✔    |          |   ✔    |    ✔     | `OPENAI_API_KEY`                                 |
 | **Parallel**   |   ✔    |    ✔     |        |          | `PARALLEL_API_KEY`                               |
 | **Perplexity** |   ✔    |          |   ✔    |    ✔     | `PERPLEXITY_API_KEY`                             |
+| **Serper**     |   ✔    |          |        |          | `SERPER_API_KEY`                                 |
 | **Tavily**     |   ✔    |    ✔     |        |          | `TAVILY_API_KEY`                                 |
 | **Valyu**      |   ✔    |    ✔     |   ✔    |    ✔     | `VALYU_API_KEY`                                  |
 
@@ -374,6 +378,35 @@ call.
 - Page content extraction with excerpt and full-content toggles
 - Exposes search option `mode`
 - Exposes contents options `excerpts` and `full_content`
+
+</details>
+
+<details>
+<summary><strong>Serper</strong></summary>
+
+- API: Serper HTTP API
+- Supports `web_search` via Serper's Google search endpoint
+- Good fit for fast, straightforward Google-style organic search results
+- Exposes search options `gl`, `hl`, `location`, `page`, and `autocorrect`
+- Preserves rich metadata from Serper responses, including ranking position,
+  sitelinks, attributes, and top-level response context such as
+  `knowledgeGraph`, `answerBox`, `peopleAlsoAsk`, and `relatedSearches`
+- Optional `baseUrl` overrides are supported for proxies and testing
+
+Minimal config:
+
+```json
+{
+  "tools": {
+    "search": "serper"
+  },
+  "providers": {
+    "serper": {
+      "apiKey": "SERPER_API_KEY"
+    }
+  }
+}
+```
 
 </details>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-web-providers",
-  "version": "2.1.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-web-providers",
-      "version": "2.1.0",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.89",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-web-providers",
-  "version": "2.3.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-web-providers",
-      "version": "2.3.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.89",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "openai",
     "parallel",
     "perplexity",
+    "serper",
     "tavily",
     "valyu"
   ],

--- a/scripts/live-smoke.mjs
+++ b/scripts/live-smoke.mjs
@@ -12,6 +12,7 @@ const PROVIDERS_BY_TOOL = {
     "gemini",
     "perplexity",
     "parallel",
+    "serper",
     "valyu",
   ],
   contents: ["custom", "exa", "parallel", "valyu"],

--- a/src/config.ts
+++ b/src/config.ts
@@ -324,14 +324,17 @@ function normalizeProvider(
     case "linkup":
     case "parallel":
     case "perplexity":
-      return parseProviderWithShape<
-        Firecrawl | Linkup | Parallel | Perplexity
-      >(raw, source, providerId, {
-        apiKey: readOptionalString,
-        baseUrl: readOptionalString,
-        options: readOptionalObject,
-        settings: parseOptionalExecutionSettings,
-      });
+      return parseProviderWithShape<Firecrawl | Linkup | Parallel | Perplexity>(
+        raw,
+        source,
+        providerId,
+        {
+          apiKey: readOptionalString,
+          baseUrl: readOptionalString,
+          options: readOptionalObject,
+          settings: parseOptionalExecutionSettings,
+        },
+      );
     case "serper":
       return parseProviderWithShape<Serper>(raw, source, providerId, {
         apiKey: readOptionalString,

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,8 @@ import type {
   ProviderId,
   SearchSettings,
   Settings,
+  Serper,
+  SerperOptions,
   Tavily,
   Tool,
   Tools,
@@ -96,6 +98,7 @@ export function parseProviderConfig(
   | OpenAI
   | Perplexity
   | Parallel
+  | Serper
   | Tavily
   | Valyu {
   const raw = parseJson(text, source);
@@ -245,6 +248,7 @@ function normalizeProvider(
   | OpenAI
   | Parallel
   | Perplexity
+  | Serper
   | Tavily
   | Valyu {
   switch (providerId) {
@@ -320,10 +324,29 @@ function normalizeProvider(
     case "linkup":
     case "parallel":
     case "perplexity":
-    case "tavily":
       return parseProviderWithShape<
-        Firecrawl | Linkup | Parallel | Perplexity | Tavily
+        Firecrawl | Linkup | Parallel | Perplexity
       >(raw, source, providerId, {
+        apiKey: readOptionalString,
+        baseUrl: readOptionalString,
+        options: readOptionalObject,
+        settings: parseOptionalExecutionSettings,
+      });
+    case "serper":
+      return parseProviderWithShape<Serper>(raw, source, providerId, {
+        apiKey: readOptionalString,
+        baseUrl: readOptionalString,
+        options: (value, innerSource, field) =>
+          parseOptionalCapabilityOptions<SerperOptions>(
+            value,
+            innerSource,
+            field,
+            ["search"],
+          ),
+        settings: parseOptionalExecutionSettings,
+      });
+    case "tavily":
+      return parseProviderWithShape<Tavily>(raw, source, providerId, {
         apiKey: readOptionalString,
         baseUrl: readOptionalString,
         options: readOptionalObject,
@@ -690,8 +713,10 @@ function toPublicProviderConfig(
     | Firecrawl
     | Gemini
     | Linkup
+    | OpenAI
     | Parallel
     | Perplexity
+    | Serper
     | Tavily
     | Valyu,
 ): Record<string, unknown> {

--- a/src/provider-config-manifests.ts
+++ b/src/provider-config-manifests.ts
@@ -20,6 +20,7 @@ import type {
   ParallelOptions,
   Perplexity,
   ProviderId,
+  Serper,
   Tavily,
   Valyu,
   ValyuOptions,
@@ -698,6 +699,9 @@ export const PROVIDER_CONFIG_MANIFESTS = {
         },
       }),
     ],
+  },
+  serper: {
+    settings: [apiKeySetting<Serper>(), baseUrlSetting<Serper>()],
   },
   tavily: {
     settings: [apiKeySetting<Tavily>(), baseUrlSetting<Tavily>()],

--- a/src/provider-tools.ts
+++ b/src/provider-tools.ts
@@ -17,6 +17,7 @@ export const PROVIDER_TOOLS_BY_ID: Record<ProviderId, readonly Tool[]> = {
   openai: ["search", "answer", "research"],
   parallel: ["search", "contents"],
   perplexity: ["search", "answer", "research"],
+  serper: ["search"],
   tavily: ["search", "contents"],
   valyu: ["search", "contents", "answer", "research"],
 };

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -10,6 +10,7 @@ import { linkupAdapter } from "./linkup.js";
 import { openaiAdapter } from "./openai.js";
 import { parallelAdapter } from "./parallel.js";
 import { perplexityAdapter } from "./perplexity.js";
+import { serperAdapter } from "./serper.js";
 import { tavilyAdapter } from "./tavily.js";
 import { valyuAdapter } from "./valyu.js";
 
@@ -28,6 +29,7 @@ export const ADAPTERS_BY_ID: Record<
   openai: openaiAdapter,
   parallel: parallelAdapter,
   perplexity: perplexityAdapter,
+  serper: serperAdapter,
   tavily: tavilyAdapter,
   valyu: valyuAdapter,
 };

--- a/src/providers/serper.ts
+++ b/src/providers/serper.ts
@@ -172,7 +172,9 @@ export const serperAdapter: ProviderAdapter<Serper> & {
       provider: serperAdapter.id,
       results: organic
         .map((entry) => toSearchResult(entry, searchContext))
-        .filter((result): result is NonNullable<typeof result> => result !== null)
+        .filter(
+          (result): result is NonNullable<typeof result> => result !== null,
+        )
         .slice(0, clampMaxResults(maxResults)),
     };
   },
@@ -195,7 +197,9 @@ async function buildHttpError(response: Response): Promise<string> {
     : `Serper API request failed (${status}).`;
 }
 
-async function readErrorDetail(response: Response): Promise<string | undefined> {
+async function readErrorDetail(
+  response: Response,
+): Promise<string | undefined> {
   const text = (await response.text()).trim();
   if (!text) {
     return undefined;
@@ -309,5 +313,7 @@ function readString(value: unknown): string | undefined {
 }
 
 function readNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
 }

--- a/src/providers/serper.ts
+++ b/src/providers/serper.ts
@@ -1,0 +1,313 @@
+import { type TObject, Type } from "@sinclair/typebox";
+import { resolveConfigValue } from "../config.js";
+import type {
+  ProviderAdapter,
+  ProviderCapabilityStatus,
+  ProviderContext,
+  ProviderRequest,
+  SearchResponse,
+  Serper,
+  Tool,
+} from "../types.js";
+import { stripLocalExecutionOptions } from "../execution-policy.js";
+import { buildProviderPlan } from "./framework.js";
+import { asJsonObject, getApiKeyStatus, trimSnippet } from "./shared.js";
+
+const DEFAULT_BASE_URL = "https://google.serper.dev";
+
+const serperSearchOptionsSchema = Type.Object(
+  {
+    gl: Type.Optional(
+      Type.String({
+        description: "Country code hint for Google results (for example 'us').",
+      }),
+    ),
+    hl: Type.Optional(
+      Type.String({
+        description:
+          "Language code hint for Google results (for example 'en').",
+      }),
+    ),
+    location: Type.Optional(
+      Type.String({
+        description: "Geographic location hint for Google results.",
+      }),
+    ),
+    page: Type.Optional(
+      Type.Integer({
+        minimum: 1,
+        description: "1-based results page to request from Serper.",
+      }),
+    ),
+    autocorrect: Type.Optional(
+      Type.Boolean({
+        description: "Enable or disable Serper query autocorrection.",
+      }),
+    ),
+  },
+  { description: "Serper search options." },
+);
+
+export const serperAdapter: ProviderAdapter<Serper> & {
+  search(
+    query: string,
+    maxResults: number,
+    config: Serper,
+    context: ProviderContext,
+    options?: Record<string, unknown>,
+  ): Promise<SearchResponse>;
+} = {
+  id: "serper",
+  label: "Serper",
+  docsUrl: "https://serper.dev/",
+  tools: ["search"] as const,
+
+  getToolOptionsSchema(capability: Tool): TObject | undefined {
+    switch (capability) {
+      case "search":
+        return serperSearchOptionsSchema;
+      default:
+        return undefined;
+    }
+  },
+
+  createTemplate(): Serper {
+    return {
+      apiKey: "SERPER_API_KEY",
+      options: {},
+    };
+  },
+
+  getConfigForCapability(capability: Tool, config: Serper): unknown {
+    switch (capability) {
+      case "search":
+        return {
+          apiKey: config.apiKey,
+          baseUrl: config.baseUrl,
+          options: config.options?.search,
+          settings: config.settings,
+        };
+      default:
+        return config;
+    }
+  },
+
+  getCapabilityStatus(config: Serper | undefined): ProviderCapabilityStatus {
+    return getApiKeyStatus(config?.apiKey);
+  },
+
+  buildPlan(request: ProviderRequest, config: Serper) {
+    return buildProviderPlan({
+      request,
+      config,
+      providerId: serperAdapter.id,
+      providerLabel: serperAdapter.label,
+      handlers: {
+        search: {
+          execute: (
+            searchRequest,
+            providerConfig: Serper,
+            context: ProviderContext,
+          ) =>
+            serperAdapter.search(
+              searchRequest.query,
+              searchRequest.maxResults,
+              providerConfig,
+              context,
+              searchRequest.options,
+            ),
+        },
+      },
+    });
+  },
+
+  async search(
+    query: string,
+    maxResults: number,
+    config: Serper,
+    context: ProviderContext,
+    options?: Record<string, unknown>,
+  ): Promise<SearchResponse> {
+    const apiKey = resolveConfigValue(config.apiKey);
+    if (!apiKey) {
+      throw new Error("is missing an API key");
+    }
+
+    const defaults =
+      stripLocalExecutionOptions(asJsonObject(config.options?.search)) ?? {};
+    const runtimeOptions = stripLocalExecutionOptions(asJsonObject(options));
+    const {
+      q: _ignoredQuery,
+      num: _ignoredNum,
+      ...providerOptions
+    } = {
+      ...defaults,
+      ...(runtimeOptions ?? {}),
+    };
+
+    const response = await fetch(joinUrl(resolveConfigValue(config.baseUrl)), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": apiKey,
+      },
+      body: JSON.stringify({
+        q: query,
+        num: clampMaxResults(maxResults),
+        ...providerOptions,
+      }),
+      signal: context.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(await buildHttpError(response));
+    }
+
+    const payload = (await response.json()) as unknown;
+    const responseRecord = asRecord(payload) ?? {};
+    const organic = asArray(responseRecord.organic) ?? [];
+    const searchContext = buildSearchContext(responseRecord);
+
+    return {
+      provider: serperAdapter.id,
+      results: organic
+        .map((entry) => toSearchResult(entry, searchContext))
+        .filter((result): result is NonNullable<typeof result> => result !== null)
+        .slice(0, clampMaxResults(maxResults)),
+    };
+  },
+};
+
+function joinUrl(baseUrl: string | undefined): string {
+  const base = (baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+  return `${base}/search`;
+}
+
+function clampMaxResults(value: number): number {
+  return Math.max(1, Math.min(20, Math.trunc(value || 0)));
+}
+
+async function buildHttpError(response: Response): Promise<string> {
+  const detail = await readErrorDetail(response);
+  const status = `${response.status}${response.statusText ? ` ${response.statusText}` : ""}`;
+  return detail
+    ? `Serper API request failed (${status}): ${detail}`
+    : `Serper API request failed (${status}).`;
+}
+
+async function readErrorDetail(response: Response): Promise<string | undefined> {
+  const text = (await response.text()).trim();
+  if (!text) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    const record = asRecord(parsed);
+    const detail =
+      readString(record?.message) ??
+      readString(record?.error) ??
+      readString(record?.detail);
+    if (detail) {
+      return detail;
+    }
+    return JSON.stringify(parsed);
+  } catch {
+    return text;
+  }
+}
+
+function toSearchResult(
+  entry: unknown,
+  searchContext: Record<string, unknown> | undefined,
+) {
+  const record = asRecord(entry);
+  if (!record) {
+    return null;
+  }
+
+  const url = readString(record.link) ?? "";
+  const title = readString(record.title) || url || "Untitled";
+  const snippet = trimSnippet(
+    readString(record.snippet) ??
+      readString(record.richSnippet) ??
+      readString(record.date) ??
+      "",
+  );
+
+  const metadata = omitUndefined({
+    source: "organic",
+    position: readNumber(record.position),
+    date: readString(record.date),
+    attributes: asRecord(record.attributes),
+    sitelinks: asArray(record.sitelinks),
+    rating: readNumber(record.rating),
+    ratingCount: readNumber(record.ratingCount),
+    cid: readString(record.cid),
+    ...extractExtraMetadata(record, ["title", "link", "snippet"]),
+    ...(searchContext ? { searchContext } : {}),
+  });
+
+  return {
+    title,
+    url,
+    snippet,
+    ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+  };
+}
+
+function buildSearchContext(
+  response: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const context = omitUndefined({
+    searchParameters: asRecord(response.searchParameters),
+    searchInformation: asRecord(response.searchInformation),
+    credits: readNumber(response.credits),
+    answerBox: asRecord(response.answerBox),
+    knowledgeGraph: asRecord(response.knowledgeGraph),
+    peopleAlsoAsk: asArray(response.peopleAlsoAsk),
+    relatedSearches: asArray(response.relatedSearches),
+    topStories: asArray(response.topStories),
+    news: asArray(response.news),
+    images: asArray(response.images),
+    videos: asArray(response.videos),
+    places: asArray(response.places),
+  });
+
+  return Object.keys(context).length > 0 ? context : undefined;
+}
+
+function extractExtraMetadata(
+  record: Record<string, unknown>,
+  ignoredKeys: string[],
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(record).filter(
+      ([key, value]) => !ignoredKeys.includes(key) && value !== undefined,
+    ),
+  );
+}
+
+function omitUndefined<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  ) as T;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function asArray(value: unknown): unknown[] | undefined {
+  return Array.isArray(value) ? value : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export const PROVIDER_IDS = [
   "openai",
   "parallel",
   "perplexity",
+  "serper",
   "tavily",
   "valyu",
 ] as const;
@@ -168,6 +169,10 @@ export interface TavilyOptions {
   extract?: Record<string, unknown>;
 }
 
+export interface SerperOptions {
+  search?: Record<string, unknown>;
+}
+
 export interface ValyuOptions {
   search?: Record<string, unknown>;
   answer?: Record<string, unknown>;
@@ -250,6 +255,11 @@ export interface Tavily extends Provider<TavilyOptions> {
   baseUrl?: string;
 }
 
+export interface Serper extends Provider<SerperOptions> {
+  apiKey?: string;
+  baseUrl?: string;
+}
+
 export interface Valyu extends Provider<ValyuOptions> {
   apiKey?: string;
   baseUrl?: string;
@@ -271,6 +281,7 @@ export interface Providers {
   perplexity?: Perplexity;
   parallel?: Parallel;
   openai?: OpenAI;
+  serper?: Serper;
   tavily?: Tavily;
   valyu?: Valyu;
 }
@@ -287,6 +298,7 @@ export type AnyProvider =
   | OpenAI
   | Perplexity
   | Parallel
+  | Serper
   | Tavily
   | Valyu;
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -190,6 +190,37 @@ describe("config parsing", () => {
     });
   });
 
+  it("parses capability-scoped Serper provider options", () => {
+    const parsed = parseConfig(
+      JSON.stringify({
+        providers: {
+          serper: {
+            apiKey: "SERPER_API_KEY",
+            baseUrl: "https://google.serper.test",
+            options: {
+              search: {
+                gl: "us",
+                hl: "en",
+              },
+            },
+          },
+        },
+      }),
+      "test-config.json",
+    );
+
+    expect(parsed.providers?.serper).toEqual({
+      apiKey: "SERPER_API_KEY",
+      baseUrl: "https://google.serper.test",
+      options: {
+        search: {
+          gl: "us",
+          hl: "en",
+        },
+      },
+    });
+  });
+
   it("parses capability-scoped Exa provider options", () => {
     const parsed = parseConfig(
       JSON.stringify({
@@ -584,6 +615,10 @@ describe("config parsing", () => {
     expect(ADAPTERS_BY_ID.gemini.createTemplate().settings).toBeUndefined();
     expect(ADAPTERS_BY_ID.linkup.createTemplate()).toEqual({
       apiKey: "LINKUP_API_KEY",
+    });
+    expect(ADAPTERS_BY_ID.serper.createTemplate()).toEqual({
+      apiKey: "SERPER_API_KEY",
+      options: {},
     });
     expect(ADAPTERS_BY_ID.tavily.createTemplate().options).toEqual({
       search: {

--- a/test/provider-config-manifests.test.ts
+++ b/test/provider-config-manifests.test.ts
@@ -3,7 +3,13 @@ import {
   getProviderConfigManifest,
   type ProviderTextSettingDescriptor,
 } from "../src/provider-config-manifests.js";
-import type { Cloudflare, Custom, Linkup, Tavily } from "../src/types.js";
+import type {
+  Cloudflare,
+  Custom,
+  Linkup,
+  Serper,
+  Tavily,
+} from "../src/types.js";
 
 describe("provider config manifests", () => {
   it("exposes only custom argv, cwd, and env settings", () => {
@@ -149,7 +155,48 @@ describe("provider config manifests", () => {
     });
   });
 
-  it("exposes only Tavily API key and base URL settings", () => {
+  it("exposes Serper API key and base URL settings", () => {
+    const manifest = getProviderConfigManifest("serper");
+    const ids = manifest.settings.map((setting) => setting.id);
+
+    expect(ids).toEqual(["apiKey", "baseUrl"]);
+  });
+
+  it("round-trips Serper API key and base URL settings", () => {
+    const manifest = getProviderConfigManifest("serper");
+    const apiKeySetting = manifest.settings.find(
+      (setting) => setting.id === "apiKey",
+    );
+    const baseUrlSetting = manifest.settings.find(
+      (setting) => setting.id === "baseUrl",
+    );
+
+    if (
+      !apiKeySetting ||
+      apiKeySetting.kind !== "text" ||
+      !baseUrlSetting ||
+      baseUrlSetting.kind !== "text"
+    ) {
+      throw new Error("Missing Serper settings.");
+    }
+
+    const config: Serper = {};
+    (apiKeySetting as ProviderTextSettingDescriptor<Serper>).setValue(
+      config,
+      "SERPER_API_KEY",
+    );
+    (baseUrlSetting as ProviderTextSettingDescriptor<Serper>).setValue(
+      config,
+      "https://google.serper.test",
+    );
+
+    expect(config).toEqual({
+      apiKey: "SERPER_API_KEY",
+      baseUrl: "https://google.serper.test",
+    });
+  });
+
+  it("exposes Tavily API key, base URL, and non-research execution settings", () => {
     const manifest = getProviderConfigManifest("tavily");
     const ids = manifest.settings.map((setting) => setting.id);
 

--- a/test/provider-resolution.test.ts
+++ b/test/provider-resolution.test.ts
@@ -40,6 +40,7 @@ beforeEach(() => {
   delete process.env.OPENAI_API_KEY;
   delete process.env.PERPLEXITY_API_KEY;
   delete process.env.PARALLEL_API_KEY;
+  delete process.env.SERPER_API_KEY;
   delete process.env.TAVILY_API_KEY;
   delete process.env.VALYU_API_KEY;
 });
@@ -53,6 +54,7 @@ afterEach(() => {
   delete process.env.OPENAI_API_KEY;
   delete process.env.PERPLEXITY_API_KEY;
   delete process.env.PARALLEL_API_KEY;
+  delete process.env.SERPER_API_KEY;
   delete process.env.TAVILY_API_KEY;
   delete process.env.VALYU_API_KEY;
   execFileSyncMock.mockReset();
@@ -152,6 +154,23 @@ describe("provider resolution", () => {
 
     const provider = resolveProviderForTool(config, process.cwd(), "contents");
     expect(provider.id).toBe("parallel");
+  });
+
+  it("uses the mapped Serper provider for search", () => {
+    process.env.SERPER_API_KEY = "test-key";
+
+    const config = createConfig({
+      tools: {
+        search: "serper",
+      },
+      providers: {
+        serper: {
+          apiKey: "SERPER_API_KEY",
+        },
+      },
+    });
+
+    expect(resolveSearchProvider(config, process.cwd()).id).toBe("serper");
   });
 
   it("uses the mapped Tavily provider for search and contents", () => {

--- a/test/provider-resolution.test.ts
+++ b/test/provider-resolution.test.ts
@@ -33,6 +33,7 @@ beforeEach(() => {
   cleanupDirs.push(home);
   process.env.HOME = home;
   delete process.env.CLOUDFLARE_API_TOKEN;
+  delete process.env.CLOUDFLARE_ACCOUNT_ID;
   delete process.env.CODEX_API_KEY;
   delete process.env.EXA_API_KEY;
   delete process.env.GOOGLE_API_KEY;
@@ -47,6 +48,7 @@ beforeEach(() => {
 
 afterEach(() => {
   delete process.env.CLOUDFLARE_API_TOKEN;
+  delete process.env.CLOUDFLARE_ACCOUNT_ID;
   delete process.env.CODEX_API_KEY;
   delete process.env.EXA_API_KEY;
   delete process.env.GOOGLE_API_KEY;

--- a/test/provider-tool-output.test.ts
+++ b/test/provider-tool-output.test.ts
@@ -1120,15 +1120,19 @@ describe("provider tool output", () => {
       "perplexity",
     )!;
     const exa = __test__.buildStructuredOptionsSchema("search", "exa")!;
+    const serper = __test__.buildStructuredOptionsSchema("search", "serper")!;
     const tavily = __test__.buildStructuredOptionsSchema("search", "tavily")!;
 
     const perplexityProvider = (perplexity.anyOf?.[0] ?? perplexity).properties
       ?.provider;
     const exaProvider = (exa.anyOf?.[0] ?? exa).properties?.provider;
+    const serperProvider = (serper.anyOf?.[0] ?? serper).properties?.provider;
     const tavilyProvider = (tavily.anyOf?.[0] ?? tavily).properties?.provider;
 
     expect(perplexityProvider?.properties ?? {}).toHaveProperty("country");
     expect(exaProvider?.properties ?? {}).toHaveProperty("userLocation");
+    expect(serperProvider?.properties ?? {}).toHaveProperty("gl");
+    expect(serperProvider?.properties ?? {}).toHaveProperty("location");
     expect(tavilyProvider?.properties ?? {}).toHaveProperty("country");
   });
 

--- a/test/serper-provider.test.ts
+++ b/test/serper-provider.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { serperAdapter } from "../src/providers/serper.js";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  delete process.env.SERPER_API_KEY;
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("serperAdapter", () => {
+  it("maps Serper organic results and preserves rich metadata", async () => {
+    process.env.SERPER_API_KEY = "test-key";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          searchParameters: {
+            q: "serper api",
+            gl: "us",
+            hl: "en",
+          },
+          credits: 1,
+          knowledgeGraph: {
+            title: "Serper",
+            type: "Company",
+          },
+          answerBox: {
+            answer: "Structured Google search API",
+          },
+          peopleAlsoAsk: [
+            {
+              question: "What is Serper?",
+              link: "https://example.com/what-is-serper",
+            },
+          ],
+          relatedSearches: [{ query: "serper pricing" }],
+          organic: [
+            {
+              title: "Serper Docs",
+              link: "https://serper.dev",
+              snippet: "A".repeat(400),
+              position: 1,
+              date: "2026-04-10",
+              sitelinks: [
+                {
+                  title: "Pricing",
+                  link: "https://serper.dev/pricing",
+                },
+              ],
+              attributes: {
+                category: "API",
+              },
+              favicon: "https://serper.dev/favicon.ico",
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const response = await serperAdapter.search(
+      "serper api",
+      25,
+      {
+        apiKey: "SERPER_API_KEY",
+        baseUrl: "https://google.serper.test",
+        options: {
+          search: {
+            gl: "de",
+            autocorrect: false,
+          },
+        },
+      },
+      { cwd: process.cwd() },
+      {
+        hl: "en",
+        location: "Berlin, Berlin, Germany",
+        requestTimeoutMs: 1000,
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith("https://google.serper.test/search", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": "test-key",
+      },
+      body: JSON.stringify({
+        q: "serper api",
+        num: 20,
+        gl: "de",
+        autocorrect: false,
+        hl: "en",
+        location: "Berlin, Berlin, Germany",
+      }),
+      signal: undefined,
+    });
+    expect(response).toEqual({
+      provider: "serper",
+      results: [
+        {
+          title: "Serper Docs",
+          url: "https://serper.dev",
+          snippet: `${"A".repeat(299)}…`,
+          metadata: {
+            source: "organic",
+            position: 1,
+            date: "2026-04-10",
+            attributes: {
+              category: "API",
+            },
+            sitelinks: [
+              {
+                title: "Pricing",
+                link: "https://serper.dev/pricing",
+              },
+            ],
+            favicon: "https://serper.dev/favicon.ico",
+            searchContext: {
+              searchParameters: {
+                q: "serper api",
+                gl: "us",
+                hl: "en",
+              },
+              credits: 1,
+              answerBox: {
+                answer: "Structured Google search API",
+              },
+              knowledgeGraph: {
+                title: "Serper",
+                type: "Company",
+              },
+              peopleAlsoAsk: [
+                {
+                  question: "What is Serper?",
+                  link: "https://example.com/what-is-serper",
+                },
+              ],
+              relatedSearches: [{ query: "serper pricing" }],
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  it("returns an empty result set when Serper has no organic matches", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ peopleAlsoAsk: [] }), { status: 200 }),
+    ) as typeof fetch;
+
+    const response = await serperAdapter.search(
+      "serper",
+      3,
+      {
+        apiKey: "literal-key",
+      },
+      { cwd: process.cwd() },
+    );
+
+    expect(response).toEqual({
+      provider: "serper",
+      results: [],
+    });
+  });
+
+  it("surfaces Serper HTTP errors with response details", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: "invalid key" }), {
+        status: 401,
+        statusText: "Unauthorized",
+      }),
+    ) as typeof fetch;
+
+    await expect(
+      serperAdapter.search(
+        "serper",
+        3,
+        {
+          apiKey: "literal-key",
+        },
+        { cwd: process.cwd() },
+      ),
+    ).rejects.toThrow(/Serper API request failed \(401 Unauthorized\): invalid key/);
+  });
+
+  it("requires an API key", async () => {
+    await expect(
+      serperAdapter.search(
+        "serper",
+        1,
+        {
+          apiKey: "SERPER_API_KEY",
+        },
+        { cwd: process.cwd() },
+      ),
+    ).rejects.toThrow(/missing an API key/);
+  });
+});

--- a/test/serper-provider.test.ts
+++ b/test/serper-provider.test.ts
@@ -81,22 +81,25 @@ describe("serperAdapter", () => {
       },
     );
 
-    expect(fetchMock).toHaveBeenCalledWith("https://google.serper.test/search", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-api-key": "test-key",
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://google.serper.test/search",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": "test-key",
+        },
+        body: JSON.stringify({
+          q: "serper api",
+          num: 20,
+          gl: "de",
+          autocorrect: false,
+          hl: "en",
+          location: "Berlin, Berlin, Germany",
+        }),
+        signal: undefined,
       },
-      body: JSON.stringify({
-        q: "serper api",
-        num: 20,
-        gl: "de",
-        autocorrect: false,
-        hl: "en",
-        location: "Berlin, Berlin, Germany",
-      }),
-      signal: undefined,
-    });
+    );
     expect(response).toEqual({
       provider: "serper",
       results: [
@@ -147,9 +150,11 @@ describe("serperAdapter", () => {
   });
 
   it("returns an empty result set when Serper has no organic matches", async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ peopleAlsoAsk: [] }), { status: 200 }),
-    ) as typeof fetch;
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ peopleAlsoAsk: [] }), { status: 200 }),
+      ) as typeof fetch;
 
     const response = await serperAdapter.search(
       "serper",
@@ -183,7 +188,9 @@ describe("serperAdapter", () => {
         },
         { cwd: process.cwd() },
       ),
-    ).rejects.toThrow(/Serper API request failed \(401 Unauthorized\): invalid key/);
+    ).rejects.toThrow(
+      /Serper API request failed \(401 Unauthorized\): invalid key/,
+    );
   });
 
   it("requires an API key", async () => {

--- a/test/tool-availability.test.ts
+++ b/test/tool-availability.test.ts
@@ -36,6 +36,7 @@ beforeEach(() => {
   delete process.env.LINKUP_API_KEY;
   delete process.env.OPENAI_API_KEY;
   delete process.env.PARALLEL_API_KEY;
+  delete process.env.SERPER_API_KEY;
   delete process.env.TAVILY_API_KEY;
   delete process.env.VALYU_API_KEY;
 });
@@ -46,6 +47,7 @@ afterEach(() => {
   delete process.env.PERPLEXITY_API_KEY;
   delete process.env.LINKUP_API_KEY;
   delete process.env.OPENAI_API_KEY;
+  delete process.env.SERPER_API_KEY;
   delete process.env.TAVILY_API_KEY;
   execFileSyncMock.mockReset();
   if (originalHome === undefined) {
@@ -486,6 +488,39 @@ describe("managed tool availability", () => {
         "research",
       ),
     ).toEqual(["perplexity"]);
+  });
+
+  it("surfaces mapped Serper search when Serper is available", () => {
+    process.env.SERPER_API_KEY = "test-key";
+
+    const config = createConfig({
+      tools: {
+        search: "serper",
+      },
+      providers: {
+        serper: {
+          apiKey: "SERPER_API_KEY",
+        },
+      },
+    });
+
+    expect(
+      __test__.getAvailableProviderIdsForCapability(
+        config,
+        process.cwd(),
+        "search",
+      ),
+    ).toEqual(["serper"]);
+    expect(
+      __test__.getAvailableProviderIdsForCapability(
+        config,
+        process.cwd(),
+        "contents",
+      ),
+    ).toEqual([]);
+    expect(
+      __test__.getAvailableManagedToolNames(config, process.cwd()),
+    ).toEqual(["web_search"]);
   });
 
   it("surfaces mapped Tavily tools when Tavily is available", () => {


### PR DESCRIPTION
Adds native support for [Serper](https://serper.dev) - a cheaper alternative to serpapi.com.

Fast, thorough, rich metadata.