### PR TITLE
Expand Serper search modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ call.
 - Exposes search options `mode`, `gl`, `hl`, `location`, `page`, `tbs`,
   `autocorrect`, and mode-specific fields such as `url`, `ll`, `placeId`,
   `cid`, `fid`, `productId`, `nextPageToken`, and webpage include flags.
+  Reviews mode uses the top-level query when no place identifier is provided.
   `includeMarkdown` defaults to `true` for webpage scraping
 - Preserves rich metadata from Serper responses, including ranking position,
   sitelinks, attributes, and top-level response context such as

--- a/README.md
+++ b/README.md
@@ -465,9 +465,14 @@ call.
 <summary><strong>Serper</strong></summary>
 
 - API: Serper HTTP API
-- Supports `web_search` via Serper's Google search endpoint
-- Good fit for fast, straightforward Google-style organic search results
-- Exposes search options `gl`, `hl`, `location`, `page`, and `autocorrect`
+- Supports `web_search` via Serper's Google endpoints for web, image, video,
+  places, maps, reviews, news, shopping, product reviews, Lens, Scholar,
+  patents, autocomplete, and webpage results
+- Good fit for fast, straightforward Google-style search results
+- Exposes search options `mode`, `gl`, `hl`, `location`, `page`, `tbs`,
+  `autocorrect`, and mode-specific fields such as `url`, `ll`, `placeId`,
+  `cid`, `fid`, `productId`, `nextPageToken`, and webpage include flags.
+  `includeMarkdown` defaults to `true` for webpage scraping
 - Preserves rich metadata from Serper responses, including ranking position,
   sitelinks, attributes, and top-level response context such as
   `knowledgeGraph`, `answerBox`, `peopleAlsoAsk`, and `relatedSearches`

--- a/changelog/unreleased/serper-vertical-search-modes.md
+++ b/changelog/unreleased/serper-vertical-search-modes.md
@@ -1,0 +1,22 @@
+---
+title: Serper vertical search modes
+type: feature
+authors:
+  - mavam
+  - codex
+pr: 19
+created: 2026-04-30T06:31:19.47589Z
+---
+
+Serper-backed `web_search` now supports Serper's vertical modes and webpage scraping through the `mode` option:
+
+```json
+{
+  "mode": "news",
+  "gl": "us",
+  "hl": "en",
+  "tbs": "qdr:d"
+}
+```
+
+Use modes such as `images`, `videos`, `maps`, `reviews`, `shopping`, `scholar`, `patents`, `autocomplete`, `lens`, and `webpage` to route a search to the matching Serper endpoint. Webpage scraping includes Markdown by default, making scraped pages easier for agents to consume.

--- a/src/providers/serper.ts
+++ b/src/providers/serper.ts
@@ -4,16 +4,111 @@ import type {
   ProviderCapabilityStatus,
   ProviderContext,
   SearchResponse,
+  SearchResult,
   Serper,
+  SerperSearchMode,
   Tool,
 } from "../types.js";
+import { SERPER_SEARCH_MODE_VALUES } from "../types.js";
 import { defineCapability, defineProvider } from "./definition.js";
 import { asJsonObject, getApiKeyStatus, trimSnippet } from "./shared.js";
 
 const DEFAULT_BASE_URL = "https://google.serper.dev";
+const DEFAULT_SCRAPE_URL = "https://scrape.serper.dev";
+
+type SerperRequestOptions = {
+  mode: SerperSearchMode;
+  gl?: string;
+  hl?: string;
+  location?: string;
+  page?: number;
+  tbs?: string;
+  autocorrect?: boolean;
+  url?: string;
+  ll?: string;
+  placeId?: string;
+  cid?: string;
+  fid?: string;
+  sortBy?: string;
+  topicId?: string;
+  productId?: string;
+  nextPageToken?: string;
+  includeMarkdown?: boolean;
+  includeImages?: boolean;
+  includeLinks?: boolean;
+  includeVideos?: boolean;
+  extra: Record<string, unknown>;
+};
+
+const SERPER_SEARCH_MODES = Object.values(SERPER_SEARCH_MODE_VALUES);
+const SERPER_SEARCH_MODE_SET = new Set<string>(SERPER_SEARCH_MODES);
+
+const RESERVED_REQUEST_OPTION_KEYS = [
+  "q",
+  "num",
+  "mode",
+  "url",
+  "productId",
+  "nextPageToken",
+  "ll",
+  "placeId",
+  "cid",
+  "fid",
+  "sortBy",
+  "topicId",
+  "includeMarkdown",
+  "includeImages",
+  "includeLinks",
+  "includeVideos",
+  "location",
+  "gl",
+  "hl",
+  "tbs",
+  "page",
+  "autocorrect",
+] as const;
+
+const PRIMARY_RESULT_FIELDS_BY_MODE = {
+  search: ["organic"],
+  images: ["images"],
+  videos: ["videos"],
+  places: ["places"],
+  maps: ["maps", "places"],
+  reviews: ["reviews"],
+  news: ["news"],
+  shopping: ["shopping"],
+  "product-reviews": ["reviews", "productReviews"],
+  lens: ["visualMatches", "organic", "images"],
+  scholar: ["organic"],
+  patents: ["organic"],
+  autocomplete: ["suggestions"],
+  webpage: [],
+} as const satisfies Record<SerperSearchMode, readonly string[]>;
+
+const CONTEXT_ARRAY_FIELDS = [
+  "peopleAlsoAsk",
+  "relatedSearches",
+  "topStories",
+  "news",
+  "images",
+  "videos",
+  "places",
+  "maps",
+  "shopping",
+  "reviews",
+  "productReviews",
+  "visualMatches",
+  "suggestions",
+] as const;
 
 const serperSearchOptionsSchema = Type.Object(
   {
+    mode: Type.Optional(
+      Type.Enum(SERPER_SEARCH_MODE_VALUES, {
+        description:
+          "Serper search type. Use 'search' for web results, 'news' for recent journalism/current events, 'images' for visual references, 'videos' for clips/tutorials, 'places' or 'maps' for local businesses/venues, 'reviews' for Google business reviews, 'shopping' for products, 'product-reviews' for product reviews, 'lens' for reverse image search, 'scholar' for scholarly articles, 'patents' for patents, 'autocomplete' for suggestions, and 'webpage' to scrape a URL.",
+      }),
+    ),
     gl: Type.Optional(
       Type.String({
         description: "Country code hint for Google results (for example 'us').",
@@ -36,10 +131,68 @@ const serperSearchOptionsSchema = Type.Object(
         description: "1-based results page to request from Serper.",
       }),
     ),
+    tbs: Type.Optional(
+      Type.String({
+        description:
+          "Google time/date or vertical-specific filter string passed through to Serper, for example 'qdr:d' for past day.",
+      }),
+    ),
     autocorrect: Type.Optional(
       Type.Boolean({
         description: "Enable or disable Serper query autocorrection.",
       }),
+    ),
+    url: Type.Optional(
+      Type.String({
+        description:
+          "URL for modes that need one: image URL for 'lens', or page URL for 'webpage'. Defaults to the query string when omitted.",
+      }),
+    ),
+    ll: Type.Optional(
+      Type.String({
+        description:
+          "Google Maps latitude/longitude/zoom hint, for example '@40.6973709,-74.1444871,11z'.",
+      }),
+    ),
+    placeId: Type.Optional(
+      Type.String({ description: "Google place ID for maps or reviews." }),
+    ),
+    cid: Type.Optional(
+      Type.String({ description: "Google CID for maps or reviews." }),
+    ),
+    fid: Type.Optional(Type.String({ description: "Google FID for reviews." })),
+    sortBy: Type.Optional(
+      Type.String({ description: "Review sort order for reviews mode." }),
+    ),
+    topicId: Type.Optional(
+      Type.String({ description: "Review topic ID for reviews mode." }),
+    ),
+    productId: Type.Optional(
+      Type.String({
+        description:
+          "Google product ID for product-reviews mode. Defaults to the query string when omitted.",
+      }),
+    ),
+    nextPageToken: Type.Optional(
+      Type.String({
+        description: "Pagination token for reviews or product-reviews modes.",
+      }),
+    ),
+    includeMarkdown: Type.Optional(
+      Type.Boolean({
+        default: true,
+        description:
+          "Include Markdown content in webpage mode. Defaults to true.",
+      }),
+    ),
+    includeImages: Type.Optional(
+      Type.Boolean({ description: "Include image metadata in webpage mode." }),
+    ),
+    includeLinks: Type.Optional(
+      Type.Boolean({ description: "Include link metadata in webpage mode." }),
+    ),
+    includeVideos: Type.Optional(
+      Type.Boolean({ description: "Include video metadata in webpage mode." }),
     ),
   },
   { description: "Serper search options." },
@@ -62,7 +215,11 @@ const serperImplementation = {
   createTemplate(): Serper {
     return {
       credentials: { api: "SERPER_API_KEY" },
-      options: {},
+      options: {
+        search: {
+          includeMarkdown: true,
+        },
+      },
     };
   },
 
@@ -82,44 +239,53 @@ const serperImplementation = {
       throw new Error("is missing an API key");
     }
 
-    const defaults = asJsonObject(config.options?.search) ?? {};
+    const defaults = asJsonObject(config.options?.search);
     const callOptions = asJsonObject(options);
-    const {
-      q: _ignoredQuery,
-      num: _ignoredNum,
-      ...providerOptions
-    } = {
+    const requestOptions = readRequestOptions({
       ...defaults,
-      ...(callOptions ?? {}),
-    };
-
-    const response = await fetch(joinUrl(resolveConfigValue(config.baseUrl)), {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-api-key": apiKey,
-      },
-      body: JSON.stringify({
-        q: query,
-        num: clampMaxResults(maxResults),
-        ...providerOptions,
-      }),
-      signal: context.signal,
+      ...callOptions,
     });
+    const requestBody = buildRequestBody(
+      query,
+      clampMaxResults(maxResults),
+      requestOptions,
+    );
+
+    const response = await fetch(
+      joinUrl(resolveConfigValue(config.baseUrl), requestOptions.mode),
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": apiKey,
+        },
+        body: JSON.stringify(requestBody),
+        signal: context.signal,
+      },
+    );
 
     if (!response.ok) {
       throw new Error(await buildHttpError(response));
     }
 
     const payload = (await response.json()) as unknown;
-    const responseRecord = asRecord(payload) ?? {};
-    const organic = asArray(responseRecord.organic) ?? [];
-    const searchContext = buildSearchContext(responseRecord);
+    const responseRecord = enrichResponseRecord(
+      asRecord(payload) ?? {},
+      requestOptions.mode,
+      requestBody,
+    );
+    const results = readPrimaryResults(responseRecord, requestOptions.mode);
+    const searchContext = buildSearchContext(
+      responseRecord,
+      requestOptions.mode,
+    );
 
     return {
       provider: serperImplementation.id,
-      results: organic
-        .map((entry) => toSearchResult(entry, searchContext))
+      results: results
+        .map((entry) =>
+          toSearchResult(entry, searchContext, requestOptions.mode),
+        )
         .filter(
           (result): result is NonNullable<typeof result> => result !== null,
         )
@@ -128,9 +294,181 @@ const serperImplementation = {
   },
 };
 
-function joinUrl(baseUrl: string | undefined): string {
+function joinUrl(
+  baseUrl: string | undefined,
+  mode: SerperSearchMode = "search",
+): string {
   const base = (baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
-  return `${base}/search`;
+  if (mode === "webpage" && base === DEFAULT_BASE_URL) {
+    return DEFAULT_SCRAPE_URL;
+  }
+  return `${base}/${mode}`;
+}
+
+function readRequestOptions(
+  options: Record<string, unknown>,
+): SerperRequestOptions {
+  const result: SerperRequestOptions = {
+    mode: readSearchMode(options.mode),
+    extra: extractExtraMetadata(options, RESERVED_REQUEST_OPTION_KEYS),
+  };
+
+  copyStringOption(result, "gl", options.gl);
+  copyStringOption(result, "hl", options.hl);
+  copyStringOption(result, "location", options.location);
+  copyStringOption(result, "tbs", options.tbs);
+  copyStringOption(result, "url", options.url);
+  copyStringOption(result, "ll", options.ll);
+  copyStringOption(result, "placeId", options.placeId);
+  copyStringOption(result, "cid", options.cid);
+  copyStringOption(result, "fid", options.fid);
+  copyStringOption(result, "sortBy", options.sortBy);
+  copyStringOption(result, "topicId", options.topicId);
+  copyStringOption(result, "productId", options.productId);
+  copyStringOption(result, "nextPageToken", options.nextPageToken);
+  copyBooleanOption(result, "autocorrect", options.autocorrect);
+  copyBooleanOption(result, "includeMarkdown", options.includeMarkdown);
+  copyBooleanOption(result, "includeImages", options.includeImages);
+  copyBooleanOption(result, "includeLinks", options.includeLinks);
+  copyBooleanOption(result, "includeVideos", options.includeVideos);
+
+  const page = readInteger(options.page);
+  if (page !== undefined) {
+    result.page = Math.max(1, page);
+  }
+
+  return result;
+}
+
+function buildRequestBody(
+  query: string,
+  maxResults: number,
+  options: SerperRequestOptions,
+): Record<string, unknown> {
+  const common = omitUndefined({
+    location: options.location,
+    gl: options.gl,
+    hl: options.hl,
+  });
+  const withExtra = (body: Record<string, unknown>) => ({
+    ...body,
+    ...options.extra,
+  });
+
+  switch (options.mode) {
+    case "webpage":
+      return withExtra(
+        omitUndefined({
+          url: options.url ?? query,
+          includeMarkdown: options.includeMarkdown ?? true,
+          includeImages: options.includeImages,
+          includeLinks: options.includeLinks,
+          includeVideos: options.includeVideos,
+        }),
+      );
+    case "product-reviews":
+      return withExtra(
+        omitUndefined({
+          productId: options.productId ?? query,
+          nextPageToken: options.nextPageToken,
+          ...common,
+          num: maxResults,
+        }),
+      );
+    case "autocomplete":
+      return withExtra({ q: query, ...common });
+    case "maps":
+      return withExtra(
+        omitUndefined({
+          q: query,
+          num: maxResults,
+          ...common,
+          ll: options.ll,
+          placeId: options.placeId,
+          cid: options.cid,
+          page: options.page,
+        }),
+      );
+    case "reviews":
+      return withExtra(
+        omitUndefined({
+          cid: options.cid,
+          fid: options.fid,
+          placeId: options.placeId,
+          gl: options.gl,
+          hl: options.hl,
+          sortBy: options.sortBy,
+          topicId: options.topicId,
+          nextPageToken: options.nextPageToken,
+        }),
+      );
+    case "lens":
+      return withExtra(
+        omitUndefined({
+          url: options.url ?? query,
+          ...common,
+          tbs: options.tbs,
+        }),
+      );
+    case "scholar":
+      return withExtra(
+        omitUndefined({
+          q: query,
+          ...common,
+          autocorrect: options.autocorrect,
+          tbs: options.tbs,
+          page: options.page,
+        }),
+      );
+    default:
+      return withExtra(
+        omitUndefined({
+          q: query,
+          num: maxResults,
+          ...common,
+          autocorrect: options.autocorrect,
+          tbs: options.tbs,
+          page: options.page,
+        }),
+      );
+  }
+}
+
+function enrichResponseRecord(
+  response: Record<string, unknown>,
+  mode: SerperSearchMode,
+  requestBody: Record<string, unknown>,
+): Record<string, unknown> {
+  if (mode !== "webpage") {
+    return response;
+  }
+  return omitUndefined({
+    ...response,
+    url: readString(response.url) ?? readString(requestBody.url),
+  });
+}
+
+function readSearchMode(value: unknown): SerperSearchMode {
+  return typeof value === "string" && SERPER_SEARCH_MODE_SET.has(value)
+    ? (value as SerperSearchMode)
+    : "search";
+}
+
+function readPrimaryResults(
+  response: Record<string, unknown>,
+  mode: SerperSearchMode,
+): unknown[] {
+  if (mode === "webpage") {
+    return [response];
+  }
+
+  for (const field of PRIMARY_RESULT_FIELDS_BY_MODE[mode]) {
+    const values = asArray(response[field]);
+    if (values) {
+      return values;
+    }
+  }
+  return [];
 }
 
 function clampMaxResults(value: number): number {
@@ -172,23 +510,57 @@ async function readErrorDetail(
 function toSearchResult(
   entry: unknown,
   searchContext: Record<string, unknown> | undefined,
-) {
+  mode: SerperSearchMode,
+): SearchResult | null {
+  if (typeof entry === "string") {
+    return {
+      title: entry,
+      url: "",
+      snippet: entry,
+      metadata: {
+        source: mode,
+        ...(searchContext ? { searchContext } : {}),
+      },
+    };
+  }
+
   const record = asRecord(entry);
   if (!record) {
     return null;
   }
 
-  const url = readString(record.link) ?? "";
-  const title = readString(record.title) || url || "Untitled";
+  const responseMetadata = asRecord(record.metadata);
+  const user = asRecord(record.user);
+  const url =
+    firstString(record.link, record.website, record.url, record.imageUrl) ?? "";
+  const title =
+    firstNonEmptyString(
+      record.title,
+      responseMetadata?.title,
+      record.name,
+      record.query,
+      record.value,
+      user?.name,
+      formatReviewTitle(record, user),
+      url,
+    ) ?? "Untitled";
   const snippet = trimSnippet(
-    readString(record.snippet) ??
-      readString(record.richSnippet) ??
-      readString(record.date) ??
-      "",
+    firstNonEmptyString(
+      record.snippet,
+      record.richSnippet,
+      record.markdown,
+      record.text,
+      record.address,
+      record.price,
+      record.date,
+      record.name,
+      record.value,
+      record.url,
+    ) ?? "",
   );
 
   const metadata = omitUndefined({
-    source: "organic",
+    source: readString(record.source) ?? (mode === "search" ? "organic" : mode),
     position: readNumber(record.position),
     date: readString(record.date),
     attributes: asRecord(record.attributes),
@@ -196,7 +568,16 @@ function toSearchResult(
     rating: readNumber(record.rating),
     ratingCount: readNumber(record.ratingCount),
     cid: readString(record.cid),
-    ...extractExtraMetadata(record, ["title", "link", "snippet"]),
+    ...extractExtraMetadata(record, [
+      "title",
+      "name",
+      "query",
+      "value",
+      "link",
+      "website",
+      "url",
+      "snippet",
+    ]),
     ...(searchContext ? { searchContext } : {}),
   });
 
@@ -210,6 +591,7 @@ function toSearchResult(
 
 function buildSearchContext(
   response: Record<string, unknown>,
+  mode: SerperSearchMode,
 ): Record<string, unknown> | undefined {
   const context = omitUndefined({
     searchParameters: asRecord(response.searchParameters),
@@ -217,21 +599,107 @@ function buildSearchContext(
     credits: readNumber(response.credits),
     answerBox: asRecord(response.answerBox),
     knowledgeGraph: asRecord(response.knowledgeGraph),
-    peopleAlsoAsk: asArray(response.peopleAlsoAsk),
-    relatedSearches: asArray(response.relatedSearches),
-    topStories: asArray(response.topStories),
-    news: asArray(response.news),
-    images: asArray(response.images),
-    videos: asArray(response.videos),
-    places: asArray(response.places),
   });
+  const primaryResultFields = new Set<string>(
+    PRIMARY_RESULT_FIELDS_BY_MODE[mode],
+  );
+
+  for (const field of CONTEXT_ARRAY_FIELDS) {
+    if (primaryResultFields.has(field)) {
+      continue;
+    }
+    const value = asArray(response[field]);
+    if (value) {
+      context[field] = value;
+    }
+  }
 
   return Object.keys(context).length > 0 ? context : undefined;
 }
 
+function copyStringOption(
+  target: SerperRequestOptions,
+  key: keyof Pick<
+    SerperRequestOptions,
+    | "gl"
+    | "hl"
+    | "location"
+    | "tbs"
+    | "url"
+    | "ll"
+    | "placeId"
+    | "cid"
+    | "fid"
+    | "sortBy"
+    | "topicId"
+    | "productId"
+    | "nextPageToken"
+  >,
+  value: unknown,
+): void {
+  const text = readString(value);
+  if (text !== undefined) {
+    target[key] = text;
+  }
+}
+
+function copyBooleanOption(
+  target: SerperRequestOptions,
+  key: keyof Pick<
+    SerperRequestOptions,
+    | "autocorrect"
+    | "includeMarkdown"
+    | "includeImages"
+    | "includeLinks"
+    | "includeVideos"
+  >,
+  value: unknown,
+): void {
+  const flag = readBoolean(value);
+  if (flag !== undefined) {
+    target[key] = flag;
+  }
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  return values.find((value): value is string => typeof value === "string");
+}
+
+function formatReviewTitle(
+  record: Record<string, unknown>,
+  user: Record<string, unknown> | undefined,
+): string | undefined {
+  const userName = readString(user?.name);
+  const rating = readNumber(record.rating);
+  const date = readString(record.date) ?? readString(record.isoDate);
+
+  if (userName && rating !== undefined) {
+    return `${userName} (${rating}-star review)`;
+  }
+  if (userName) {
+    return `${userName}'s review`;
+  }
+  if (rating !== undefined && date) {
+    return `${rating}-star review from ${date}`;
+  }
+  if (rating !== undefined) {
+    return `${rating}-star review`;
+  }
+  if (date) {
+    return `Review from ${date}`;
+  }
+  return undefined;
+}
+
+function firstNonEmptyString(...values: unknown[]): string | undefined {
+  return values.find(
+    (value): value is string => typeof value === "string" && value.length > 0,
+  );
+}
+
 function extractExtraMetadata(
   record: Record<string, unknown>,
-  ignoredKeys: string[],
+  ignoredKeys: readonly string[],
 ): Record<string, unknown> {
   return Object.fromEntries(
     Object.entries(record).filter(
@@ -240,10 +708,12 @@ function extractExtraMetadata(
   );
 }
 
-function omitUndefined<T extends Record<string, unknown>>(value: T): T {
+function omitUndefined(
+  value: Record<string, unknown>,
+): Record<string, unknown> {
   return Object.fromEntries(
     Object.entries(value).filter(([, entry]) => entry !== undefined),
-  ) as T;
+  );
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
@@ -264,6 +734,16 @@ function readNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value)
     ? value
     : undefined;
+}
+
+function readInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value)
+    ? value
+    : undefined;
+}
+
+function readBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
 }
 
 export const serperProvider = defineProvider({

--- a/src/providers/serper.ts
+++ b/src/providers/serper.ts
@@ -101,6 +101,17 @@ const CONTEXT_ARRAY_FIELDS = [
   "suggestions",
 ] as const;
 
+const serperSearchPromptGuidelines = [
+  "Use Serper news mode for recent journalism, current events, announcements, or time-sensitive reporting.",
+  "Use Serper images or videos mode when the user asks for visual references, screenshots, diagrams, clips, tutorials, or media results.",
+  "Use Serper places or maps mode for local businesses, venues, addresses, ratings, phone numbers, opening details, or nearby/in-location searches.",
+  "Use Serper reviews mode when the task needs Google business reviews. Prefer cid, fid, or placeId from a maps or places result when available; otherwise use the search query as the place identifier.",
+  "Use Serper shopping mode for product listings, prices, merchants, offers, or purchase comparisons, and use product-reviews mode when the task needs reviews for a known product ID.",
+  "Use Serper scholar mode for academic papers and patents mode for patent searches.",
+  "Use Serper autocomplete mode when the task is to discover search suggestions or query completions rather than source pages.",
+  "Use Serper lens mode for reverse image search with an image URL, and use webpage mode to scrape a specific URL. Webpage mode includes Markdown by default.",
+] as const;
+
 const serperSearchOptionsSchema = Type.Object(
   {
     mode: Type.Optional(
@@ -775,6 +786,7 @@ export const serperProvider = defineProvider({
   capabilities: {
     search: defineCapability({
       options: serperImplementation.getToolOptionsSchema?.("search"),
+      promptGuidelines: serperSearchPromptGuidelines,
       async execute(input: any, ctx) {
         const { query, maxResults, options } = input;
         return await serperImplementation.search!(

--- a/src/providers/serper.ts
+++ b/src/providers/serper.ts
@@ -106,7 +106,7 @@ const serperSearchOptionsSchema = Type.Object(
     mode: Type.Optional(
       Type.Enum(SERPER_SEARCH_MODE_VALUES, {
         description:
-          "Serper search type. Use 'search' for web results, 'news' for recent journalism/current events, 'images' for visual references, 'videos' for clips/tutorials, 'places' or 'maps' for local businesses/venues, 'reviews' for Google business reviews, 'shopping' for products, 'product-reviews' for product reviews, 'lens' for reverse image search, 'scholar' for scholarly articles, 'patents' for patents, 'autocomplete' for suggestions, and 'webpage' to scrape a URL.",
+          "Serper search type. Use 'search' for web results, 'news' for recent journalism/current events, 'images' for visual references, 'videos' for clips/tutorials, 'places' or 'maps' for local businesses/venues, 'reviews' for Google business reviews by place ID/CID/FID or query, 'shopping' for products, 'product-reviews' for product reviews, 'lens' for reverse image search, 'scholar' for scholarly articles, 'patents' for patents, 'autocomplete' for suggestions, and 'webpage' to scrape a URL.",
       }),
     ),
     gl: Type.Optional(
@@ -389,9 +389,13 @@ function buildRequestBody(
           page: options.page,
         }),
       );
-    case "reviews":
+    case "reviews": {
+      const hasExplicitPlaceIdentifier =
+        firstNonEmptyString(options.cid, options.fid, options.placeId) !==
+        undefined;
       return withExtra(
         omitUndefined({
+          q: hasExplicitPlaceIdentifier ? undefined : query,
           cid: options.cid,
           fid: options.fid,
           placeId: options.placeId,
@@ -402,6 +406,7 @@ function buildRequestBody(
           nextPageToken: options.nextPageToken,
         }),
       );
+    }
     case "lens":
       return withExtra(
         omitUndefined({
@@ -515,7 +520,7 @@ function toSearchResult(
   if (typeof entry === "string") {
     return {
       title: entry,
-      url: "",
+      url: mode === "autocomplete" ? toGoogleSearchUrl(entry) : "",
       snippet: entry,
       metadata: {
         source: mode,
@@ -531,7 +536,7 @@ function toSearchResult(
 
   const responseMetadata = asRecord(record.metadata);
   const user = asRecord(record.user);
-  const url =
+  const resultUrl =
     firstString(record.link, record.website, record.url, record.imageUrl) ?? "";
   const title =
     firstNonEmptyString(
@@ -542,8 +547,10 @@ function toSearchResult(
       record.value,
       user?.name,
       formatReviewTitle(record, user),
-      url,
+      resultUrl,
     ) ?? "Untitled";
+  const url =
+    resultUrl || (mode === "autocomplete" ? toGoogleSearchUrl(title) : "");
   const snippet = trimSnippet(
     firstNonEmptyString(
       record.snippet,
@@ -663,6 +670,10 @@ function copyBooleanOption(
 
 function firstString(...values: unknown[]): string | undefined {
   return values.find((value): value is string => typeof value === "string");
+}
+
+function toGoogleSearchUrl(query: string): string {
+  return `https://www.google.com/search?q=${encodeURIComponent(query)}`;
 }
 
 function formatReviewTitle(

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,8 +170,52 @@ export interface TavilyOptions {
   extract?: Record<string, unknown>;
 }
 
+export const SERPER_SEARCH_MODE_VALUES = {
+  search: "search",
+  images: "images",
+  videos: "videos",
+  places: "places",
+  maps: "maps",
+  reviews: "reviews",
+  news: "news",
+  shopping: "shopping",
+  productReviews: "product-reviews",
+  lens: "lens",
+  scholar: "scholar",
+  patents: "patents",
+  autocomplete: "autocomplete",
+  webpage: "webpage",
+} as const;
+
+export type SerperSearchMode =
+  (typeof SERPER_SEARCH_MODE_VALUES)[keyof typeof SERPER_SEARCH_MODE_VALUES];
+
+export interface SerperSearchOptions {
+  mode?: SerperSearchMode;
+  gl?: string;
+  hl?: string;
+  location?: string;
+  page?: number;
+  tbs?: string;
+  autocorrect?: boolean;
+  url?: string;
+  ll?: string;
+  placeId?: string;
+  cid?: string;
+  fid?: string;
+  sortBy?: string;
+  topicId?: string;
+  productId?: string;
+  nextPageToken?: string;
+  includeMarkdown?: boolean;
+  includeImages?: boolean;
+  includeLinks?: boolean;
+  includeVideos?: boolean;
+  [key: string]: unknown;
+}
+
 export interface SerperOptions {
-  search?: Record<string, unknown>;
+  search?: SerperSearchOptions;
 }
 
 export interface ValyuOptions {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -675,7 +675,11 @@ describe("config parsing", () => {
     });
     expect(PROVIDERS_BY_ID.serper.config.createTemplate()).toEqual({
       credentials: { api: "SERPER_API_KEY" },
-      options: {},
+      options: {
+        search: {
+          includeMarkdown: true,
+        },
+      },
     });
     expect(PROVIDERS_BY_ID.tavily.config.createTemplate().options).toEqual({
       search: {

--- a/test/serper-provider.test.ts
+++ b/test/serper-provider.test.ts
@@ -92,10 +92,10 @@ describe("providerHarness(serperProvider)", () => {
         body: JSON.stringify({
           q: "serper api",
           num: 20,
-          gl: "de",
-          autocorrect: false,
-          hl: "en",
           location: "Berlin, Berlin, Germany",
+          gl: "de",
+          hl: "en",
+          autocorrect: false,
         }),
         signal: undefined,
       },
@@ -147,6 +147,283 @@ describe("providerHarness(serperProvider)", () => {
         },
       ],
     });
+  });
+
+  it("drops invalid Serper option types before sending requests", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ organic: [] }), { status: 200 }),
+      );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await providerHarness(serperProvider).search(
+      "serper api",
+      3,
+      {
+        credentials: { api: "literal-key" },
+        options: {
+          search: {
+            gl: 123,
+            page: "2",
+            autocorrect: "false",
+            customOption: "preserved",
+          },
+        },
+      },
+      { cwd: process.cwd() },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith("https://google.serper.dev/search", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": "literal-key",
+      },
+      body: JSON.stringify({
+        q: "serper api",
+        num: 3,
+        customOption: "preserved",
+      }),
+      signal: undefined,
+    });
+  });
+
+  it("queries Serper vertical endpoints with structured mode options", async () => {
+    process.env.SERPER_API_KEY = "test-key";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          videos: [
+            {
+              title: "SpaceX Falcon 9 Launches Starlink 6-55",
+              link: "https://www.youtube.com/watch?v=2ag4dKkL-pM",
+              snippet: "SpaceX launch of Starlink satellites",
+              imageUrl: "https://i.ytimg.com/vi/2ag4dKkL-pM/mqdefault.jpg",
+              duration: "2:22:33",
+              source: "YouTube",
+              channel: "NASASpaceflight",
+              date: "1 day ago",
+              position: 1,
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const response = await providerHarness(serperProvider).search(
+      "falcon 9 launch",
+      5,
+      {
+        credentials: { api: "SERPER_API_KEY" },
+        baseUrl: "https://google.serper.test",
+      },
+      { cwd: process.cwd() },
+      {
+        mode: "videos",
+        gl: "us",
+        hl: "en",
+        tbs: "qdr:d",
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://google.serper.test/videos",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": "test-key",
+        },
+        body: JSON.stringify({
+          q: "falcon 9 launch",
+          num: 5,
+          gl: "us",
+          hl: "en",
+          tbs: "qdr:d",
+        }),
+        signal: undefined,
+      },
+    );
+    expect(response.results).toEqual([
+      {
+        title: "SpaceX Falcon 9 Launches Starlink 6-55",
+        url: "https://www.youtube.com/watch?v=2ag4dKkL-pM",
+        snippet: "SpaceX launch of Starlink satellites",
+        metadata: {
+          source: "YouTube",
+          position: 1,
+          date: "1 day ago",
+          imageUrl: "https://i.ytimg.com/vi/2ag4dKkL-pM/mqdefault.jpg",
+          duration: "2:22:33",
+          channel: "NASASpaceflight",
+        },
+      },
+    ]);
+  });
+
+  it("shapes Serper webpage requests and maps the scraped page", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          text: "Example Domain",
+          markdown: "# Example Domain",
+          metadata: { title: "Example Domain" },
+          credits: 2,
+        }),
+        { status: 200 },
+      ),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const response = await providerHarness(serperProvider).search(
+      "https://example.com",
+      1,
+      {
+        credentials: { api: "literal-key" },
+      },
+      { cwd: process.cwd() },
+      { mode: "webpage" },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith("https://scrape.serper.dev", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": "literal-key",
+      },
+      body: JSON.stringify({
+        url: "https://example.com",
+        includeMarkdown: true,
+      }),
+      signal: undefined,
+    });
+    expect(response.results[0]).toMatchObject({
+      title: "Example Domain",
+      url: "https://example.com",
+      snippet: "# Example Domain",
+      metadata: {
+        source: "webpage",
+        markdown: "# Example Domain",
+        text: "Example Domain",
+        metadata: { title: "Example Domain" },
+        searchContext: { credits: 2 },
+      },
+    });
+  });
+
+  it("maps Serper maps responses that return places", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          places: [
+            {
+              title: "Fauve Coffee Berlin",
+              address: "Neue Schönhauser Str. 8, 10178 Berlin, Germany",
+              website: "https://fauve.example",
+              rating: 4.8,
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    ) as typeof fetch;
+
+    const response = await providerHarness(serperProvider).search(
+      "coffee berlin",
+      1,
+      {
+        credentials: { api: "literal-key" },
+        options: {
+          search: {
+            gl: "de",
+            location: "Berlin, Berlin, Germany",
+          },
+        },
+      },
+      { cwd: process.cwd() },
+      { mode: "maps", hl: "en" },
+    );
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://google.serper.dev/maps",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": "literal-key",
+        },
+        body: JSON.stringify({
+          q: "coffee berlin",
+          num: 1,
+          location: "Berlin, Berlin, Germany",
+          gl: "de",
+          hl: "en",
+        }),
+        signal: undefined,
+      },
+    );
+    expect(response.results).toEqual([
+      {
+        title: "Fauve Coffee Berlin",
+        url: "https://fauve.example",
+        snippet: "Neue Schönhauser Str. 8, 10178 Berlin, Germany",
+        metadata: {
+          source: "maps",
+          rating: 4.8,
+          address: "Neue Schönhauser Str. 8, 10178 Berlin, Germany",
+        },
+      },
+    ]);
+  });
+
+  it("maps Serper review titles from reviewer metadata", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          reviews: [
+            {
+              rating: 5,
+              date: "5 days ago",
+              snippet: "Great service!",
+              user: {
+                name: "pilgrim",
+              },
+              link: "https://www.google.com/maps/reviews/data=abc",
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    ) as typeof fetch;
+
+    const response = await providerHarness(serperProvider).search(
+      "ignored",
+      1,
+      {
+        credentials: { api: "literal-key" },
+      },
+      { cwd: process.cwd() },
+      { mode: "reviews", cid: "4800608071159241399" },
+    );
+
+    expect(response.results).toEqual([
+      {
+        title: "pilgrim",
+        url: "https://www.google.com/maps/reviews/data=abc",
+        snippet: "Great service!",
+        metadata: {
+          source: "reviews",
+          date: "5 days ago",
+          rating: 5,
+          user: {
+            name: "pilgrim",
+          },
+        },
+      },
+    ]);
   });
 
   it("returns an empty result set when Serper has no organic matches", async () => {

--- a/test/serper-provider.test.ts
+++ b/test/serper-provider.test.ts
@@ -379,6 +379,101 @@ describe("providerHarness(serperProvider)", () => {
     ]);
   });
 
+  it("uses the query as a Serper reviews identifier when no place id is provided", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ reviews: [] }), { status: 200 }),
+      );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await providerHarness(serperProvider).search(
+      "Fauve Coffee Berlin",
+      5,
+      {
+        credentials: { api: "literal-key" },
+      },
+      { cwd: process.cwd() },
+      { mode: "reviews", gl: "de", hl: "en" },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://google.serper.dev/reviews",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": "literal-key",
+        },
+        body: JSON.stringify({
+          q: "Fauve Coffee Berlin",
+          gl: "de",
+          hl: "en",
+        }),
+        signal: undefined,
+      },
+    );
+  });
+
+  it("maps Serper autocomplete suggestions to actionable search URLs", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          suggestions: [
+            { value: "how to build your own pc" },
+            "how to build your own website",
+          ],
+        }),
+        { status: 200 },
+      ),
+    ) as typeof fetch;
+
+    const response = await providerHarness(serperProvider).search(
+      "how to build your own",
+      5,
+      {
+        credentials: { api: "literal-key" },
+      },
+      { cwd: process.cwd() },
+      { mode: "autocomplete", gl: "us", hl: "en" },
+    );
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://google.serper.dev/autocomplete",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": "literal-key",
+        },
+        body: JSON.stringify({
+          q: "how to build your own",
+          gl: "us",
+          hl: "en",
+        }),
+        signal: undefined,
+      },
+    );
+    expect(response.results).toEqual([
+      {
+        title: "how to build your own pc",
+        url: "https://www.google.com/search?q=how%20to%20build%20your%20own%20pc",
+        snippet: "how to build your own pc",
+        metadata: {
+          source: "autocomplete",
+        },
+      },
+      {
+        title: "how to build your own website",
+        url: "https://www.google.com/search?q=how%20to%20build%20your%20own%20website",
+        snippet: "how to build your own website",
+        metadata: {
+          source: "autocomplete",
+        },
+      },
+    ]);
+  });
+
   it("maps Serper review titles from reviewer metadata", async () => {
     globalThis.fetch = vi.fn().mockResolvedValue(
       new Response(

--- a/test/tool-availability.test.ts
+++ b/test/tool-availability.test.ts
@@ -203,6 +203,35 @@ describe("managed tool availability", () => {
     );
   });
 
+  it("adds Serper mode guidance to the search prompt", async () => {
+    process.env.SERPER_API_KEY = "test-key";
+    writeConfig({
+      tools: {
+        search: "serper",
+      },
+      providers: {
+        serper: {
+          credentials: { api: "SERPER_API_KEY" },
+        },
+      },
+    });
+
+    const tools = await captureRegisteredTools();
+    const webSearch = tools.find((tool) => tool.name === "web_search");
+
+    const guidelines = webSearch?.promptGuidelines ?? [];
+    expect(guidelines).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Serper news mode"),
+        expect.stringContaining("Serper places or maps mode"),
+        expect.stringContaining("Serper reviews mode"),
+        expect.stringContaining("product-reviews mode"),
+        expect.stringContaining("Serper autocomplete mode"),
+        expect.stringContaining("webpage mode"),
+      ]),
+    );
+  });
+
   it("registers provider-bound search schemas from configuration", async () => {
     process.env.OLLAMA_API_KEY = "test-key";
     writeConfig({


### PR DESCRIPTION
## 🔍 Problem

- Serper searches were limited to the basic web search endpoint.
- Agents could not discover or use Serper's vertical endpoints or webpage scraping through the tool schema.

## 🛠️ Solution

- Add a `mode` search option for Serper verticals such as news, images, videos, maps, reviews, shopping, Scholar, patents, autocomplete, Lens, and webpage scraping.
- Surface mode-specific options in the schema and preserve rich response metadata in normalized results.
- Default webpage scraping to Markdown output for easier agent consumption.

## 💬 Review

- Check the request shaping for each Serper mode and the normalized result fields for non-organic responses.
