### PR TITLE
Add Linkup research support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ reported when the tool is actually called.
 | **Exa**        |   ✔    |    ✔     |   ✔    |    ✔     | `EXA_API_KEY`                                    |
 | **Firecrawl**  |   ✔    |    ✔     |        |          | `FIRECRAWL_API_KEY`                              |
 | **Gemini**     |   ✔    |          |   ✔    |    ✔     | `GOOGLE_API_KEY`                                 |
-| **Linkup**     |   ✔    |    ✔     |        |          | `LINKUP_API_KEY`                                 |
+| **Linkup**     |   ✔    |    ✔     |        |    ✔     | `LINKUP_API_KEY`                                 |
 | **Ollama**     |   ✔    |    ✔     |        |          | `OLLAMA_API_KEY`                                 |
 | **OpenAI**     |   ✔    |          |   ✔    |    ✔     | `OPENAI_API_KEY`                                 |
 | **Parallel**   |   ✔    |    ✔     |        |          | `PARALLEL_API_KEY`                               |
@@ -352,10 +352,17 @@ scope, or account ID is usually wrong.
 - SDK: `linkup-sdk`
 - Supports `web_search` via Linkup Search with fixed `searchResults` output
 - Supports `web_contents` via Linkup Fetch and always returns markdown
+- Supports `web_research` via Linkup's async Research API
 - Exposes search options `depth`, `includeImages`, `includeDomains`,
   `excludeDomains`, `fromDate`, and `toDate`
 - Exposes contents options `renderJs`, `includeRawHtml`, and `extractImages`
-- Good fit for a simple search-plus-markdown setup without extra provider wiring
+- Exposes research options `outputType`, `mode`, `reasoningDepth`,
+  `includeDomains`, `excludeDomains`, `fromDate`, `toDate`, and
+  `structuredOutputSchema`
+- Research defaults to `sourcedAnswer`; provide `structuredOutputSchema` for
+  structured output
+- Good fit for search, markdown extraction, and long-running sourced research
+  without extra provider wiring
 
 </details>
 

--- a/changelog/unreleased/linkup-research-provider-support.md
+++ b/changelog/unreleased/linkup-research-provider-support.md
@@ -1,0 +1,31 @@
+---
+title: Linkup research provider support
+type: feature
+authors:
+  - mavam
+  - codex
+prs:
+  - 30
+created: 2026-05-24T19:37:37.847981Z
+---
+
+Linkup can now power the `web_research` tool in addition to `web_search` and `web_contents`.
+
+Example configuration:
+
+```json
+{
+  "tools": {
+    "research": "linkup"
+  },
+  "providers": {
+    "linkup": {
+      "credentials": {
+        "api": "LINKUP_API_KEY"
+      }
+    }
+  }
+}
+```
+
+Research calls support Linkup's sourced-answer and structured output modes, plus mode, reasoning-depth, domain, and date filters for controlling the investigation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-web-providers",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-web-providers",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.123",
@@ -17,7 +17,7 @@
         "@tavily/core": "^0.7.3",
         "cloudflare": "^5.2.0",
         "exa-js": "^2.12.1",
-        "linkup-sdk": "^2.7.0",
+        "linkup-sdk": "^3.2.0",
         "openai": "^6.35.0",
         "parallel-web": "^0.4.1",
         "valyu-js": "^2.7.14"
@@ -5583,9 +5583,9 @@
       }
     },
     "node_modules/linkup-sdk": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/linkup-sdk/-/linkup-sdk-2.7.0.tgz",
-      "integrity": "sha512-X/EvibI045zDY+n5SRNlKmmo7rCf9B/krAvuf4Jj6axatIPwufq8LqEi49ScVmgNBMp68wTB19gETK+jPzfl3A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/linkup-sdk/-/linkup-sdk-3.2.0.tgz",
+      "integrity": "sha512-zsFhUQCAyS60PD6kz1kklABV2T77pMGNS3BN7dAroIlwbY1lHsjXuO480R5KBQdlAmXiRwD5AU1Zqh7wHsKXNw==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.2",
@@ -5593,7 +5593,23 @@
         "zod-to-json-schema": "^3.24.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@x402/core": "^2.6.0",
+        "@x402/evm": "^2.6.0",
+        "viem": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@x402/core": {
+          "optional": true
+        },
+        "@x402/evm": {
+          "optional": true
+        },
+        "viem": {
+          "optional": true
+        }
       }
     },
     "node_modules/linkup-sdk/node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@tavily/core": "^0.7.3",
     "cloudflare": "^5.2.0",
     "exa-js": "^2.12.1",
-    "linkup-sdk": "^2.7.0",
+    "linkup-sdk": "^3.2.0",
     "openai": "^6.35.0",
     "parallel-web": "^0.4.1",
     "valyu-js": "^2.7.14"

--- a/scripts/live-smoke.mjs
+++ b/scripts/live-smoke.mjs
@@ -10,14 +10,15 @@ const PROVIDERS_BY_TOOL = {
     "custom",
     "exa",
     "gemini",
+    "linkup",
     "perplexity",
     "parallel",
     "serper",
     "valyu",
   ],
-  contents: ["custom", "exa", "parallel", "valyu"],
+  contents: ["custom", "exa", "linkup", "parallel", "valyu"],
   answer: ["claude", "custom", "exa", "gemini", "perplexity", "valyu"],
-  research: ["custom", "exa", "gemini", "perplexity", "valyu"],
+  research: ["custom", "exa", "gemini", "linkup", "perplexity", "valyu"],
 };
 
 const PROBE_INPUTS = {
@@ -33,6 +34,9 @@ const PROBE_INPUTS = {
     urlsByProvider: {
       custom: ["https://platform.openai.com/docs/overview"],
       exa: ["https://platform.openai.com/docs/overview"],
+      linkup: [
+        "https://docs.linkup.so/pages/documentation/endpoints/research/overview",
+      ],
       parallel: ["https://openai.com/api/"],
       valyu: ["https://github.com/openai/openai-python"],
     },
@@ -50,7 +54,13 @@ const PROBE_INPUTS = {
       pollIntervalMs: 3_000,
       maxConsecutivePollErrors: 2,
     },
-    timeoutMs: 240_000,
+    optionsByProvider: {
+      linkup: {
+        mode: "answer",
+        reasoningDepth: "S",
+      },
+    },
+    timeoutMs: 360_000,
   },
 };
 
@@ -68,11 +78,11 @@ for (const probe of probes) {
     probe.providerId,
     probe.capability,
   );
-  if (!status.available) {
+  if (!isProviderStatusAvailable(status)) {
     const outcome = {
       probe,
       status: "skipped",
-      message: status.summary,
+      message: formatProviderStatus(status),
     };
     outcomes.push(outcome);
     printOutcome(outcome);
@@ -164,6 +174,17 @@ function parseArgs(args) {
   return filters;
 }
 
+function isProviderStatusAvailable(status) {
+  return status.state === "ready" || status.state === "deferred_secret";
+}
+
+function formatProviderStatus(status) {
+  if (status.detail) {
+    return `${status.state}: ${status.detail}`;
+  }
+  return status.state;
+}
+
 function printHelp() {
   console.log(
     [
@@ -231,7 +252,10 @@ function buildProbe(capability, providerId) {
     capability,
     providerId,
     input: PROBE_INPUTS.research.input,
-    options: PROBE_INPUTS.research.options,
+    options: {
+      ...PROBE_INPUTS.research.options,
+      ...(PROBE_INPUTS.research.optionsByProvider[providerId] ?? {}),
+    },
     timeoutMs: PROBE_INPUTS.research.timeoutMs,
   };
 }

--- a/src/providers/linkup.ts
+++ b/src/providers/linkup.ts
@@ -1,23 +1,36 @@
 import {
   type FetchParams,
   LinkupClient,
+  type ResearchMode,
+  type ResearchParams,
+  type ResearchReasoningDepth,
+  type ResearchTask,
   type SearchDepth,
   type SearchParams,
 } from "linkup-sdk";
 import { type TObject, Type } from "typebox";
 import { resolveConfigValue } from "../config-values.js";
 import type { ContentsResponse } from "../contents.js";
+import { executeAsyncResearch } from "../execution-policy.js";
 import type {
   Linkup,
   ProviderCapabilityStatus,
   ProviderCapabilityStatusOptions,
   ProviderContext,
+  ResearchJob,
+  ResearchPollResult,
   SearchResponse,
   SearchResult,
   Tool,
+  ToolOutput,
 } from "../types.js";
 import { literalUnion } from "./schema.js";
-import { asJsonObject, getApiKeyStatus, trimSnippet } from "./shared.js";
+import {
+  asJsonObject,
+  formatJson,
+  getApiKeyStatus,
+  trimSnippet,
+} from "./shared.js";
 
 import { defineCapability, defineProvider } from "./definition.js";
 type LinkupSearchOptions = {
@@ -43,6 +56,22 @@ type ManagedLinkupSearchParams = Extract<
   SearchParams,
   { outputType: "searchResults" }
 >;
+
+type ManagedLinkupResearchParams = ResearchParams;
+
+type LinkupResearchOptions = {
+  outputType?: "sourcedAnswer" | "structured";
+  mode?: ResearchMode;
+  reasoningDepth?: ResearchReasoningDepth;
+  includeDomains?: string[];
+  excludeDomains?: string[];
+  fromDate?: string | number | Date;
+  toDate?: string | number | Date;
+  structuredOutputSchema?: unknown;
+  q?: string;
+  query?: string;
+  input?: string;
+};
 
 const linkupSearchOptionsSchema = Type.Object(
   {
@@ -89,6 +118,50 @@ const linkupContentsOptionsSchema = Type.Object(
   { description: "Linkup fetch options." },
 );
 
+const linkupResearchOptionsSchema = Type.Object(
+  {
+    outputType: Type.Optional(
+      literalUnion(["sourcedAnswer", "structured"], {
+        description:
+          "Research output type. Defaults to 'sourcedAnswer' unless structuredOutputSchema is provided.",
+      }),
+    ),
+    mode: Type.Optional(
+      literalUnion(["answer", "auto", "investigate", "research"], {
+        description:
+          "Research mode. Use 'answer' for precise verified answers, 'investigate' for focused deep dives, 'research' for broad reports, or omit/auto to let Linkup classify the task.",
+      }),
+    ),
+    reasoningDepth: Type.Optional(
+      literalUnion(["S", "M", "L", "XL"], {
+        description:
+          "Reasoning depth. Higher values trade latency for more thorough investigation.",
+      }),
+    ),
+    includeDomains: Type.Optional(
+      Type.Array(Type.String(), {
+        description: "Restrict research to these domains.",
+      }),
+    ),
+    excludeDomains: Type.Optional(
+      Type.Array(Type.String(), { description: "Exclude these domains." }),
+    ),
+    fromDate: Type.Optional(
+      Type.String({ description: "ISO date string for earliest result date." }),
+    ),
+    toDate: Type.Optional(
+      Type.String({ description: "ISO date string for latest result date." }),
+    ),
+    structuredOutputSchema: Type.Optional(
+      Type.Record(Type.String(), Type.Any(), {
+        description:
+          "JSON schema object required when outputType is 'structured'.",
+      }),
+    ),
+  },
+  { description: "Linkup research options." },
+);
+
 const linkupImplementation = {
   id: "linkup" as const,
   label: "Linkup",
@@ -100,6 +173,8 @@ const linkupImplementation = {
         return linkupSearchOptionsSchema;
       case "contents":
         return linkupContentsOptionsSchema;
+      case "research":
+        return linkupResearchOptionsSchema;
       default:
         return undefined;
     }
@@ -185,6 +260,74 @@ const linkupImplementation = {
       ),
     };
   },
+
+  async research(
+    input: string,
+    config: Linkup,
+    context: ProviderContext,
+    options?: Record<string, unknown>,
+  ): Promise<ToolOutput> {
+    return await executeAsyncResearch({
+      providerLabel: linkupImplementation.label,
+      providerId: linkupImplementation.id,
+      context,
+      start: (researchContext) =>
+        linkupImplementation.startResearch(
+          input,
+          config,
+          researchContext,
+          options,
+        ),
+      poll: (id, researchContext) =>
+        linkupImplementation.pollResearch(id, config, researchContext),
+    });
+  },
+
+  async startResearch(
+    input: string,
+    config: Linkup,
+    _context: ProviderContext,
+    options?: Record<string, unknown>,
+  ): Promise<ResearchJob> {
+    const client = createClient(config);
+    const defaults = asJsonObject(config.options?.research) ?? {};
+    const task = await client.research(
+      buildResearchParams(input, {
+        ...defaults,
+        ...(options ?? {}),
+      }),
+    );
+
+    return { id: task.id };
+  },
+
+  async pollResearch(
+    id: string,
+    config: Linkup,
+    _context: ProviderContext,
+  ): Promise<ResearchPollResult> {
+    const client = createClient(config);
+    const task = await client.getResearch(id);
+
+    if (task.status === "completed") {
+      return {
+        status: "completed",
+        output: formatResearchTaskOutput(task),
+      };
+    }
+
+    if (task.status === "failed") {
+      return {
+        status: "failed",
+        error: task.error ?? "research failed",
+      };
+    }
+
+    return {
+      status: "in_progress",
+      statusText: task.status,
+    };
+  },
 };
 
 function buildSearchParams(
@@ -265,6 +408,82 @@ function buildFetchParams(
   };
 }
 
+function buildResearchParams(
+  input: string,
+  options: Record<string, unknown>,
+): ManagedLinkupResearchParams {
+  const researchOptions = options as LinkupResearchOptions;
+
+  if (
+    researchOptions.q !== undefined ||
+    researchOptions.query !== undefined ||
+    researchOptions.input !== undefined
+  ) {
+    throw new Error(
+      "Linkup research options cannot override the managed input.",
+    );
+  }
+
+  const outputType =
+    researchOptions.outputType ??
+    (researchOptions.structuredOutputSchema !== undefined
+      ? "structured"
+      : "sourcedAnswer");
+
+  if (
+    outputType === "structured" &&
+    researchOptions.structuredOutputSchema === undefined
+  ) {
+    throw new Error(
+      "Linkup research outputType 'structured' requires structuredOutputSchema.",
+    );
+  }
+
+  if (
+    outputType === "sourcedAnswer" &&
+    researchOptions.structuredOutputSchema !== undefined
+  ) {
+    throw new Error(
+      "Linkup research structuredOutputSchema requires outputType 'structured'.",
+    );
+  }
+
+  const commonParams = {
+    query: input,
+    ...(researchOptions.includeDomains !== undefined
+      ? { includeDomains: researchOptions.includeDomains }
+      : {}),
+    ...(researchOptions.excludeDomains !== undefined
+      ? { excludeDomains: researchOptions.excludeDomains }
+      : {}),
+    ...(researchOptions.fromDate !== undefined
+      ? { fromDate: toDate(researchOptions.fromDate, "fromDate") }
+      : {}),
+    ...(researchOptions.toDate !== undefined
+      ? { toDate: toDate(researchOptions.toDate, "toDate") }
+      : {}),
+    ...(researchOptions.mode !== undefined
+      ? { mode: researchOptions.mode }
+      : {}),
+    ...(researchOptions.reasoningDepth !== undefined
+      ? { reasoningDepth: researchOptions.reasoningDepth }
+      : {}),
+  };
+
+  if (outputType === "structured") {
+    return {
+      ...commonParams,
+      outputType,
+      structuredOutputSchema: researchOptions.structuredOutputSchema,
+    } as ManagedLinkupResearchParams;
+  }
+
+  return {
+    ...commonParams,
+    outputType,
+  } as ManagedLinkupResearchParams;
+}
+
 function createClient(config: Linkup): LinkupClient {
   const apiKey = resolveConfigValue(config.credentials?.api);
   if (!apiKey) {
@@ -275,6 +494,47 @@ function createClient(config: Linkup): LinkupClient {
     apiKey,
     baseUrl: resolveConfigValue(config.baseUrl),
   });
+}
+
+function formatResearchTaskOutput(task: ResearchTask): ToolOutput {
+  const output = task.output;
+  if (!output) {
+    return {
+      provider: linkupImplementation.id,
+      text: "Linkup research completed without textual output.",
+    };
+  }
+
+  const outputRecord = asRecord(output);
+  const inputRecord = asRecord(task.input);
+  const outputType = inputRecord
+    ? readString(inputRecord.outputType)
+    : undefined;
+  const answer = outputRecord ? readString(outputRecord.answer) : undefined;
+  const sources = outputRecord ? readSources(outputRecord.sources) : [];
+
+  if (outputType !== "structured" && answer !== undefined) {
+    const lines = [answer];
+    if (sources.length > 0) {
+      lines.push("");
+      lines.push("Sources:");
+      for (const [index, source] of sources.entries()) {
+        lines.push(`${index + 1}. ${source.title}`);
+        lines.push(`   ${source.url}`);
+      }
+    }
+
+    return {
+      provider: linkupImplementation.id,
+      text: lines.join("\n").trimEnd(),
+      itemCount: sources.length,
+    };
+  }
+
+  return {
+    provider: linkupImplementation.id,
+    text: formatJson(output),
+  };
 }
 
 function toSearchResult(value: unknown): SearchResult | null {
@@ -300,6 +560,31 @@ function toSearchResult(value: unknown): SearchResult | null {
     snippet,
     metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
   };
+}
+
+function readSources(value: unknown): Array<{ title: string; url: string }> {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((entry) => {
+    const source = asRecord(entry);
+    if (!source) {
+      return [];
+    }
+
+    const url = readString(source.url);
+    if (!url) {
+      return [];
+    }
+
+    return [
+      {
+        title: readString(source.name) ?? url,
+        url,
+      },
+    ];
+  });
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
@@ -356,6 +641,17 @@ export const linkupProvider = defineProvider({
       async execute(input: any, ctx) {
         return await linkupImplementation.contents!(
           input.urls,
+          ctx.config as never,
+          ctx,
+          input.options,
+        );
+      },
+    }),
+    research: defineCapability({
+      options: linkupImplementation.getToolOptionsSchema?.("research"),
+      async execute(input: any, ctx) {
+        return await linkupImplementation.research!(
+          input.input,
           ctx.config as never,
           ctx,
           input.options,

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,6 +151,7 @@ export interface GeminiOptions {
 export interface LinkupOptions {
   search?: Record<string, unknown>;
   fetch?: Record<string, unknown>;
+  research?: Record<string, unknown>;
 }
 
 export interface PerplexityOptions {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -165,6 +165,10 @@ describe("config parsing", () => {
               fetch: {
                 renderJs: true,
               },
+              research: {
+                mode: "investigate",
+                reasoningDepth: "L",
+              },
             },
             settings: {
               requestTimeoutMs: 45000,
@@ -184,6 +188,10 @@ describe("config parsing", () => {
         },
         fetch: {
           renderJs: true,
+        },
+        research: {
+          mode: "investigate",
+          reasoningDepth: "L",
         },
       },
       settings: {

--- a/test/linkup-provider.test.ts
+++ b/test/linkup-provider.test.ts
@@ -1,18 +1,26 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { linkupCtorMock, linkupFetchMock, linkupSearchMock } = vi.hoisted(
-  () => ({
-    linkupCtorMock: vi.fn(),
-    linkupFetchMock: vi.fn(),
-    linkupSearchMock: vi.fn(),
-  }),
-);
+const {
+  linkupCtorMock,
+  linkupFetchMock,
+  linkupGetResearchMock,
+  linkupResearchMock,
+  linkupSearchMock,
+} = vi.hoisted(() => ({
+  linkupCtorMock: vi.fn(),
+  linkupFetchMock: vi.fn(),
+  linkupGetResearchMock: vi.fn(),
+  linkupResearchMock: vi.fn(),
+  linkupSearchMock: vi.fn(),
+}));
 
 vi.mock("linkup-sdk", () => ({
   LinkupClient: linkupCtorMock.mockImplementation(function MockLinkup() {
     return {
       search: linkupSearchMock,
       fetch: linkupFetchMock,
+      research: linkupResearchMock,
+      getResearch: linkupGetResearchMock,
     };
   }),
 }));
@@ -25,6 +33,9 @@ afterEach(() => {
   linkupCtorMock.mockClear();
   linkupSearchMock.mockReset();
   linkupFetchMock.mockReset();
+  linkupResearchMock.mockReset();
+  linkupGetResearchMock.mockReset();
+  vi.useRealTimers();
 });
 
 describe("providerHarness(linkupProvider)", () => {
@@ -202,6 +213,206 @@ describe("providerHarness(linkupProvider)", () => {
         error: "No content returned for this URL.",
       },
     ]);
+  });
+
+  it("starts Linkup research, polls by id, and formats sourced answers", async () => {
+    vi.useFakeTimers();
+
+    process.env.LINKUP_API_KEY = "test-key";
+    linkupResearchMock.mockResolvedValue({
+      id: "linkup-research-1",
+      status: "pending",
+    });
+    linkupGetResearchMock
+      .mockResolvedValueOnce({
+        id: "linkup-research-1",
+        status: "processing",
+        output: null,
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        id: "linkup-research-1",
+        status: "completed",
+        output: {
+          answer: "Linkup research result",
+          sources: [
+            {
+              name: "Source A",
+              url: "https://example.com/a",
+              snippet: "A",
+              favicon: "https://example.com/favicon.ico",
+            },
+          ],
+        },
+        error: null,
+      });
+
+    const promise = providerHarness(linkupProvider).research(
+      "Investigate Linkup research",
+      {
+        credentials: { api: "LINKUP_API_KEY" },
+        baseUrl: "https://api.linkup.test/v1",
+        options: {
+          research: {
+            includeDomains: ["docs.linkup.so"],
+            reasoningDepth: "M",
+          },
+        },
+      },
+      { cwd: process.cwd() },
+      {
+        mode: "investigate",
+        reasoningDepth: "L",
+        excludeDomains: ["example.net"],
+        fromDate: "2026-01-02T03:04:05.000Z",
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(3000);
+    const response = await promise;
+
+    expect(linkupResearchMock).toHaveBeenCalledTimes(1);
+    expect(linkupResearchMock).toHaveBeenCalledWith({
+      query: "Investigate Linkup research",
+      outputType: "sourcedAnswer",
+      includeDomains: ["docs.linkup.so"],
+      excludeDomains: ["example.net"],
+      fromDate: expect.any(Date),
+      mode: "investigate",
+      reasoningDepth: "L",
+    });
+    expect(
+      (
+        linkupResearchMock.mock.calls[0]?.[0] as { fromDate: Date }
+      ).fromDate.toISOString(),
+    ).toBe("2026-01-02T03:04:05.000Z");
+    expect(linkupGetResearchMock).toHaveBeenCalledTimes(2);
+    expect(linkupGetResearchMock).toHaveBeenNthCalledWith(
+      1,
+      "linkup-research-1",
+    );
+    expect(response).toEqual({
+      provider: "linkup",
+      text: "Linkup research result\n\nSources:\n1. Source A\n   https://example.com/a",
+      itemCount: 1,
+    });
+  });
+
+  it("infers structured Linkup research output from structuredOutputSchema", async () => {
+    linkupResearchMock.mockResolvedValue({
+      id: "linkup-research-structured",
+      status: "pending",
+    });
+    linkupGetResearchMock.mockResolvedValue({
+      id: "linkup-research-structured",
+      status: "completed",
+      output: {
+        companies: [
+          {
+            name: "Example Corp",
+            score: 0.9,
+          },
+        ],
+      },
+      error: null,
+    });
+
+    const response = await providerHarness(linkupProvider).research(
+      "Find companies",
+      {
+        credentials: { api: "literal-key" },
+      },
+      { cwd: process.cwd() },
+      {
+        structuredOutputSchema: {
+          type: "object",
+          properties: {
+            companies: {
+              type: "array",
+            },
+          },
+        },
+      },
+    );
+
+    expect(linkupResearchMock).toHaveBeenCalledWith({
+      query: "Find companies",
+      outputType: "structured",
+      structuredOutputSchema: {
+        type: "object",
+        properties: {
+          companies: {
+            type: "array",
+          },
+        },
+      },
+    });
+    expect(response).toEqual({
+      provider: "linkup",
+      text: JSON.stringify(
+        {
+          companies: [
+            {
+              name: "Example Corp",
+              score: 0.9,
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    });
+  });
+
+  it("maps failed Linkup research tasks to terminal research errors", async () => {
+    linkupResearchMock.mockResolvedValue({
+      id: "linkup-research-failed",
+      status: "pending",
+    });
+    linkupGetResearchMock.mockResolvedValue({
+      id: "linkup-research-failed",
+      status: "failed",
+      output: null,
+      error: "quota exceeded",
+    });
+
+    await expect(
+      providerHarness(linkupProvider).research(
+        "Investigate failure",
+        {
+          credentials: { api: "literal-key" },
+        },
+        { cwd: process.cwd() },
+      ),
+    ).rejects.toThrow(/Linkup research failed: quota exceeded/);
+  });
+
+  it("rejects incompatible Linkup research option overrides", async () => {
+    await expect(
+      providerHarness(linkupProvider).research(
+        "Investigate Linkup",
+        {
+          credentials: { api: "literal-key" },
+        },
+        { cwd: process.cwd() },
+        {
+          query: "override",
+        },
+      ),
+    ).rejects.toThrow(/cannot override the managed input/);
+
+    await expect(
+      providerHarness(linkupProvider).research(
+        "Investigate Linkup",
+        {
+          credentials: { api: "literal-key" },
+        },
+        { cwd: process.cwd() },
+        {
+          outputType: "structured",
+        },
+      ),
+    ).rejects.toThrow(/requires structuredOutputSchema/);
   });
 
   it("requires an API key", async () => {

--- a/test/tool-availability.test.ts
+++ b/test/tool-availability.test.ts
@@ -887,6 +887,7 @@ describe("managed tool availability", () => {
       tools: {
         search: "linkup",
         contents: "linkup",
+        research: "linkup",
       },
       providers: {
         linkup: {
@@ -910,8 +911,15 @@ describe("managed tool availability", () => {
       ),
     ).toEqual(["linkup"]);
     expect(
+      __test__.getAvailableProviderIdsForCapability(
+        config,
+        process.cwd(),
+        "research",
+      ),
+    ).toEqual(["linkup"]);
+    expect(
       __test__.getAvailableManagedToolNames(config, process.cwd()),
-    ).toEqual(["web_search", "web_contents"]);
+    ).toEqual(["web_search", "web_contents", "web_research"]);
   });
 });
 


### PR DESCRIPTION
## 🔍 Problem

- Linkup is available for search and contents, but cannot be selected for `web_research`.
- The live smoke harness also does not exercise Linkup, so provider regressions are harder to catch manually.

## 🛠️ Solution

- Add Linkup as an async `web_research` provider using its research task lifecycle.
- Expose Linkup research options for output type, mode, reasoning depth, domains, dates, and structured schemas.
- Update docs, config parsing, availability checks, live smoke probes, and mocked provider tests.

## 💬 Review

- Check the Linkup option validation and output formatting for sourced-answer versus structured research results.
- The live smoke script remains opt-in; CI coverage is fully mocked and does not depend on local credentials.