### PR TITLE
Migrate Brave Answers request options

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ The built-in providers below integrate with official SDKs or documented APIs.
 - API: Brave Search API and Brave Answers API
 - Supports `web_search` via Web Search, plus optional `llm_context`, `news`, `videos`, `images`, and `places` search modes
 - Supports `web_answer` and `web_research` via Brave Answers streaming chat completions
+- Uses the Answers API replacement for Brave's deprecated Summarizer API; answer and research search controls are sent through `web_search_options`
+- Exposes the Answers `model` option (`brave` or `brave-pro`) for answer and research calls
 - `web_contents` stays routed to URL-fetch providers; Brave LLM Context is query-based retrieval and is exposed as a search mode instead
 - Brave Answers may require a different key or plan than Brave Search
 

--- a/changelog/unreleased/brave-answers-api-compatibility.md
+++ b/changelog/unreleased/brave-answers-api-compatibility.md
@@ -1,0 +1,33 @@
+---
+title: Brave Answers API compatibility
+type: bugfix
+authors:
+  - mavam
+  - codex
+prs:
+  - 27
+created: 2026-05-19T15:43:57.453652Z
+---
+
+Brave-backed `web_answer` and `web_research` now use the current Brave Answers API request format.
+
+Existing Brave configurations continue to work, and users can opt into Brave Pro for answer or research calls:
+
+```json
+{
+  "providers": {
+    "brave": {
+      "options": {
+        "answer": {
+          "model": "brave-pro"
+        },
+        "research": {
+          "model": "brave-pro"
+        }
+      }
+    }
+  }
+}
+```
+
+This keeps Brave grounded answers and research compatible after Brave deprecated the Summarizer API in favor of Answers.

--- a/src/providers/brave.ts
+++ b/src/providers/brave.ts
@@ -275,8 +275,14 @@ const braveSearchPromptGuidelines = [
 
 const braveAnswerOptionsSchema = Type.Object(
   {
+    model: Type.Optional(
+      Type.Enum({ brave: "brave", bravePro: "brave-pro" } as const, {
+        description: "Brave Answers model. Defaults to 'brave'.",
+      }),
+    ),
     country: Type.Optional(Type.String()),
     language: Type.Optional(Type.String()),
+    safesearch: safesearchOption,
     enable_citations: Type.Optional(Type.Boolean()),
     enable_entities: Type.Optional(Type.Boolean()),
     max_completion_tokens: Type.Optional(Type.Integer({ minimum: 1 })),
@@ -286,8 +292,14 @@ const braveAnswerOptionsSchema = Type.Object(
 
 const braveResearchOptionsSchema = Type.Object(
   {
+    model: Type.Optional(
+      Type.Enum({ brave: "brave", bravePro: "brave-pro" } as const, {
+        description: "Brave Answers model. Defaults to 'brave'.",
+      }),
+    ),
     country: Type.Optional(Type.String()),
     language: Type.Optional(Type.String()),
+    safesearch: safesearchOption,
     enable_entities: Type.Optional(Type.Boolean()),
     enable_citations: Type.Optional(
       Type.Boolean({
@@ -1014,30 +1026,30 @@ function placeRating(
 function buildAnswerRequest(
   raw: Record<string, unknown>,
 ): Record<string, unknown> {
-  const answerOptions = pick(raw, [
+  const webSearchOptions = pick(raw, [
     "country",
     "language",
     "safesearch",
     "enable_entities",
     "enable_citations",
   ]);
-  if (answerOptions.enable_citations === undefined) {
-    answerOptions.enable_citations = true;
+  if (webSearchOptions.enable_citations === undefined) {
+    webSearchOptions.enable_citations = true;
   }
   const stream =
-    answerOptions.enable_citations === true ||
-    answerOptions.enable_entities === true;
+    webSearchOptions.enable_citations === true ||
+    webSearchOptions.enable_entities === true;
   return {
     stream,
-    ...pick(raw, ["max_completion_tokens", "metadata", "seed"]),
-    ...answerOptions,
+    ...pick(raw, ["model", "max_completion_tokens", "metadata", "seed"]),
+    web_search_options: webSearchOptions,
   };
 }
 
 function buildResearchRequest(
   raw: Record<string, unknown>,
 ): Record<string, unknown> {
-  const researchOptions = pick(raw, [
+  const webSearchOptions = pick(raw, [
     "country",
     "language",
     "safesearch",
@@ -1049,12 +1061,12 @@ function buildResearchRequest(
     "research_maximum_number_of_seconds",
     "research_maximum_number_of_results_per_query",
   ]);
+  webSearchOptions.enable_research = true;
+  webSearchOptions.enable_citations = false;
   return {
     stream: true,
-    ...pick(raw, ["max_completion_tokens", "metadata", "seed"]),
-    ...researchOptions,
-    enable_research: true,
-    enable_citations: false,
+    ...pick(raw, ["model", "max_completion_tokens", "metadata", "seed"]),
+    web_search_options: webSearchOptions,
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -287,16 +287,20 @@ export interface BraveSearchOptions {
 }
 
 export interface BraveAnswerOptions {
+  model?: "brave" | "brave-pro";
   country?: string;
   language?: string;
+  safesearch?: "off" | "moderate" | "strict";
   enable_citations?: boolean;
   enable_entities?: boolean;
   max_completion_tokens?: number;
 }
 
 export interface BraveResearchOptions {
+  model?: "brave" | "brave-pro";
   country?: string;
   language?: string;
+  safesearch?: "off" | "moderate" | "strict";
   enable_entities?: boolean;
   enable_citations?: boolean;
   max_completion_tokens?: number;

--- a/test/brave-provider.test.ts
+++ b/test/brave-provider.test.ts
@@ -237,7 +237,7 @@ describe("providerHarness(braveProvider)", () => {
     ]);
   });
 
-  it("sends Brave Answers options at the top level and parses streamed tags", async () => {
+  it("sends Brave Answers search options under web_search_options and parses streamed tags", async () => {
     process.env.BRAVE_ANSWERS_API_KEY = "answers-key";
     const fetchMock = vi
       .fn()
@@ -262,7 +262,12 @@ describe("providerHarness(braveProvider)", () => {
         baseUrl: "https://api.search.brave.test",
       },
       { cwd: process.cwd() },
-      { country: "US", language: "en", enable_entities: true },
+      {
+        model: "brave-pro",
+        country: "US",
+        language: "en",
+        enable_entities: true,
+      },
     );
 
     const [, init] = fetchMock.mock.calls[0];
@@ -278,13 +283,15 @@ describe("providerHarness(braveProvider)", () => {
       }),
     );
     expect(JSON.parse(String(init.body))).toEqual({
-      model: "brave",
+      model: "brave-pro",
       messages: [{ role: "user", content: "what happened?" }],
       stream: true,
-      country: "US",
-      language: "en",
-      enable_entities: true,
-      enable_citations: true,
+      web_search_options: {
+        country: "US",
+        language: "en",
+        enable_entities: true,
+        enable_citations: true,
+      },
     });
     expect(response).toEqual({
       provider: "brave",
@@ -349,10 +356,12 @@ describe("providerHarness(braveProvider)", () => {
       messages: [{ role: "user", content: "research this topic" }],
       stream: true,
       max_completion_tokens: 1000,
-      country: "US",
-      research_maximum_number_of_queries: 3,
-      enable_research: true,
-      enable_citations: false,
+      web_search_options: {
+        country: "US",
+        research_maximum_number_of_queries: 3,
+        enable_research: true,
+        enable_citations: false,
+      },
     });
     expect(response.text).toBe("Research report");
   });


### PR DESCRIPTION
## Summary

- Move Brave answer and research search controls into `web_search_options` for the current Answers API request shape.
- Add `brave` / `brave-pro` model support plus `safesearch` to Brave answer and research options.
- Update README and Brave provider tests for the Summarizer deprecation migration.

## Why

Brave notified API users that the Summarizer Search API is deprecated and that Answers is the replacement. The linked Answers API reference expects Brave-specific search controls inside `web_search_options`, while top-level chat fields such as `model`, `messages`, `stream`, and token controls remain at the request root.

## Validation

- `npm test -- test/brave-provider.test.ts`
- `npm run check`
- `npm test`
- `npm run build`

Note: repo-wide `npm run format:check` still reports an unrelated ignored local settings file, `.sc/last-chat-settings.json`, missing a trailing newline. The touched files pass Biome formatting.
