### PR TITLE
[codex] Resolve provider secrets lazily

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ settings UI mirrors the three sections below: tools, providers, and settings.
 
 Each tool can be routed to any compatible provider:
 
+Provider credentials can be literal values, environment variable names, or
+`!command` references. pi-web-providers resolves those secrets lazily on the
+first matching tool use, not when a session starts. This avoids startup delays
+from password-manager commands such as `op`; missing or failing secrets are
+reported when the tool is actually called.
+
 **Built-in local providers**
 
 | Provider   | search | contents | answer | research | Auth                   |

--- a/changelog/unreleased/lazy-provider-secret-resolution.md
+++ b/changelog/unreleased/lazy-provider-secret-resolution.md
@@ -1,0 +1,28 @@
+---
+title: Lazy provider secret resolution
+type: bugfix
+authors:
+  - mavam
+  - codex
+prs:
+  - 28
+created: 2026-05-19T16:11:52.070619Z
+---
+
+Provider secrets are now resolved only when a configured web tool is used, instead of during session startup.
+
+Configurations that use environment variables or `!command` values for provider credentials no longer pay the secret lookup cost just because a pi session starts. For example:
+
+```json
+{
+  "providers": {
+    "exa": {
+      "credentials": {
+        "api": "!op read op://Private/Exa/api-key"
+      }
+    }
+  }
+}
+```
+
+If the secret is missing or the command fails, the error is reported when the matching web tool is called.

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ import {
   getMappedProviderIdForTool,
   getProviderCapabilityStatus,
   getProviderSetupState,
-  isProviderCapabilityReady,
+  isProviderCapabilityExposable,
   resolveProviderForTool,
   resolveSearchProvider,
   supportsTool,
@@ -611,12 +611,21 @@ function getAvailableProviderIdsForCapability(
     return [];
   }
 
-  try {
-    resolveProviderForTool(config, cwd, capability);
-    return [providerId];
-  } catch {
+  const provider = PROVIDERS_BY_ID[providerId];
+  if (!supportsTool(provider, capability)) {
     return [];
   }
+
+  const status = getProviderCapabilityStatus(
+    config,
+    cwd,
+    providerId,
+    capability,
+    {
+      resolveSecrets: false,
+    },
+  );
+  return isProviderCapabilityExposable(status) ? [providerId] : [];
 }
 
 function getProviderStatusForTool(
@@ -2811,12 +2820,19 @@ function getReadyCompatibleProvidersForTool(
   cwd: string,
   toolId: Tool,
 ): ProviderId[] {
+  const mappedProviderId = getMappedProviderIdForTool(config, toolId);
   return sortProviderIdsForSettings(
-    getCompatibleProviders(toolId).filter((providerId) =>
-      isProviderCapabilityReady(
-        getProviderCapabilityStatus(config, cwd, providerId, toolId),
-      ),
-    ),
+    getCompatibleProviders(toolId).filter((providerId) => {
+      const setupState = getProviderSetupState(config, providerId);
+      if (setupState === "none" && providerId !== mappedProviderId) {
+        return false;
+      }
+      return isProviderCapabilityExposable(
+        getProviderCapabilityStatus(config, cwd, providerId, toolId, {
+          resolveSecrets: false,
+        }),
+      );
+    }),
   );
 }
 
@@ -3115,7 +3131,7 @@ class WebProvidersSettingsView implements Component {
         description:
           `Press Enter to configure web_${toolId}. ${TOOL_INFO[toolId].help} Route web_${toolId} to one compatible provider or turn it off.` +
           (compatibleLabels.length > 0
-            ? ` Ready compatible providers: ${compatibleLabels.join(", ")}.`
+            ? ` Compatible providers: ${compatibleLabels.join(", ")}.`
             : ""),
         kind: "action",
       };
@@ -3500,7 +3516,7 @@ class ToolSettingsSubmenu implements Component {
         id: "provider",
         label: "Provider",
         currentValue: currentProviderValue,
-        description: `Route web_${this.toolId} to one compatible ready provider or turn it off.`,
+        description: `Route web_${this.toolId} to one compatible provider or turn it off.`,
         kind: "cycle",
         values: providerValues,
       },
@@ -3986,10 +4002,15 @@ function getProviderReadinessSummary(
 ): string {
   const tools = getProviderTools(providerId);
   const statuses = tools.map((tool) =>
-    getProviderCapabilityStatus(config, cwd, providerId, tool),
+    getProviderCapabilityStatus(config, cwd, providerId, tool, {
+      resolveSecrets: false,
+    }),
   );
   if (statuses.some((status) => status.state === "ready")) {
     return "Ready";
+  }
+  if (statuses.some((status) => status.state === "deferred_secret")) {
+    return "Secrets resolved on first use";
   }
   return formatProviderCapabilityStatus(statuses[0], providerId, tools[0]);
 }
@@ -4002,6 +4023,8 @@ function getProviderReadinessSummaryForProviderConfig(
     (providerConfig ??
       PROVIDERS_BY_ID[providerId].config.createTemplate()) as never,
     "",
+    undefined,
+    { resolveSecrets: false },
   );
   return formatProviderCapabilityStatus(status, providerId);
 }

--- a/src/provider-resolution.ts
+++ b/src/provider-resolution.ts
@@ -4,6 +4,7 @@ import { PROVIDERS } from "./providers/index.js";
 import type {
   ExecutionSettings,
   ProviderCapabilityStatus,
+  ProviderCapabilityStatusOptions,
   ProviderConfig,
   ProviderId,
   ProviderSetupState,
@@ -131,12 +132,14 @@ export function getProviderCapabilityStatus<TProviderId extends ProviderId>(
   cwd: string,
   providerId: TProviderId,
   tool?: Tool,
+  options?: ProviderCapabilityStatusOptions,
 ): ProviderCapabilityStatus {
   const provider = PROVIDERS[providerId];
   return provider.getCapabilityStatus(
     getEffectiveProviderConfig(config, providerId) as never,
     cwd,
     tool,
+    options,
   );
 }
 
@@ -144,6 +147,12 @@ export function isProviderCapabilityReady(
   status: ProviderCapabilityStatus,
 ): boolean {
   return status.state === "ready";
+}
+
+export function isProviderCapabilityExposable(
+  status: ProviderCapabilityStatus,
+): boolean {
+  return status.state === "ready" || status.state === "deferred_secret";
 }
 
 export function getProviderSetupState(
@@ -183,6 +192,8 @@ export function formatProviderCapabilityStatus(
   switch (status.state) {
     case "ready":
       return "Ready";
+    case "deferred_secret":
+      return "Secret resolved on first use";
     case "missing_api_key":
       return "Missing API key";
     case "missing_executable":

--- a/src/providers/brave.ts
+++ b/src/providers/brave.ts
@@ -3,13 +3,14 @@ import { resolveConfigValue } from "../config-values.js";
 import type {
   Brave,
   ProviderCapabilityStatus,
+  ProviderCapabilityStatusOptions,
   ProviderContext,
   SearchResponse,
   Tool,
   ToolOutput,
 } from "../types.js";
 import { defineCapability, defineProvider } from "./definition.js";
-import { asJsonObject, formatConfigValueError, trimSnippet } from "./shared.js";
+import { asJsonObject, getApiKeyStatus, trimSnippet } from "./shared.js";
 
 const DEFAULT_BASE_URL = "https://api.search.brave.com";
 const BRAVE_API_VERSION: string | undefined = undefined;
@@ -348,26 +349,28 @@ const braveImplementation = {
     config: Brave | undefined,
     _cwd: string,
     tool?: Tool,
+    options?: ProviderCapabilityStatusOptions,
   ): ProviderCapabilityStatus {
     const key =
       tool === "answer" || tool === "research"
         ? config?.credentials?.answers
         : config?.credentials?.search;
-    try {
-      if (tool)
-        return resolveConfigValue(key)
-          ? { state: "ready" }
-          : { state: "missing_api_key" };
-      return [
-        config?.credentials?.search,
-        config?.credentials?.answers,
-        config?.credentials?.autosuggest,
-      ].some((v) => resolveConfigValue(v))
-        ? { state: "ready" }
-        : { state: "missing_api_key" };
-    } catch (error) {
-      return { state: "invalid_config", detail: formatConfigValueError(error) };
+    if (tool) {
+      return getApiKeyStatus(key, options);
     }
+
+    const statuses = [
+      config?.credentials?.search,
+      config?.credentials?.answers,
+      config?.credentials?.autosuggest,
+    ].map((value) => getApiKeyStatus(value, options));
+    return (
+      statuses.find((status) => status.state === "ready") ??
+      statuses.find((status) => status.state === "deferred_secret") ??
+      statuses.find((status) => status.state === "invalid_config") ?? {
+        state: "missing_api_key",
+      }
+    );
   },
 
   async search(
@@ -1319,11 +1322,12 @@ export const braveProvider = defineProvider({
     },
     optionCapabilities: ["search", "answer", "research"],
   },
-  getCapabilityStatus: (config, cwd, tool) =>
+  getCapabilityStatus: (config, cwd, tool, options) =>
     braveImplementation.getCapabilityStatus(
       config as Brave | undefined,
       cwd,
       tool,
+      options,
     ),
   capabilities: {
     search: defineCapability({

--- a/src/providers/cloudflare.ts
+++ b/src/providers/cloudflare.ts
@@ -5,6 +5,7 @@ import type { ContentsResponse } from "../contents.js";
 import type {
   Cloudflare,
   ProviderCapabilityStatus,
+  ProviderCapabilityStatusOptions,
   ProviderContext,
   Tool,
 } from "../types.js";
@@ -68,10 +69,15 @@ const cloudflareImplementation = {
 
   getCapabilityStatus(
     config: Cloudflare | undefined,
+    _cwd: string,
+    _tool: Tool | undefined,
+    options?: ProviderCapabilityStatusOptions,
   ): ProviderCapabilityStatus {
-    const apiTokenStatus = getApiKeyStatus(config?.credentials?.api);
+    const apiTokenStatus = getApiKeyStatus(config?.credentials?.api, options);
     if (apiTokenStatus.state !== "ready") {
-      return apiTokenStatus;
+      if (apiTokenStatus.state !== "deferred_secret") {
+        return apiTokenStatus;
+      }
     }
 
     try {
@@ -85,7 +91,9 @@ const cloudflareImplementation = {
       };
     }
 
-    return { state: "ready" };
+    return apiTokenStatus.state === "deferred_secret"
+      ? apiTokenStatus
+      : { state: "ready" };
   },
 
   async contents(
@@ -160,11 +168,12 @@ export const cloudflareProvider = defineProvider({
     createTemplate: () => cloudflareImplementation.createTemplate(),
     fields: ["credentials", "accountId", "options", "settings"],
   },
-  getCapabilityStatus: (config, cwd, tool) =>
+  getCapabilityStatus: (config, cwd, tool, options) =>
     (cloudflareImplementation.getCapabilityStatus as any)(
       config as Cloudflare | undefined,
       cwd,
       tool,
+      options,
     ),
   capabilities: {
     contents: defineCapability({

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -1,6 +1,7 @@
 import type { TObject } from "typebox";
 import type {
   ProviderCapabilityStatus,
+  ProviderCapabilityStatusOptions,
   ProviderConfig,
   ProviderContext,
   ProviderId,
@@ -83,6 +84,7 @@ export interface ProviderDefinition<
     config: TConfig | undefined,
     cwd: string,
     tool?: Tool,
+    options?: ProviderCapabilityStatusOptions,
   ): ProviderCapabilityStatus;
 }
 

--- a/src/providers/exa.ts
+++ b/src/providers/exa.ts
@@ -6,6 +6,7 @@ import { executeAsyncResearch } from "../execution-policy.js";
 import type {
   Exa,
   ProviderCapabilityStatus,
+  ProviderCapabilityStatusOptions,
   ProviderContext,
   ResearchJob,
   ResearchPollResult,
@@ -133,8 +134,13 @@ const exaImplementation = {
     };
   },
 
-  getCapabilityStatus(config: Exa | undefined): ProviderCapabilityStatus {
-    return getApiKeyStatus(config?.credentials?.api);
+  getCapabilityStatus(
+    config: Exa | undefined,
+    _cwd: string,
+    _tool: Tool | undefined,
+    options?: ProviderCapabilityStatusOptions,
+  ): ProviderCapabilityStatus {
+    return getApiKeyStatus(config?.credentials?.api, options);
   },
 
   async search(
@@ -339,11 +345,12 @@ export const exaProvider = defineProvider({
     fields: ["credentials", "baseUrl", "options", "settings"],
     optionCapabilities: ["search"],
   },
-  getCapabilityStatus: (config, cwd, tool) =>
+  getCapabilityStatus: (config, cwd, tool, options) =>
     (exaImplementation.getCapabilityStatus as any)(
       config as Exa | undefined,
       cwd,
       tool,
+      options,
     ),
   capabilities: {
     search: defineCapability({

--- a/src/providers/firecrawl.ts
+++ b/src/providers/firecrawl.ts
@@ -8,6 +8,7 @@ import type { ContentsResponse } from "../contents.js";
 import type {
   Firecrawl,
   ProviderCapabilityStatus,
+  ProviderCapabilityStatusOptions,
   ProviderContext,
   SearchResponse,
   SearchResult,
@@ -154,8 +155,13 @@ const firecrawlImplementation = {
     };
   },
 
-  getCapabilityStatus(config: Firecrawl | undefined): ProviderCapabilityStatus {
-    return getApiKeyStatus(config?.credentials?.api);
+  getCapabilityStatus(
+    config: Firecrawl | undefined,
+    _cwd: string,
+    _tool: Tool | undefined,
+    options?: ProviderCapabilityStatusOptions,
+  ): ProviderCapabilityStatus {
+    return getApiKeyStatus(config?.credentials?.api, options);
   },
 
   async search(
@@ -321,11 +327,12 @@ export const firecrawlProvider = defineProvider({
     createTemplate: () => firecrawlImplementation.createTemplate(),
     fields: ["credentials", "baseUrl", "options", "settings"],
   },
-  getCapabilityStatus: (config, cwd, tool) =>
+  getCapabilityStatus: (config, cwd, tool, options) =>
     (firecrawlImplementation.getCapabilityStatus as any)(
       config as Firecrawl | undefined,
       cwd,
       tool,
+      options,
     ),
   capabilities: {
     search: defineCapability({

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -6,6 +6,7 @@ import { DEFAULT_GEMINI_RESEARCH_MAX_CONSECUTIVE_POLL_ERRORS } from "../executio
 import type {
   Gemini,
   ProviderCapabilityStatus,
+  ProviderCapabilityStatusOptions,
   ProviderContext,
   ResearchJob,
   ResearchPollResult,
@@ -152,8 +153,13 @@ export const geminiImplementation = {
     };
   },
 
-  getCapabilityStatus(config: Gemini | undefined): ProviderCapabilityStatus {
-    return getApiKeyStatus(config?.credentials?.api);
+  getCapabilityStatus(
+    config: Gemini | undefined,
+    _cwd: string,
+    _tool: Tool | undefined,
+    options?: ProviderCapabilityStatusOptions,
+  ): ProviderCapabilityStatus {
+    return getApiKeyStatus(config?.credentials?.api, options);
   },
 
   async search(
@@ -1085,11 +1091,12 @@ export const geminiProvider = defineProvider({
     createTemplate: () => geminiImplementation.createTemplate(),
     fields: ["credentials", "options", "settings"],
   },
-  getCapabilityStatus: (config, cwd, tool) =>
+  getCapabilityStatus: (config, cwd, tool, options) =>
     (geminiImplementation.getCapabilityStatus as any)(
       config as Gemini | undefined,
       cwd,
       tool,
+      options,
     ),
   capabilities: {
     search: defineCapability({

--- a/src/providers/linkup.ts
+++ b/src/providers/linkup.ts
@@ -10,6 +10,7 @@ import type { ContentsResponse } from "../contents.js";
 import type {
   Linkup,
   ProviderCapabilityStatus,
+  ProviderCapabilityStatusOptions,
   ProviderContext,
   SearchResponse,
   SearchResult,
@@ -110,8 +111,13 @@ const linkupImplementation = {
     };
   },
 
-  getCapabilityStatus(config: Linkup | undefined): ProviderCapabilityStatus {
-    return getApiKeyStatus(config?.credentials?.api);
+  getCapabilityStatus(
+    config: Linkup | undefined,
+    _cwd: string,
+    _tool: Tool | undefined,
+    options?: ProviderCapabilityStatusOptions,
+  ): ProviderCapabilityStatus {
+    return getApiKeyStatus(config?.credentials?.api, options);
   },
 
   async search(
@@ -324,11 +330,12 @@ export const linkupProvider = defineProvider({
     createTemplate: () => linkupImplementation.createTemplate(),
     fields: ["credentials", "baseUrl", "options", "settings"],
   },
-  getCapabilityStatus: (config, cwd, tool) =>
+  getCapabilityStatus: (config, cwd, tool, options) =>
     (linkupImplementation.getCapabilityStatus as any)(
       config as Linkup | undefined,
       cwd,
       tool,
+      options,
     ),
   capabilities: {
     search: defineCapability({

--- a/src/providers/ollama.ts
+++ b/src/providers/ollama.ts
@@ -1,6 +1,12 @@
 import { resolveConfigValue } from "../config-values.js";
 import type { ContentsResponse } from "../contents.js";
-import type { Ollama, ProviderContext, SearchResponse } from "../types.js";
+import type {
+  Ollama,
+  ProviderCapabilityStatusOptions,
+  ProviderContext,
+  SearchResponse,
+  Tool,
+} from "../types.js";
 import { defineCapability, defineProvider } from "./definition.js";
 import {
   getApiKeyStatus,
@@ -26,8 +32,13 @@ export const ollamaProvider = defineProvider({
     fields: ["credentials", "baseUrl", "settings"],
   },
 
-  getCapabilityStatus(config: Ollama | undefined) {
-    return getApiKeyStatus(config?.credentials?.api);
+  getCapabilityStatus(
+    config: Ollama | undefined,
+    _cwd: string,
+    _tool: Tool | undefined,
+    options?: ProviderCapabilityStatusOptions,
+  ) {
+    return getApiKeyStatus(config?.credentials?.api, options);
   },
 
   capabilities: {

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -8,6 +8,7 @@ import type {
   OpenAIResearchOptions,
   OpenAISearchOptions,
   ProviderCapabilityStatus,
+  ProviderCapabilityStatusOptions,
   ProviderContext,
   ResearchJob,
   ResearchPollResult,
@@ -171,8 +172,11 @@ const openaiImplementation = {
 
   getCapabilityStatus(
     config: OpenAIConfig | undefined,
+    _cwd: string,
+    _tool: Tool | undefined,
+    options?: ProviderCapabilityStatusOptions,
   ): ProviderCapabilityStatus {
-    return getApiKeyStatus(config?.credentials?.api);
+    return getApiKeyStatus(config?.credentials?.api, options);
   },
 
   async search(
@@ -687,11 +691,12 @@ export const openaiProvider = defineProvider({
     fields: ["credentials", "baseUrl", "options", "settings"],
     optionCapabilities: ["search", "answer", "research"],
   },
-  getCapabilityStatus: (config, cwd, tool) =>
+  getCapabilityStatus: (config, cwd, tool, options) =>
     (openaiImplementation.getCapabilityStatus as any)(
-      config as OpenAI | undefined,
+      config as OpenAIConfig | undefined,
       cwd,
       tool,
+      options,
     ),
   capabilities: {
     search: defineCapability({

--- a/src/providers/parallel.ts
+++ b/src/providers/parallel.ts
@@ -5,6 +5,7 @@ import type { ContentsResponse } from "../contents.js";
 import type {
   Parallel,
   ProviderCapabilityStatus,
+  ProviderCapabilityStatusOptions,
   ProviderContext,
   SearchResponse,
   Tool,
@@ -75,8 +76,13 @@ const parallelImplementation = {
     };
   },
 
-  getCapabilityStatus(config: Parallel | undefined): ProviderCapabilityStatus {
-    return getApiKeyStatus(config?.credentials?.api);
+  getCapabilityStatus(
+    config: Parallel | undefined,
+    _cwd: string,
+    _tool: Tool | undefined,
+    options?: ProviderCapabilityStatusOptions,
+  ): ProviderCapabilityStatus {
+    return getApiKeyStatus(config?.credentials?.api, options);
   },
 
   async search(
@@ -188,11 +194,12 @@ export const parallelProvider = defineProvider({
     createTemplate: () => parallelImplementation.createTemplate(),
     fields: ["credentials", "baseUrl", "options", "settings"],
   },
-  getCapabilityStatus: (config, cwd, tool) =>
+  getCapabilityStatus: (config, cwd, tool, options) =>
     (parallelImplementation.getCapabilityStatus as any)(
       config as Parallel | undefined,
       cwd,
       tool,
+      options,
     ),
   capabilities: {
     search: defineCapability({

--- a/src/providers/perplexity.ts
+++ b/src/providers/perplexity.ts
@@ -4,6 +4,7 @@ import { resolveConfigValue } from "../config-values.js";
 import type {
   Perplexity,
   ProviderCapabilityStatus,
+  ProviderCapabilityStatusOptions,
   ProviderContext,
   SearchResponse,
   Tool,
@@ -108,8 +109,11 @@ const perplexityImplementation = {
 
   getCapabilityStatus(
     config: Perplexity | undefined,
+    _cwd: string,
+    _tool: Tool | undefined,
+    options?: ProviderCapabilityStatusOptions,
   ): ProviderCapabilityStatus {
-    return getApiKeyStatus(config?.credentials?.api);
+    return getApiKeyStatus(config?.credentials?.api, options);
   },
 
   async search(
@@ -433,11 +437,12 @@ export const perplexityProvider = defineProvider({
     createTemplate: () => perplexityImplementation.createTemplate(),
     fields: ["credentials", "baseUrl", "options", "settings"],
   },
-  getCapabilityStatus: (config, cwd, tool) =>
+  getCapabilityStatus: (config, cwd, tool, options) =>
     (perplexityImplementation.getCapabilityStatus as any)(
       config as Perplexity | undefined,
       cwd,
       tool,
+      options,
     ),
   capabilities: {
     search: defineCapability({

--- a/src/providers/serper.ts
+++ b/src/providers/serper.ts
@@ -2,6 +2,7 @@ import { type TObject, Type } from "typebox";
 import { resolveConfigValue } from "../config-values.js";
 import type {
   ProviderCapabilityStatus,
+  ProviderCapabilityStatusOptions,
   ProviderContext,
   SearchResponse,
   SearchResult,
@@ -234,8 +235,13 @@ const serperImplementation = {
     };
   },
 
-  getCapabilityStatus(config: Serper | undefined): ProviderCapabilityStatus {
-    return getApiKeyStatus(config?.credentials?.api);
+  getCapabilityStatus(
+    config: Serper | undefined,
+    _cwd: string,
+    _tool: Tool | undefined,
+    options?: ProviderCapabilityStatusOptions,
+  ): ProviderCapabilityStatus {
+    return getApiKeyStatus(config?.credentials?.api, options);
   },
 
   async search(
@@ -777,11 +783,12 @@ export const serperProvider = defineProvider({
     fields: ["credentials", "baseUrl", "options", "settings"],
     optionCapabilities: ["search"],
   },
-  getCapabilityStatus: (config, cwd, tool) =>
+  getCapabilityStatus: (config, cwd, tool, options) =>
     (serperImplementation.getCapabilityStatus as any)(
       config as Serper | undefined,
       cwd,
       tool,
+      options,
     ),
   capabilities: {
     search: defineCapability({

--- a/src/providers/shared.ts
+++ b/src/providers/shared.ts
@@ -1,5 +1,8 @@
 import { resolveConfigValue } from "../config-values.js";
-import type { ProviderCapabilityStatus } from "../types.js";
+import type {
+  ProviderCapabilityStatus,
+  ProviderCapabilityStatusOptions,
+} from "../types.js";
 
 export function trimSnippet(
   input: string | undefined,
@@ -46,7 +49,14 @@ export function formatJson(value: unknown): string {
 
 export function getApiKeyStatus(
   apiKeyReference: string | undefined,
+  options: ProviderCapabilityStatusOptions = {},
 ): ProviderCapabilityStatus {
+  if (!apiKeyReference) {
+    return { state: "missing_api_key" };
+  }
+  if (options.resolveSecrets === false && isSecretReference(apiKeyReference)) {
+    return { state: "deferred_secret" };
+  }
   try {
     return resolveConfigValue(apiKeyReference)
       ? { state: "ready" }
@@ -57,6 +67,10 @@ export function getApiKeyStatus(
       detail: formatConfigValueError(error),
     };
   }
+}
+
+export function isSecretReference(reference: string): boolean {
+  return reference.startsWith("!") || /^[A-Z][A-Z0-9_]*$/.test(reference);
 }
 
 export function formatConfigValueError(error: unknown): string {

--- a/src/providers/tavily.ts
+++ b/src/providers/tavily.ts
@@ -9,6 +9,7 @@ import { resolveConfigValue } from "../config-values.js";
 import type { ContentsResponse } from "../contents.js";
 import type {
   ProviderCapabilityStatus,
+  ProviderCapabilityStatusOptions,
   ProviderContext,
   SearchResponse,
   Tavily,
@@ -130,8 +131,13 @@ const tavilyImplementation = {
     };
   },
 
-  getCapabilityStatus(config: Tavily | undefined): ProviderCapabilityStatus {
-    return getApiKeyStatus(config?.credentials?.api);
+  getCapabilityStatus(
+    config: Tavily | undefined,
+    _cwd: string,
+    _tool: Tool | undefined,
+    options?: ProviderCapabilityStatusOptions,
+  ): ProviderCapabilityStatus {
+    return getApiKeyStatus(config?.credentials?.api, options);
   },
 
   async search(
@@ -268,11 +274,12 @@ export const tavilyProvider = defineProvider({
     createTemplate: () => tavilyImplementation.createTemplate(),
     fields: ["credentials", "baseUrl", "options", "settings"],
   },
-  getCapabilityStatus: (config, cwd, tool) =>
+  getCapabilityStatus: (config, cwd, tool, options) =>
     (tavilyImplementation.getCapabilityStatus as any)(
       config as Tavily | undefined,
       cwd,
       tool,
+      options,
     ),
   capabilities: {
     search: defineCapability({

--- a/src/providers/valyu.ts
+++ b/src/providers/valyu.ts
@@ -5,6 +5,7 @@ import type { ContentsResponse } from "../contents.js";
 import { executeAsyncResearch } from "../execution-policy.js";
 import type {
   ProviderCapabilityStatus,
+  ProviderCapabilityStatusOptions,
   ProviderContext,
   ResearchJob,
   ResearchPollResult,
@@ -100,8 +101,13 @@ const valyuImplementation = {
     };
   },
 
-  getCapabilityStatus(config: Valyu | undefined): ProviderCapabilityStatus {
-    return getApiKeyStatus(config?.credentials?.api);
+  getCapabilityStatus(
+    config: Valyu | undefined,
+    _cwd: string,
+    _tool: Tool | undefined,
+    options?: ProviderCapabilityStatusOptions,
+  ): ProviderCapabilityStatus {
+    return getApiKeyStatus(config?.credentials?.api, options);
   },
 
   async search(
@@ -357,11 +363,12 @@ export const valyuProvider = defineProvider({
     fields: ["credentials", "baseUrl", "options", "settings"],
     optionCapabilities: ["search", "answer", "research"],
   },
-  getCapabilityStatus: (config, cwd, tool) =>
+  getCapabilityStatus: (config, cwd, tool, options) =>
     (valyuImplementation.getCapabilityStatus as any)(
       config as Valyu | undefined,
       cwd,
       tool,
+      options,
     ),
   capabilities: {
     search: defineCapability({

--- a/src/types.ts
+++ b/src/types.ts
@@ -415,10 +415,15 @@ export type ProviderSetupState = "builtin" | "configured" | "none";
 
 export type ProviderCapabilityStatus =
   | { state: "ready" }
+  | { state: "deferred_secret" }
   | { state: "missing_api_key" }
   | { state: "missing_executable" }
   | { state: "missing_command" }
   | { state: "invalid_config"; detail: string };
+
+export interface ProviderCapabilityStatusOptions {
+  resolveSecrets?: boolean;
+}
 
 export interface ProviderContext {
   cwd: string;

--- a/test/tool-availability.test.ts
+++ b/test/tool-availability.test.ts
@@ -1,4 +1,11 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionAPI, Theme } from "@earendil-works/pi-coding-agent";
@@ -310,6 +317,120 @@ describe("managed tool availability", () => {
         "search",
       ),
     ).toEqual(["codex"]);
+  });
+
+  it("registers mapped command-backed secret tools without resolving the command on startup", async () => {
+    const { command, markerPath } = createCommandBackedSecret();
+    const config = createConfig({
+      tools: {
+        search: "exa",
+      },
+      providers: {
+        exa: {
+          credentials: { api: command },
+        },
+      },
+    });
+
+    writeConfig(config);
+
+    const tools = await captureRegisteredTools();
+
+    expect(tools.map((tool) => tool.name)).toContain("web_search");
+    expect(existsSync(markerPath)).toBe(false);
+
+    await __test__.executeSearchTool({
+      config,
+      ctx: { cwd: process.cwd() },
+      signal: null,
+      onUpdate: undefined,
+      options: undefined,
+      queries: ["lazy secrets"],
+      executionOverrides: [
+        {
+          capability: "search",
+          providerLabel: "Exa",
+          async execute() {
+            return { provider: "exa", results: [] };
+          },
+        },
+      ],
+    });
+    await __test__.executeSearchTool({
+      config,
+      ctx: { cwd: process.cwd() },
+      signal: null,
+      onUpdate: undefined,
+      options: undefined,
+      queries: ["lazy secrets again"],
+      executionOverrides: [
+        {
+          capability: "search",
+          providerLabel: "Exa",
+          async execute() {
+            return { provider: "exa", results: [] };
+          },
+        },
+      ],
+    });
+
+    expect(readFileSync(markerPath, "utf-8")).toBe("x");
+  });
+
+  it("exposes mapped env-backed secret tools at startup but fails on execution when the env var is missing", async () => {
+    const config = createConfig({
+      tools: {
+        search: "exa",
+      },
+      providers: {
+        exa: {
+          credentials: { api: "EXA_API_KEY" },
+        },
+      },
+    });
+
+    expect(
+      __test__.getAvailableManagedToolNames(config, process.cwd()),
+    ).toEqual(["web_search"]);
+
+    await expect(
+      __test__.executeSearchTool({
+        config,
+        ctx: { cwd: process.cwd() },
+        signal: null,
+        onUpdate: undefined,
+        options: undefined,
+        queries: ["missing env"],
+        executionOverrides: [
+          {
+            capability: "search",
+            providerLabel: "Exa",
+            async execute() {
+              return { provider: "exa", results: [] };
+            },
+          },
+        ],
+      }),
+    ).rejects.toThrow(/Provider 'exa' is not available: missing API key/);
+  });
+
+  it("does not defer Cloudflare account ID validation when the API token secret is lazy", () => {
+    const { command, markerPath } = createCommandBackedSecret();
+    const config = createConfig({
+      tools: {
+        contents: "cloudflare",
+      },
+      providers: {
+        cloudflare: {
+          credentials: { api: command },
+        },
+      },
+    });
+
+    expect(
+      __test__.getAvailableManagedToolNames(config, process.cwd()),
+    ).toEqual([]);
+    expect(existsSync(markerPath)).toBe(false);
   });
 
   it("only exposes tools whose mapped providers are available", () => {
@@ -805,6 +926,28 @@ function writeConfig(config: WebProviders): void {
   const agentDir = join(process.env.HOME!, ".pi", "agent");
   mkdirSync(agentDir, { recursive: true });
   writeFileSync(join(agentDir, "web-providers.json"), JSON.stringify(config));
+}
+
+function createCommandBackedSecret(): {
+  command: string;
+  markerPath: string;
+} {
+  const root = mkdtempSync(join(tmpdir(), "pi-web-providers-secret-"));
+  cleanupDirs.push(root);
+  const markerPath = join(root, "marker.txt");
+  const scriptPath = join(root, "secret.js");
+  writeFileSync(
+    scriptPath,
+    [
+      'const { appendFileSync } = require("node:fs");',
+      'appendFileSync(process.argv[2], "x");',
+      'process.stdout.write("secret-key");',
+    ].join("\n"),
+  );
+  return {
+    command: `!${JSON.stringify(process.execPath)} ${JSON.stringify(scriptPath)} ${JSON.stringify(markerPath)}`,
+    markerPath,
+  };
 }
 
 async function captureRegisteredTools(): Promise<


### PR DESCRIPTION
## 🔍 Problem

- Provider credentials configured as env vars or `!command` values were resolved during session startup and availability checks.
- Password-manager backed commands such as `op` could delay startup even if no web tool was used.

## 🛠️ Solution

- Defer secret resolution during startup and settings availability checks.
- Keep execution-time validation strict, so missing or failing credentials are reported when the matching web tool is called.
- Preserve eager validation for non-secret config such as Cloudflare account IDs.
- Add a changelog entry for the user-visible behavior change.

## 💬 Review

- The main review point is the split between lazy availability checks and strict execution checks.
- Regression coverage includes command-backed secrets, missing env-backed secrets, and Cloudflare account ID validation.

<sub>
✅ Closes #20
</sub>
