### PR TITLE
Add Firecrawl page answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ reported when the tool is actually called.
 | **Brave**      |   ✔    |          |   ✔    |    ✔     | `BRAVE_SEARCH_API_KEY` / `BRAVE_ANSWERS_API_KEY` |
 | **Cloudflare** |        |    ✔     |        |          | `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` |
 | **Exa**        |   ✔    |    ✔     |   ✔    |    ✔     | `EXA_API_KEY`                                    |
-| **Firecrawl**  |   ✔    |    ✔     |        |          | `FIRECRAWL_API_KEY`                              |
+| **Firecrawl**  |   ✔    |    ✔     |   ✔    |          | `FIRECRAWL_API_KEY`                              |
 | **Gemini**     |   ✔    |          |   ✔    |    ✔     | `GOOGLE_API_KEY`                                 |
 | **Linkup**     |   ✔    |    ✔     |        |    ✔     | `LINKUP_API_KEY`                                 |
 | **Ollama**     |   ✔    |    ✔     |        |          | `OLLAMA_API_KEY`                                 |
@@ -315,13 +315,19 @@ scope, or account ID is usually wrong.
 <summary><strong>Firecrawl</strong></summary>
 
 - SDK: `@mendable/firecrawl-js`
-- Supports `web_search` and `web_contents`
+- Supports `web_search`, `web_contents`, and page-scoped `web_answer`
 - Search can optionally include Firecrawl scrape-backed result enrichment
 - Contents extraction uses Firecrawl scrape with markdown-first defaults
+- Answers use Firecrawl scrape's `question` format against one explicit page URL;
+  set `options.url` in the `web_answer` call or
+  `providers.firecrawl.options.answer.url` as a default
 - Exposes search options such as `lang`, `country`, `sources`, `categories`,
   `location`, `timeout`, and `scrapeOptions`
 - Exposes contents options such as `formats`, `onlyMainContent`, `includeTags`,
   `excludeTags`, `waitFor`, `headers`, `location`, `mobile`, and `proxy`
+- Exposes answer options `url`, `onlyMainContent`, `includeTags`,
+  `excludeTags`, `waitFor`, `headers`, `location`, `mobile`, and `proxy`
+- Firecrawl charges 5 credits per page for the `question` format
 - Optional `baseUrl` overrides are supported for self-hosted Firecrawl
   instances, proxies, and testing. API keys are required for Firecrawl Cloud,
   but can be omitted for self-hosted endpoints that do not enforce

--- a/changelog/unreleased/firecrawl-page-scoped-answers.md
+++ b/changelog/unreleased/firecrawl-page-scoped-answers.md
@@ -1,0 +1,25 @@
+---
+title: Firecrawl page-scoped answers
+type: feature
+authors:
+  - mavam
+  - codex
+prs:
+  - 31
+created: 2026-05-31T16:36:32.341073Z
+---
+
+Firecrawl can now power page-scoped `web_answer` calls through its question format.
+
+Example call:
+
+```json
+{
+  "queries": ["What does this page say about the question format?"],
+  "options": {
+    "url": "https://docs.firecrawl.dev/features/scrape#question-format"
+  }
+}
+```
+
+This is useful when you already know the page to inspect and want a concise answer without fetching the full page contents first. The Firecrawl answer provider remains URL-scoped, so use `web_search` plus `web_contents` or `web_research` for multi-source answers.

--- a/src/providers/firecrawl.ts
+++ b/src/providers/firecrawl.ts
@@ -12,14 +12,22 @@ import type {
   ProviderContext,
   SearchResponse,
   SearchResult,
+  ToolOutput,
   Tool,
 } from "../types.js";
 import { literalUnion } from "./schema.js";
-import { asJsonObject, getApiKeyStatus, trimSnippet } from "./shared.js";
+import {
+  asJsonObject,
+  formatJson,
+  getApiKeyStatus,
+  trimSnippet,
+} from "./shared.js";
 
 import { defineCapability, defineProvider } from "./definition.js";
 
 const FIRECRAWL_CLOUD_HOST = "api.firecrawl.dev";
+const FIRECRAWL_DEFAULT_API_URL = "https://api.firecrawl.dev";
+const FIRECRAWL_QUESTION_LIMIT = 10_000;
 
 const firecrawlSearchOptionsSchema = Type.Object(
   {
@@ -129,6 +137,57 @@ const firecrawlScrapeOptionsSchema = Type.Object(
   { description: "Firecrawl scrape options." },
 );
 
+const firecrawlAnswerOptionsSchema = Type.Object(
+  {
+    url: Type.String({
+      minLength: 1,
+      description: "URL of the page to ask about.",
+    }),
+    onlyMainContent: Type.Optional(
+      Type.Boolean({ description: "Extract only the main content." }),
+    ),
+    includeTags: Type.Optional(
+      Type.Array(Type.String(), { description: "CSS selectors to include." }),
+    ),
+    excludeTags: Type.Optional(
+      Type.Array(Type.String(), { description: "CSS selectors to exclude." }),
+    ),
+    waitFor: Type.Optional(
+      Type.Integer({
+        minimum: 0,
+        description: "Milliseconds to wait before scraping.",
+      }),
+    ),
+    headers: Type.Optional(
+      Type.Record(Type.String(), Type.String(), {
+        description: "Headers to send when scraping.",
+      }),
+    ),
+    location: Type.Optional(
+      Type.Object(
+        {
+          country: Type.Optional(Type.String({ description: "Country hint." })),
+          region: Type.Optional(Type.String({ description: "Region hint." })),
+          city: Type.Optional(Type.String({ description: "City hint." })),
+        },
+        { description: "Location hint for scraping." },
+      ),
+    ),
+    mobile: Type.Optional(
+      Type.Boolean({ description: "Use a mobile browser profile." }),
+    ),
+    proxy: Type.Optional(
+      Type.String({
+        description: "Proxy mode passed through to Firecrawl.",
+      }),
+    ),
+  },
+  {
+    description:
+      "Firecrawl page-question options. The URL is required; the question comes from the web_answer query.",
+  },
+);
+
 const firecrawlImplementation = {
   id: "firecrawl" as const,
   label: "Firecrawl",
@@ -140,6 +199,8 @@ const firecrawlImplementation = {
         return firecrawlSearchOptionsSchema;
       case "contents":
         return firecrawlScrapeOptionsSchema;
+      case "answer":
+        return firecrawlAnswerOptionsSchema;
       default:
         return undefined;
     }
@@ -233,6 +294,44 @@ const firecrawlImplementation = {
       ),
     };
   },
+
+  async answer(
+    query: string,
+    config: Firecrawl,
+    _context: ProviderContext,
+    options?: Record<string, unknown>,
+  ): Promise<ToolOutput> {
+    const question = validateQuestion(query);
+    const defaults = asJsonObject(config.options?.scrape);
+    const answerDefaults = asJsonObject(config.options?.answer);
+    const mergedOptions: Record<string, unknown> = {
+      onlyMainContent: true,
+      ...defaults,
+      ...answerDefaults,
+      ...(options ?? {}),
+    };
+    const url = validateUrl(mergedOptions.url);
+    const scrapeOptions = stripAnswerOnlyOptions(mergedOptions);
+    const response = await scrapeQuestion(config, url, question, scrapeOptions);
+    const document = getFirecrawlDocument(response);
+    const answer = readString(document.answer);
+
+    if (!answer?.trim()) {
+      throw new Error("No answer returned for this URL.");
+    }
+
+    return {
+      provider: firecrawlImplementation.id,
+      text: answer.trim(),
+      itemCount: 1,
+      metadata: {
+        url,
+        ...(asRecord(document.metadata)
+          ? { metadata: document.metadata as Record<string, unknown> }
+          : {}),
+      },
+    };
+  },
 };
 
 function createClient(config: Firecrawl): FirecrawlClient {
@@ -264,6 +363,112 @@ function getFirecrawlCapabilityStatus(
 
 function isFirecrawlCloudApiUrl(apiUrl: string | undefined): boolean {
   return !apiUrl || apiUrl.includes(FIRECRAWL_CLOUD_HOST);
+}
+
+function validateQuestion(query: string): string {
+  const question = query.trim();
+  if (!question) {
+    throw new Error("question must be a non-empty string.");
+  }
+  if (question.length > FIRECRAWL_QUESTION_LIMIT) {
+    throw new Error(
+      `Firecrawl question must be at most ${FIRECRAWL_QUESTION_LIMIT} characters.`,
+    );
+  }
+  return question;
+}
+
+function validateUrl(value: unknown): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error("Firecrawl answer requires options.url.");
+  }
+  return value.trim();
+}
+
+function stripAnswerOnlyOptions(
+  options: Record<string, unknown>,
+): Record<string, unknown> {
+  const { url: _url, formats: _formats, ...scrapeOptions } = options;
+  return scrapeOptions;
+}
+
+async function scrapeQuestion(
+  config: Firecrawl,
+  url: string,
+  question: string,
+  options: Record<string, unknown>,
+): Promise<unknown> {
+  const apiUrl =
+    resolveConfigValue(config.baseUrl) ?? FIRECRAWL_DEFAULT_API_URL;
+  const apiKey = resolveConfigValue(config.credentials?.api);
+  if (isFirecrawlCloudApiUrl(apiUrl) && !apiKey) {
+    throw new Error("is missing an API key");
+  }
+
+  const response = await fetch(joinUrl(apiUrl, "/v2/scrape"), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+    },
+    body: JSON.stringify({
+      ...options,
+      url,
+      formats: [{ type: "question", question }],
+    }),
+  });
+
+  const payload = await readJsonResponse(response);
+  if (!response.ok) {
+    throw new Error(readFirecrawlError(payload, response.statusText));
+  }
+  if (isFirecrawlFailure(payload)) {
+    throw new Error(readFirecrawlError(payload, "Firecrawl scrape failed."));
+  }
+  return payload;
+}
+
+function joinUrl(baseUrl: string, path: string): string {
+  return `${baseUrl.replace(/\/+$/g, "")}/${path.replace(/^\/+/g, "")}`;
+}
+
+async function readJsonResponse(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) {
+    return {};
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+function isFirecrawlFailure(value: unknown): boolean {
+  const record = asRecord(value);
+  return record?.success === false || record?.error !== undefined;
+}
+
+function readFirecrawlError(value: unknown, fallback: string): string {
+  const record = asRecord(value);
+  return (
+    readString(record?.error) ??
+    readString(record?.message) ??
+    (typeof value === "string" ? value : undefined) ??
+    fallback
+  );
+}
+
+function getFirecrawlDocument(value: unknown): Record<string, unknown> {
+  const record = asRecord(value);
+  const data = asRecord(record?.data);
+  if (data) {
+    return data;
+  }
+  if (record) {
+    return record;
+  }
+  throw new Error(`Unexpected Firecrawl response: ${formatJson(value)}`);
 }
 
 function flattenSearchResults(response: SearchData): SearchResult[] {
@@ -374,6 +579,21 @@ export const firecrawlProvider = defineProvider({
       async execute(input: any, ctx) {
         return await firecrawlImplementation.contents!(
           input.urls,
+          ctx.config as never,
+          ctx,
+          input.options,
+        );
+      },
+    }),
+    answer: defineCapability({
+      options: firecrawlImplementation.getToolOptionsSchema?.("answer"),
+      promptGuidelines: [
+        "Firecrawl web_answer is page-scoped: set options.url to the specific page URL to ask about.",
+        "Do not use Firecrawl web_answer for general multi-source answers; use web_search plus web_contents or web_research instead.",
+      ],
+      async execute(input: any, ctx) {
+        return await firecrawlImplementation.answer!(
+          input.query,
           ctx.config as never,
           ctx,
           input.options,

--- a/src/types.ts
+++ b/src/types.ts
@@ -194,6 +194,7 @@ export interface ExaOptions {
 export interface FirecrawlOptions {
   search?: Record<string, unknown>;
   scrape?: Record<string, unknown>;
+  answer?: Record<string, unknown>;
 }
 
 export interface TavilyOptions {

--- a/test/firecrawl-provider.test.ts
+++ b/test/firecrawl-provider.test.ts
@@ -24,6 +24,7 @@ afterEach(() => {
   firecrawlCtorMock.mockClear();
   firecrawlSearchMock.mockReset();
   firecrawlScrapeMock.mockReset();
+  vi.unstubAllGlobals();
 });
 
 describe("providerHarness(firecrawlProvider)", () => {
@@ -294,5 +295,157 @@ describe("providerHarness(firecrawlProvider)", () => {
         },
       },
     ]);
+  });
+
+  it("answers a question about one URL using Firecrawl's question scrape format", async () => {
+    process.env.FIRECRAWL_API_KEY = "test-key";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: {
+            answer: "The page says Firecrawl supports question scraping.",
+            metadata: {
+              title: "Firecrawl Docs",
+            },
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await providerHarness(firecrawlProvider).answer(
+      "What does the page say about question scraping?",
+      {
+        credentials: { api: "FIRECRAWL_API_KEY" },
+        options: {
+          scrape: {
+            formats: ["markdown"],
+            onlyMainContent: false,
+            waitFor: 100,
+          },
+          answer: {
+            url: "https://docs.firecrawl.dev/features/scrape",
+            mobile: true,
+          },
+        },
+      },
+      { cwd: process.cwd() },
+      {
+        url: "https://docs.firecrawl.dev/features/scrape#question-format",
+        waitFor: 250,
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.firecrawl.dev/v2/scrape",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer test-key",
+        },
+        body: JSON.stringify({
+          onlyMainContent: false,
+          waitFor: 250,
+          mobile: true,
+          url: "https://docs.firecrawl.dev/features/scrape#question-format",
+          formats: [
+            {
+              type: "question",
+              question: "What does the page say about question scraping?",
+            },
+          ],
+        }),
+      },
+    );
+    expect(response).toEqual({
+      provider: "firecrawl",
+      text: "The page says Firecrawl supports question scraping.",
+      itemCount: 1,
+      metadata: {
+        url: "https://docs.firecrawl.dev/features/scrape#question-format",
+        metadata: {
+          title: "Firecrawl Docs",
+        },
+      },
+    });
+  });
+
+  it("requires a URL for Firecrawl answers", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      providerHarness(firecrawlProvider).answer(
+        "What does this page say?",
+        {
+          credentials: { api: "literal-key" },
+        },
+        { cwd: process.cwd() },
+      ),
+    ).rejects.toThrow("Firecrawl answer requires options.url.");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("requires a non-empty Firecrawl answer question", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      providerHarness(firecrawlProvider).answer(
+        "   ",
+        {
+          credentials: { api: "literal-key" },
+        },
+        { cwd: process.cwd() },
+        { url: "https://example.com" },
+      ),
+    ).rejects.toThrow("question must be a non-empty string.");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects Firecrawl answer questions over 10000 characters", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      providerHarness(firecrawlProvider).answer(
+        "A".repeat(10_001),
+        {
+          credentials: { api: "literal-key" },
+        },
+        { cwd: process.cwd() },
+        { url: "https://example.com" },
+      ),
+    ).rejects.toThrow("Firecrawl question must be at most 10000 characters.");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("propagates Firecrawl answer API errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            success: false,
+            error: "question format is unavailable",
+          }),
+          { status: 400, statusText: "Bad Request" },
+        ),
+      ),
+    );
+
+    await expect(
+      providerHarness(firecrawlProvider).answer(
+        "What changed?",
+        {
+          credentials: { api: "literal-key" },
+        },
+        { cwd: process.cwd() },
+        { url: "https://example.com" },
+      ),
+    ).rejects.toThrow("question format is unavailable");
   });
 });


### PR DESCRIPTION
## 🔍 Problem

- Firecrawl exposes a `question` scrape format for answering questions about a specific page, but pi-web-providers only exposed Firecrawl for search and page contents.
- Treating that as a general web-answer provider would overstate the capability because it is URL-scoped.

## 🛠️ Solution

- Add page-scoped Firecrawl `web_answer` support that requires `options.url` and sends the question scrape format to `/v2/scrape`.
- Validate empty and overlong questions, propagate Firecrawl API errors, and preserve the existing search and contents behavior.
- Document the URL requirement, provider option surface, and Firecrawl credit cost.

## 💬 Review

- Focus on the provider contract: `web_answer` remains page-scoped and should not imply multi-source answer behavior.
- Check that the direct `/v2/scrape` request shape matches Firecrawl question-format docs and still respects shared scrape defaults.