### PR TITLE
Add Ollama provider for web search and contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ not as a replacement for source inspection or deeper research.
 ## ✨ Features
 
 - **Multiple providers**: Claude, Cloudflare, Codex, Exa, Firecrawl,
-  Gemini, Linkup, OpenAI, Perplexity, Parallel, Serper,
+  Gemini, Linkup, Ollama, OpenAI, Perplexity, Parallel, Serper,
   [Tavily](https://tavily.com), Valyu
 - **Provider-aware tool options**: pi only exposes the provider settings that
   actually apply to the backend you selected, so tool calls are easier to
@@ -62,6 +62,7 @@ Each tool can be routed to any compatible provider:
 | **Firecrawl**  |   ✔    |    ✔     |        |          | `FIRECRAWL_API_KEY`                              |
 | **Gemini**     |   ✔    |          |   ✔    |    ✔     | `GOOGLE_API_KEY`                                 |
 | **Linkup**     |   ✔    |    ✔     |        |          | `LINKUP_API_KEY`                                 |
+| **Ollama**     |   ✔    |    ✔     |        |          | `OLLAMA_API_KEY`                                 |
 | **OpenAI**     |   ✔    |          |   ✔    |    ✔     | `OPENAI_API_KEY`                                 |
 | **Parallel**   |   ✔    |    ✔     |        |          | `PARALLEL_API_KEY`                               |
 | **Perplexity** |   ✔    |          |   ✔    |    ✔     | `PERPLEXITY_API_KEY`                             |
@@ -306,6 +307,36 @@ scope, or account ID is usually wrong.
   `excludeDomains`, `fromDate`, and `toDate`
 - Exposes contents options `renderJs`, `includeRawHtml`, and `extractImages`
 - Good fit for a simple search-plus-markdown setup without extra provider wiring
+
+</details>
+
+<details>
+<summary><strong>Ollama</strong></summary>
+
+- API: [Ollama Web Search and Fetch API](https://docs.ollama.com/capabilities/web-search)
+- Supports `web_search` via Ollama's `POST /api/web_search` endpoint
+- Supports `web_contents` via Ollama's `POST /api/web_fetch` endpoint
+- Authenticates with an Ollama API key using `OLLAMA_API_KEY` by default
+- Optional `baseUrl` overrides the default `https://ollama.com` API host for
+  proxies or compatible endpoints
+- Ollama caps search requests at 10 results, so `web_search.maxResults` is
+  clamped to `1–10` for this provider
+
+Minimal config:
+
+```json
+{
+  "tools": {
+    "search": "ollama",
+    "contents": "ollama"
+  },
+  "providers": {
+    "ollama": {
+      "apiKey": "OLLAMA_API_KEY"
+    }
+  }
+}
+```
 
 </details>
 

--- a/changelog/unreleased/ollama-provider-for-web-search-and-contents.md
+++ b/changelog/unreleased/ollama-provider-for-web-search-and-contents.md
@@ -1,0 +1,26 @@
+---
+title: Ollama provider for web search and contents
+type: feature
+authors:
+  - mcowger
+pr: 16
+created: 2026-04-27T08:24:27.664117Z
+---
+
+Ollama can now power `web_search` and `web_contents` through its Web Search and Web Fetch APIs:
+
+```json
+{
+  "tools": {
+    "search": "ollama",
+    "contents": "ollama"
+  },
+  "providers": {
+    "ollama": {
+      "apiKey": "OLLAMA_API_KEY"
+    }
+  }
+}
+```
+
+This gives users another API-backed option for search-plus-page-fetch workflows, including installations that already use Ollama Cloud credentials.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "firecrawl",
     "gemini",
     "linkup",
+    "ollama",
     "openai",
     "parallel",
     "perplexity",

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,7 +18,6 @@ import type {
   Gemini,
   Linkup,
   Ollama,
-  OllamaOptions,
   OpenAI,
   OpenAIOptions,
   Parallel,
@@ -276,13 +275,6 @@ function normalizeProvider(
       return parseProviderWithShape<Ollama>(raw, source, providerId, {
         apiKey: readOptionalString,
         baseUrl: readOptionalString,
-        options: (value, innerSource, field) =>
-          parseOptionalCapabilityOptions<OllamaOptions>(
-            value,
-            innerSource,
-            field,
-            ["search", "fetch"],
-          ),
         settings: parseOptionalExecutionSettings,
       });
     case "firecrawl":

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,8 @@ import type {
   Firecrawl,
   Gemini,
   Linkup,
+  Ollama,
+  OllamaOptions,
   OpenAI,
   OpenAIOptions,
   Parallel,
@@ -94,6 +96,7 @@ export function parseProviderConfig(
   | Firecrawl
   | Gemini
   | Linkup
+  | Ollama
   | OpenAI
   | Perplexity
   | Parallel
@@ -193,6 +196,7 @@ function normalizeProvider(
   | Firecrawl
   | Gemini
   | Linkup
+  | Ollama
   | OpenAI
   | Parallel
   | Perplexity
@@ -265,6 +269,19 @@ function normalizeProvider(
             innerSource,
             field,
             ["search", "answer", "research"],
+          ),
+        settings: parseOptionalExecutionSettings,
+      });
+    case "ollama":
+      return parseProviderWithShape<Ollama>(raw, source, providerId, {
+        apiKey: readOptionalString,
+        baseUrl: readOptionalString,
+        options: (value, innerSource, field) =>
+          parseOptionalCapabilityOptions<OllamaOptions>(
+            value,
+            innerSource,
+            field,
+            ["search", "fetch"],
           ),
         settings: parseOptionalExecutionSettings,
       });

--- a/src/provider-config-manifests.ts
+++ b/src/provider-config-manifests.ts
@@ -12,6 +12,7 @@ import type {
   Gemini,
   GeminiOptions,
   Linkup,
+  Ollama,
   OpenAI,
   OpenAIAnswerOptions,
   OpenAIResearchOptions,
@@ -518,6 +519,9 @@ export const PROVIDER_CONFIG_MANIFESTS = {
   },
   linkup: {
     settings: [apiKeySetting<Linkup>(), baseUrlSetting<Linkup>()],
+  },
+  ollama: {
+    settings: [apiKeySetting<Ollama>(), baseUrlSetting<Ollama>()],
   },
   openai: {
     settings: [

--- a/src/provider-config-manifests.ts
+++ b/src/provider-config-manifests.ts
@@ -775,7 +775,9 @@ export const PROVIDER_CONFIG_MANIFESTS = {
   },
 } as const;
 
-export function getProviderConfigManifest(providerId: ProviderId) {
+export function getProviderConfigManifest<TProviderId extends ProviderId>(
+  providerId: TProviderId,
+): (typeof PROVIDER_CONFIG_MANIFESTS)[TProviderId] {
   return PROVIDER_CONFIG_MANIFESTS[providerId];
 }
 

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -7,6 +7,7 @@ import { exaAdapter } from "./exa.js";
 import { firecrawlAdapter } from "./firecrawl.js";
 import { geminiAdapter } from "./gemini.js";
 import { linkupAdapter } from "./linkup.js";
+import { ollamaAdapter } from "./ollama.js";
 import { openaiAdapter } from "./openai.js";
 import { parallelAdapter } from "./parallel.js";
 import { perplexityAdapter } from "./perplexity.js";
@@ -23,6 +24,7 @@ export const ADAPTERS_BY_ID: ProviderAdaptersById = {
   firecrawl: firecrawlAdapter,
   gemini: geminiAdapter,
   linkup: linkupAdapter,
+  ollama: ollamaAdapter,
   openai: openaiAdapter,
   parallel: parallelAdapter,
   perplexity: perplexityAdapter,

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -1,6 +1,5 @@
 import { resolveConfigValue } from "../config-values.js";
 import type { ContentsResponse } from "../contents.js";
-import { stripLocalExecutionOptions } from "../execution-policy.js";
 import type {
   Ollama,
   ProviderAdapter,
@@ -9,7 +8,6 @@ import type {
   SearchResponse,
 } from "../types.js";
 import {
-  asJsonObject,
   getApiKeyStatus,
   normalizeContentText,
   trimSnippet,
@@ -53,14 +51,9 @@ export const ollamaAdapter: ProviderAdapter<"ollama"> & {
     maxResults: number,
     config: Ollama,
     context: ProviderContext,
-    options?: Record<string, unknown>,
+    _options?: Record<string, unknown>,
   ): Promise<SearchResponse> {
     const apiKey = resolveApiKey(config);
-    const providerOptions = mergeProviderOptions(
-      config.options?.search,
-      options,
-      ["query", "max_results"],
-    );
 
     const response = await fetch(
       resolveEndpoint(config.baseUrl, WEB_SEARCH_PATH),
@@ -68,7 +61,6 @@ export const ollamaAdapter: ProviderAdapter<"ollama"> & {
         method: "POST",
         headers: buildHeaders(apiKey),
         body: JSON.stringify({
-          ...providerOptions,
           query,
           max_results: clampMaxResults(maxResults),
         }),
@@ -97,15 +89,10 @@ export const ollamaAdapter: ProviderAdapter<"ollama"> & {
     urls: string[],
     config: Ollama,
     context: ProviderContext,
-    options?: Record<string, unknown>,
+    _options?: Record<string, unknown>,
   ): Promise<ContentsResponse> {
     const apiKey = resolveApiKey(config);
     const endpoint = resolveEndpoint(config.baseUrl, WEB_FETCH_PATH);
-    const providerOptions = mergeProviderOptions(
-      config.options?.fetch,
-      options,
-      ["url"],
-    );
 
     return {
       provider: ollamaAdapter.id,
@@ -116,7 +103,6 @@ export const ollamaAdapter: ProviderAdapter<"ollama"> & {
               method: "POST",
               headers: buildHeaders(apiKey),
               body: JSON.stringify({
-                ...providerOptions,
                 url,
               }),
               signal: context.signal,
@@ -186,23 +172,6 @@ function resolveEndpoint(
     return `${base}/${apiPath}`;
   }
   return `${base}${endpointPath}`;
-}
-
-function mergeProviderOptions(
-  defaults: Record<string, unknown> | undefined,
-  options: Record<string, unknown> | undefined,
-  reservedKeys: readonly string[],
-): Record<string, unknown> {
-  const merged = {
-    ...(stripLocalExecutionOptions(asJsonObject(defaults)) ?? {}),
-    ...(stripLocalExecutionOptions(asJsonObject(options)) ?? {}),
-  };
-
-  for (const key of reservedKeys) {
-    delete merged[key];
-  }
-
-  return merged;
 }
 
 function clampMaxResults(value: number): number {

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -1,0 +1,272 @@
+import { resolveConfigValue } from "../config-values.js";
+import type { ContentsResponse } from "../contents.js";
+import { stripLocalExecutionOptions } from "../execution-policy.js";
+import type {
+  Ollama,
+  ProviderAdapter,
+  ProviderCapabilityStatus,
+  ProviderContext,
+  SearchResponse,
+} from "../types.js";
+import {
+  asJsonObject,
+  getApiKeyStatus,
+  normalizeContentText,
+  trimSnippet,
+} from "./shared.js";
+
+const DEFAULT_BASE_URL = "https://ollama.com";
+const WEB_SEARCH_PATH = "/api/web_search";
+const WEB_FETCH_PATH = "/api/web_fetch";
+
+export const ollamaAdapter: ProviderAdapter<"ollama"> & {
+  search(
+    query: string,
+    maxResults: number,
+    config: Ollama,
+    context: ProviderContext,
+    options?: Record<string, unknown>,
+  ): Promise<SearchResponse>;
+  contents(
+    urls: string[],
+    config: Ollama,
+    context: ProviderContext,
+    options?: Record<string, unknown>,
+  ): Promise<ContentsResponse>;
+} = {
+  id: "ollama",
+  label: "Ollama",
+  docsUrl: "https://docs.ollama.com/capabilities/web-search",
+
+  createTemplate(): Ollama {
+    return {
+      apiKey: "OLLAMA_API_KEY",
+    };
+  },
+
+  getCapabilityStatus(config: Ollama | undefined): ProviderCapabilityStatus {
+    return getApiKeyStatus(config?.apiKey);
+  },
+
+  async search(
+    query: string,
+    maxResults: number,
+    config: Ollama,
+    context: ProviderContext,
+    options?: Record<string, unknown>,
+  ): Promise<SearchResponse> {
+    const apiKey = resolveApiKey(config);
+    const providerOptions = mergeProviderOptions(
+      config.options?.search,
+      options,
+      ["query", "max_results"],
+    );
+
+    const response = await fetch(
+      resolveEndpoint(config.baseUrl, WEB_SEARCH_PATH),
+      {
+        method: "POST",
+        headers: buildHeaders(apiKey),
+        body: JSON.stringify({
+          ...providerOptions,
+          query,
+          max_results: clampMaxResults(maxResults),
+        }),
+        signal: context.signal,
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(await buildHttpError(response));
+    }
+
+    const data = (await response.json()) as OllamaSearchResponse;
+    const results = Array.isArray(data.results) ? data.results : [];
+
+    return {
+      provider: ollamaAdapter.id,
+      results: results.slice(0, clampMaxResults(maxResults)).map((result) => ({
+        title: result.title || result.url || "Untitled",
+        url: result.url ?? "",
+        snippet: trimSnippet(result.content),
+      })),
+    };
+  },
+
+  async contents(
+    urls: string[],
+    config: Ollama,
+    context: ProviderContext,
+    options?: Record<string, unknown>,
+  ): Promise<ContentsResponse> {
+    const apiKey = resolveApiKey(config);
+    const endpoint = resolveEndpoint(config.baseUrl, WEB_FETCH_PATH);
+    const providerOptions = mergeProviderOptions(
+      config.options?.fetch,
+      options,
+      ["url"],
+    );
+
+    return {
+      provider: ollamaAdapter.id,
+      answers: await Promise.all(
+        urls.map(async (url) => {
+          try {
+            const response = await fetch(endpoint, {
+              method: "POST",
+              headers: buildHeaders(apiKey),
+              body: JSON.stringify({
+                ...providerOptions,
+                url,
+              }),
+              signal: context.signal,
+            });
+
+            if (!response.ok) {
+              return {
+                url,
+                error: await buildHttpError(response),
+              };
+            }
+
+            const data = (await response.json()) as OllamaFetchResponse;
+            const content = normalizeContentText(data.content);
+            if (!content) {
+              return {
+                url,
+                error: "No content returned for this URL.",
+              };
+            }
+
+            const metadata = buildFetchMetadata(data);
+            return {
+              url,
+              content,
+              ...(metadata ? { metadata } : {}),
+            };
+          } catch (error) {
+            return {
+              url,
+              error: error instanceof Error ? error.message : String(error),
+            };
+          }
+        }),
+      ),
+    };
+  },
+};
+
+function resolveApiKey(config: Ollama): string {
+  const apiKey = resolveConfigValue(config.apiKey);
+  if (!apiKey) {
+    throw new Error("is missing an API key");
+  }
+  return apiKey;
+}
+
+function buildHeaders(apiKey: string): HeadersInit {
+  return {
+    authorization: `Bearer ${apiKey}`,
+    "content-type": "application/json",
+  };
+}
+
+function resolveEndpoint(
+  baseUrlReference: string | undefined,
+  endpointPath: string,
+): string {
+  const baseUrl = resolveConfigValue(baseUrlReference) ?? DEFAULT_BASE_URL;
+  const base = baseUrl.replace(/\/+$/, "");
+  const apiPath = endpointPath.replace(/^\/api\//, "");
+
+  if (base.endsWith(endpointPath)) {
+    return base;
+  }
+  if (base.endsWith("/api")) {
+    return `${base}/${apiPath}`;
+  }
+  return `${base}${endpointPath}`;
+}
+
+function mergeProviderOptions(
+  defaults: Record<string, unknown> | undefined,
+  options: Record<string, unknown> | undefined,
+  reservedKeys: readonly string[],
+): Record<string, unknown> {
+  const merged = {
+    ...(stripLocalExecutionOptions(asJsonObject(defaults)) ?? {}),
+    ...(stripLocalExecutionOptions(asJsonObject(options)) ?? {}),
+  };
+
+  for (const key of reservedKeys) {
+    delete merged[key];
+  }
+
+  return merged;
+}
+
+function clampMaxResults(value: number): number {
+  return Math.max(1, Math.min(10, Math.trunc(value || 0)));
+}
+
+async function buildHttpError(response: Response): Promise<string> {
+  const detail = await readErrorDetail(response);
+  const status = `${response.status}${response.statusText ? ` ${response.statusText}` : ""}`;
+  return detail
+    ? `Ollama API request failed (${status}): ${detail}`
+    : `Ollama API request failed (${status}).`;
+}
+
+async function readErrorDetail(
+  response: Response,
+): Promise<string | undefined> {
+  const text = (await response.text()).trim();
+  if (!text) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(text) as {
+      message?: unknown;
+      error?: unknown;
+      detail?: unknown;
+    };
+    for (const key of ["message", "error", "detail"] as const) {
+      if (typeof parsed[key] === "string" && parsed[key].trim()) {
+        return parsed[key];
+      }
+    }
+    return JSON.stringify(parsed);
+  } catch {
+    return text;
+  }
+}
+
+interface OllamaSearchResponse {
+  results?: OllamaSearchResult[];
+}
+
+interface OllamaSearchResult {
+  title?: string;
+  url?: string;
+  content?: string;
+}
+
+interface OllamaFetchResponse {
+  title?: string;
+  content?: string;
+  links?: string[];
+}
+
+function buildFetchMetadata(
+  data: OllamaFetchResponse,
+): Record<string, unknown> | undefined {
+  const metadata: Record<string, unknown> = {};
+  if (data.title) {
+    metadata.title = data.title;
+  }
+  if (data.links?.length) {
+    metadata.links = data.links;
+  }
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,11 +123,6 @@ export interface LinkupOptions {
   fetch?: Record<string, unknown>;
 }
 
-export interface OllamaOptions {
-  search?: Record<string, unknown>;
-  fetch?: Record<string, unknown>;
-}
-
 export interface PerplexityOptions {
   search?: Record<string, unknown>;
   answer?: Record<string, unknown>;
@@ -198,7 +193,7 @@ export interface CustomOptions {
   research?: CustomCommandConfig;
 }
 
-export interface Provider<TOptions> {
+export interface Provider<TOptions = never> {
   options?: TOptions;
   settings?: ExecutionSettings;
 }
@@ -239,7 +234,7 @@ export interface Linkup extends Provider<LinkupOptions> {
   baseUrl?: string;
 }
 
-export interface Ollama extends Provider<OllamaOptions> {
+export interface Ollama extends Provider {
   apiKey?: string;
   baseUrl?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export const PROVIDER_IDS = [
   "firecrawl",
   "gemini",
   "linkup",
+  "ollama",
   "openai",
   "parallel",
   "perplexity",
@@ -118,6 +119,11 @@ export interface GeminiOptions {
 }
 
 export interface LinkupOptions {
+  search?: Record<string, unknown>;
+  fetch?: Record<string, unknown>;
+}
+
+export interface OllamaOptions {
   search?: Record<string, unknown>;
   fetch?: Record<string, unknown>;
 }
@@ -233,6 +239,11 @@ export interface Linkup extends Provider<LinkupOptions> {
   baseUrl?: string;
 }
 
+export interface Ollama extends Provider<OllamaOptions> {
+  apiKey?: string;
+  baseUrl?: string;
+}
+
 export interface Perplexity extends Provider<PerplexityOptions> {
   apiKey?: string;
   baseUrl?: string;
@@ -278,6 +289,7 @@ export interface ProviderConfigMap {
   firecrawl: Firecrawl;
   gemini: Gemini;
   linkup: Linkup;
+  ollama: Ollama;
   openai: OpenAI;
   parallel: Parallel;
   perplexity: Perplexity;

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -30,6 +30,7 @@ afterEach(async () => {
   delete process.env.CLOUDFLARE_ACCOUNT_ID;
   delete process.env.GOOGLE_API_KEY;
   delete process.env.LINKUP_API_KEY;
+  delete process.env.OLLAMA_API_KEY;
   delete process.env.PARALLEL_API_KEY;
   delete process.env.PERPLEXITY_API_KEY;
   delete process.env.TAVILY_API_KEY;
@@ -615,6 +616,9 @@ describe("config parsing", () => {
     expect(ADAPTERS_BY_ID.gemini.createTemplate().settings).toBeUndefined();
     expect(ADAPTERS_BY_ID.linkup.createTemplate()).toEqual({
       apiKey: "LINKUP_API_KEY",
+    });
+    expect(ADAPTERS_BY_ID.ollama.createTemplate()).toEqual({
+      apiKey: "OLLAMA_API_KEY",
     });
     expect(ADAPTERS_BY_ID.serper.createTemplate()).toEqual({
       apiKey: "SERPER_API_KEY",

--- a/test/ollama-provider.test.ts
+++ b/test/ollama-provider.test.ts
@@ -103,47 +103,6 @@ describe("ollamaAdapter", () => {
     );
   });
 
-  it("does not let provider options override the query or max result count", async () => {
-    process.env.OLLAMA_API_KEY = "test-key";
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(
-        new Response(JSON.stringify({ results: [] }), { status: 200 }),
-      );
-    globalThis.fetch = fetchMock as typeof fetch;
-
-    await ollamaAdapter.search(
-      "real query",
-      3,
-      {
-        apiKey: "OLLAMA_API_KEY",
-        options: {
-          search: {
-            query: "ignored query",
-            max_results: 9,
-            locale: "en-US",
-          },
-        },
-      },
-      { cwd: process.cwd() },
-      {
-        query: "also ignored",
-        max_results: 8,
-      },
-    );
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        body: JSON.stringify({
-          locale: "en-US",
-          query: "real query",
-          max_results: 3,
-        }),
-      }),
-    );
-  });
-
   it("returns contents from the Ollama web fetch API", async () => {
     process.env.OLLAMA_API_KEY = "test-key";
     const fetchMock = vi.fn().mockResolvedValue(
@@ -324,14 +283,6 @@ describe("Ollama config", () => {
           ollama: {
             apiKey: "OLLAMA_API_KEY",
             baseUrl: "https://ollama-proxy.test",
-            options: {
-              search: {
-                locale: "en-US",
-              },
-              fetch: {
-                format: "markdown",
-              },
-            },
             settings: {
               requestTimeoutMs: 45000,
             },
@@ -344,21 +295,13 @@ describe("Ollama config", () => {
     expect(parsed.providers?.ollama).toEqual({
       apiKey: "OLLAMA_API_KEY",
       baseUrl: "https://ollama-proxy.test",
-      options: {
-        search: {
-          locale: "en-US",
-        },
-        fetch: {
-          format: "markdown",
-        },
-      },
       settings: {
         requestTimeoutMs: 45000,
       },
     });
   });
 
-  it("rejects unsupported flat Ollama provider options", () => {
+  it("rejects unsupported Ollama provider options", () => {
     expect(() =>
       parseConfig(
         JSON.stringify({
@@ -373,7 +316,7 @@ describe("Ollama config", () => {
         }),
         "test-config.json",
       ),
-    ).toThrow(/providers\.ollama\.options/);
+    ).toThrow(/providers\.ollama/);
   });
 
   it("creates an Ollama provider template", () => {

--- a/test/ollama-provider.test.ts
+++ b/test/ollama-provider.test.ts
@@ -1,0 +1,425 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parseConfig } from "../src/config.js";
+import {
+  getProviderConfigManifest,
+  type ProviderTextSettingDescriptor,
+} from "../src/provider-config-manifests.js";
+import { ollamaAdapter } from "../src/providers/ollama.js";
+import type { Ollama } from "../src/types.js";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  delete process.env.OLLAMA_API_KEY;
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("ollamaAdapter", () => {
+  it("returns search results from the Ollama web search API", async () => {
+    process.env.OLLAMA_API_KEY = "test-key";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          results: [
+            {
+              title: "Ollama",
+              url: "https://ollama.com/",
+              content: "Cloud models are now available in Ollama",
+            },
+            {
+              title: "What is Ollama?",
+              url: "https://example.com/what-is-ollama",
+              content: "Ollama is an open-source tool...",
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const response = await ollamaAdapter.search(
+      "what is ollama?",
+      5,
+      {
+        apiKey: "OLLAMA_API_KEY",
+      },
+      { cwd: process.cwd() },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://ollama.com/api/web_search",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          authorization: "Bearer test-key",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ query: "what is ollama?", max_results: 5 }),
+      }),
+    );
+
+    expect(response).toEqual({
+      provider: "ollama",
+      results: [
+        {
+          title: "Ollama",
+          url: "https://ollama.com/",
+          snippet: "Cloud models are now available in Ollama",
+        },
+        {
+          title: "What is Ollama?",
+          url: "https://example.com/what-is-ollama",
+          snippet: "Ollama is an open-source tool...",
+        },
+      ],
+    });
+  });
+
+  it("clamps web search result counts to Ollama's 1-10 range", async () => {
+    process.env.OLLAMA_API_KEY = "test-key";
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ results: [] }), { status: 200 }),
+      );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await ollamaAdapter.search(
+      "test",
+      20,
+      {
+        apiKey: "OLLAMA_API_KEY",
+      },
+      { cwd: process.cwd() },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: JSON.stringify({ query: "test", max_results: 10 }),
+      }),
+    );
+  });
+
+  it("does not let provider options override the query or max result count", async () => {
+    process.env.OLLAMA_API_KEY = "test-key";
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ results: [] }), { status: 200 }),
+      );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await ollamaAdapter.search(
+      "real query",
+      3,
+      {
+        apiKey: "OLLAMA_API_KEY",
+        options: {
+          search: {
+            query: "ignored query",
+            max_results: 9,
+            locale: "en-US",
+          },
+        },
+      },
+      { cwd: process.cwd() },
+      {
+        query: "also ignored",
+        max_results: 8,
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: JSON.stringify({
+          locale: "en-US",
+          query: "real query",
+          max_results: 3,
+        }),
+      }),
+    );
+  });
+
+  it("returns contents from the Ollama web fetch API", async () => {
+    process.env.OLLAMA_API_KEY = "test-key";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          title: "Ollama",
+          content:
+            "Cloud models are now available in Ollama\n\n\nExplore models",
+          links: ["https://ollama.com/models"],
+        }),
+        { status: 200 },
+      ),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const response = await ollamaAdapter.contents(
+      ["https://ollama.com"],
+      {
+        apiKey: "OLLAMA_API_KEY",
+      },
+      { cwd: process.cwd() },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://ollama.com/api/web_fetch",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          authorization: "Bearer test-key",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ url: "https://ollama.com" }),
+      }),
+    );
+
+    expect(response).toEqual({
+      provider: "ollama",
+      answers: [
+        {
+          url: "https://ollama.com",
+          content: "Cloud models are now available in Ollama\n\nExplore models",
+          metadata: {
+            title: "Ollama",
+            links: ["https://ollama.com/models"],
+          },
+        },
+      ],
+    });
+  });
+
+  it("builds Ollama endpoints from a configurable base URL", async () => {
+    process.env.OLLAMA_API_KEY = "test-key";
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ results: [] }), { status: 200 }),
+      );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await ollamaAdapter.search(
+      "test",
+      5,
+      {
+        apiKey: "OLLAMA_API_KEY",
+        baseUrl: "https://ollama-proxy.test/api/",
+      },
+      { cwd: process.cwd() },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://ollama-proxy.test/api/web_search",
+      expect.any(Object),
+    );
+  });
+
+  it("handles failed fetch requests per URL", async () => {
+    process.env.OLLAMA_API_KEY = "test-key";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: "invalid key" }), {
+        status: 401,
+        statusText: "Unauthorized",
+      }),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const response = await ollamaAdapter.contents(
+      ["https://ollama.com"],
+      {
+        apiKey: "OLLAMA_API_KEY",
+      },
+      { cwd: process.cwd() },
+    );
+
+    expect(response).toEqual({
+      provider: "ollama",
+      answers: [
+        {
+          url: "https://ollama.com",
+          error: "Ollama API request failed (401 Unauthorized): invalid key",
+        },
+      ],
+    });
+  });
+
+  it("surfaces Ollama HTTP errors with response details", async () => {
+    process.env.OLLAMA_API_KEY = "test-key";
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: "invalid key" }), {
+        status: 401,
+        statusText: "Unauthorized",
+      }),
+    ) as typeof fetch;
+
+    await expect(
+      ollamaAdapter.search(
+        "test",
+        5,
+        {
+          apiKey: "OLLAMA_API_KEY",
+        },
+        { cwd: process.cwd() },
+      ),
+    ).rejects.toThrow(
+      /Ollama API request failed \(401 Unauthorized\): invalid key/,
+    );
+  });
+
+  it("requires an API key", async () => {
+    await expect(
+      ollamaAdapter.search(
+        "test",
+        5,
+        {
+          apiKey: "OLLAMA_API_KEY",
+        },
+        { cwd: process.cwd() },
+      ),
+    ).rejects.toThrow(/missing an API key/);
+  });
+
+  it("reports missing_api_key when the configured API key does not resolve", () => {
+    expect(
+      ollamaAdapter.getCapabilityStatus(
+        {
+          apiKey: "OLLAMA_API_KEY",
+        },
+        process.cwd(),
+      ),
+    ).toEqual({ state: "missing_api_key" });
+  });
+
+  it("reports ready when the configured API key resolves", () => {
+    process.env.OLLAMA_API_KEY = "test-key";
+
+    expect(
+      ollamaAdapter.getCapabilityStatus(
+        {
+          apiKey: "OLLAMA_API_KEY",
+        },
+        process.cwd(),
+      ),
+    ).toEqual({ state: "ready" });
+  });
+
+  it("supports search and contents tools", () => {
+    expect(typeof ollamaAdapter.search).toBe("function");
+    expect(typeof ollamaAdapter.contents).toBe("function");
+    expect(ollamaAdapter.answer).toBeUndefined();
+    expect(ollamaAdapter.research).toBeUndefined();
+  });
+});
+
+describe("Ollama config", () => {
+  it("parses Ollama provider config", () => {
+    const parsed = parseConfig(
+      JSON.stringify({
+        providers: {
+          ollama: {
+            apiKey: "OLLAMA_API_KEY",
+            baseUrl: "https://ollama-proxy.test",
+            options: {
+              search: {
+                locale: "en-US",
+              },
+              fetch: {
+                format: "markdown",
+              },
+            },
+            settings: {
+              requestTimeoutMs: 45000,
+            },
+          },
+        },
+      }),
+      "test-config.json",
+    );
+
+    expect(parsed.providers?.ollama).toEqual({
+      apiKey: "OLLAMA_API_KEY",
+      baseUrl: "https://ollama-proxy.test",
+      options: {
+        search: {
+          locale: "en-US",
+        },
+        fetch: {
+          format: "markdown",
+        },
+      },
+      settings: {
+        requestTimeoutMs: 45000,
+      },
+    });
+  });
+
+  it("rejects unsupported flat Ollama provider options", () => {
+    expect(() =>
+      parseConfig(
+        JSON.stringify({
+          providers: {
+            ollama: {
+              apiKey: "OLLAMA_API_KEY",
+              options: {
+                locale: "en-US",
+              },
+            },
+          },
+        }),
+        "test-config.json",
+      ),
+    ).toThrow(/providers\.ollama\.options/);
+  });
+
+  it("creates an Ollama provider template", () => {
+    expect(ollamaAdapter.createTemplate()).toEqual({
+      apiKey: "OLLAMA_API_KEY",
+    });
+  });
+
+  it("exposes Ollama API key and base URL settings", () => {
+    const manifest = getProviderConfigManifest("ollama");
+    const ids = manifest.settings.map((setting) => setting.id);
+
+    expect(ids).toEqual(["apiKey", "baseUrl"]);
+  });
+
+  it("round-trips Ollama API key and base URL settings", () => {
+    const manifest = getProviderConfigManifest("ollama");
+    const apiKeySetting = manifest.settings.find(
+      (setting) => setting.id === "apiKey",
+    );
+    const baseUrlSetting = manifest.settings.find(
+      (setting) => setting.id === "baseUrl",
+    );
+
+    if (
+      !apiKeySetting ||
+      apiKeySetting.kind !== "text" ||
+      !baseUrlSetting ||
+      baseUrlSetting.kind !== "text"
+    ) {
+      throw new Error("Missing Ollama settings.");
+    }
+
+    const config: Ollama = {};
+    (apiKeySetting as ProviderTextSettingDescriptor<Ollama>).setValue(
+      config,
+      "OLLAMA_API_KEY",
+    );
+    (baseUrlSetting as ProviderTextSettingDescriptor<Ollama>).setValue(
+      config,
+      "https://ollama-proxy.test",
+    );
+
+    expect(config).toEqual({
+      apiKey: "OLLAMA_API_KEY",
+      baseUrl: "https://ollama-proxy.test",
+    });
+  });
+});

--- a/test/tool-availability.test.ts
+++ b/test/tool-availability.test.ts
@@ -34,6 +34,7 @@ beforeEach(() => {
   delete process.env.PERPLEXITY_API_KEY;
   delete process.env.GOOGLE_API_KEY;
   delete process.env.LINKUP_API_KEY;
+  delete process.env.OLLAMA_API_KEY;
   delete process.env.OPENAI_API_KEY;
   delete process.env.PARALLEL_API_KEY;
   delete process.env.SERPER_API_KEY;
@@ -46,6 +47,7 @@ afterEach(() => {
   delete process.env.CODEX_API_KEY;
   delete process.env.PERPLEXITY_API_KEY;
   delete process.env.LINKUP_API_KEY;
+  delete process.env.OLLAMA_API_KEY;
   delete process.env.OPENAI_API_KEY;
   delete process.env.SERPER_API_KEY;
   delete process.env.TAVILY_API_KEY;


### PR DESCRIPTION
Implements Ollama as a new provider supporting:
- web_search via POST /api/web_search
- web_contents via POST /api/web_fetch

Uses native fetch against the Ollama REST API (no SDK dependency). API key resolved from OLLAMA_API_KEY env var or config via resolveConfigValue. Follows current ProviderAdapter pattern with buildProviderPlan framework.