### PR TITLE
Support custom Firecrawl base URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,10 @@ scope, or account ID is usually wrong.
   `location`, `timeout`, and `scrapeOptions`
 - Exposes contents options such as `formats`, `onlyMainContent`, `includeTags`,
   `excludeTags`, `waitFor`, `headers`, `location`, `mobile`, and `proxy`
+- Optional `baseUrl` overrides are supported for self-hosted Firecrawl
+  instances, proxies, and testing. API keys are required for Firecrawl Cloud,
+  but can be omitted for self-hosted endpoints that do not enforce
+  authentication.
 
 </details>
 

--- a/changelog/unreleased/support-unauthenticated-firecrawl-base-urls.md
+++ b/changelog/unreleased/support-unauthenticated-firecrawl-base-urls.md
@@ -1,0 +1,11 @@
+---
+title: Support unauthenticated Firecrawl base URLs
+type: bugfix
+authors:
+  - mavam
+prs:
+  - 29
+created: 2026-05-19T16:46:07.715194Z
+---
+
+Firecrawl provider configurations can now use a custom base URL without requiring an API key, enabling unauthenticated self-hosted instances and local proxies while preserving API key checks for Firecrawl Cloud.

--- a/src/provider-resolution.ts
+++ b/src/provider-resolution.ts
@@ -181,6 +181,13 @@ export function getProviderSetupState(
       : "none";
   }
 
+  if (providerId === "firecrawl") {
+    return providerConfig.credentials !== undefined ||
+      providerConfig.baseUrl !== undefined
+      ? "configured"
+      : "none";
+  }
+
   return providerConfig.credentials !== undefined ? "configured" : "none";
 }
 

--- a/src/providers/firecrawl.ts
+++ b/src/providers/firecrawl.ts
@@ -19,6 +19,8 @@ import { asJsonObject, getApiKeyStatus, trimSnippet } from "./shared.js";
 
 import { defineCapability, defineProvider } from "./definition.js";
 
+const FIRECRAWL_CLOUD_HOST = "api.firecrawl.dev";
+
 const firecrawlSearchOptionsSchema = Type.Object(
   {
     lang: Type.Optional(
@@ -161,7 +163,7 @@ const firecrawlImplementation = {
     _tool: Tool | undefined,
     options?: ProviderCapabilityStatusOptions,
   ): ProviderCapabilityStatus {
-    return getApiKeyStatus(config?.credentials?.api, options);
+    return getFirecrawlCapabilityStatus(config, options);
   },
 
   async search(
@@ -234,15 +236,34 @@ const firecrawlImplementation = {
 };
 
 function createClient(config: Firecrawl): FirecrawlClient {
+  const apiUrl = resolveConfigValue(config.baseUrl);
   const apiKey = resolveConfigValue(config.credentials?.api);
-  if (!apiKey) {
+  if (isFirecrawlCloudApiUrl(apiUrl) && !apiKey) {
     throw new Error("is missing an API key");
   }
 
   return new FirecrawlClient({
     apiKey,
-    apiUrl: resolveConfigValue(config.baseUrl),
+    apiUrl,
   });
+}
+
+function getFirecrawlCapabilityStatus(
+  config: Firecrawl | undefined,
+  options?: ProviderCapabilityStatusOptions,
+): ProviderCapabilityStatus {
+  if (!config?.baseUrl || isFirecrawlCloudApiUrl(config.baseUrl)) {
+    return getApiKeyStatus(config?.credentials?.api, options);
+  }
+
+  const apiKeyStatus = getApiKeyStatus(config.credentials?.api, options);
+  return apiKeyStatus.state === "missing_api_key"
+    ? { state: "ready" }
+    : apiKeyStatus;
+}
+
+function isFirecrawlCloudApiUrl(apiUrl: string | undefined): boolean {
+  return !apiUrl || apiUrl.includes(FIRECRAWL_CLOUD_HOST);
 }
 
 function flattenSearchResults(response: SearchData): SearchResult[] {

--- a/test/firecrawl-provider.test.ts
+++ b/test/firecrawl-provider.test.ts
@@ -27,6 +27,53 @@ afterEach(() => {
 });
 
 describe("providerHarness(firecrawlProvider)", () => {
+  it("reports ready for a custom base URL without an API key", () => {
+    expect(
+      firecrawlProvider.getCapabilityStatus(
+        {
+          baseUrl: "http://localhost:3002",
+        },
+        process.cwd(),
+      ),
+    ).toEqual({ state: "ready" });
+  });
+
+  it("reports missing_api_key for Firecrawl Cloud without an API key", () => {
+    expect(firecrawlProvider.getCapabilityStatus({}, process.cwd())).toEqual({
+      state: "missing_api_key",
+    });
+    expect(
+      firecrawlProvider.getCapabilityStatus(
+        {
+          baseUrl: "https://api.firecrawl.dev",
+        },
+        process.cwd(),
+      ),
+    ).toEqual({ state: "missing_api_key" });
+  });
+
+  it("searches with a custom base URL without an API key", async () => {
+    firecrawlSearchMock.mockResolvedValue({ web: [] });
+
+    const response = await providerHarness(firecrawlProvider).search(
+      "firecrawl sdk",
+      4,
+      {
+        baseUrl: "http://localhost:3002",
+      },
+      { cwd: process.cwd() },
+    );
+
+    expect(firecrawlCtorMock).toHaveBeenCalledWith({
+      apiKey: undefined,
+      apiUrl: "http://localhost:3002",
+    });
+    expect(firecrawlSearchMock).toHaveBeenCalledWith("firecrawl sdk", {
+      limit: 4,
+    });
+    expect(response.results).toEqual([]);
+  });
+
   it("merges search options and maps results", async () => {
     process.env.FIRECRAWL_API_KEY = "test-key";
 

--- a/test/provider-resolution.test.ts
+++ b/test/provider-resolution.test.ts
@@ -22,6 +22,7 @@ import {
   getEffectiveProviderConfig,
   getEffectiveSharedSettings,
   getProviderCapabilityStatus,
+  getProviderSetupState,
   resolveProviderForTool,
   resolveSearchProvider,
 } from "../src/provider-resolution.js";
@@ -288,6 +289,18 @@ describe("provider resolution", () => {
       state: "invalid_config",
       detail: expect.stringContaining("Command failed"),
     });
+  });
+
+  it("treats Firecrawl with only a base URL as configured", () => {
+    const config = createConfig({
+      providers: {
+        firecrawl: {
+          baseUrl: "http://localhost:3002",
+        },
+      },
+    });
+
+    expect(getProviderSetupState(config, "firecrawl")).toBe("configured");
   });
 
   it("rejects Custom when the mapped capability has no command configured", () => {


### PR DESCRIPTION
## Summary
- allow Firecrawl configurations with custom base URLs to run without an API key
- keep API key validation for Firecrawl Cloud URLs
- document the behavior and add coverage for provider setup/status and search flows

Fixes #26

## Testing
- npm run check
- npm test